### PR TITLE
chore: professionalize CI/CD workflow and repo infrastructure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug Report
+description: Report something that is broken
+labels: ['bug']
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+      placeholder: |
+        1. Run `npx clawboo`
+        2. Connect to Gateway
+        3. Click on Ghost Graph tab
+        4. See error in console
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Clawboo version
+      description: Run `npx clawboo --version` or check package.json
+      placeholder: '0.1.0'
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Ghost Graph
+        - Chat Panel
+        - Fleet Sidebar
+        - Cost Dashboard
+        - Scheduler
+        - Approvals
+        - Skill Marketplace
+        - Gateway Connection
+        - CLI
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, OS/browser info, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest an improvement or new feature
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve? What is frustrating today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How should this work?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Ghost Graph
+        - Chat Panel
+        - Fleet Sidebar
+        - Cost Dashboard
+        - Scheduler
+        - Approvals
+        - Skill Marketplace
+        - Gateway Connection
+        - CLI
+        - New area
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you thought about?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+-
+
+## Type
+
+<!-- Check one: -->
+
+- [ ] Feature (`feat:`)
+- [ ] Bug fix (`fix:`)
+- [ ] Refactor (`refactor:`)
+- [ ] Chore (CI, deps, config)
+- [ ] Documentation
+- [ ] Test
+
+## Changeset
+
+<!-- Required for user-facing changes to packages/* or apps/cli. -->
+<!-- Run `pnpm changeset` and commit the generated file. -->
+
+- [ ] Added changeset (or not needed — docs/CI/web-only change)
+
+## Checklist
+
+- [ ] `pnpm build` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm test` passes
+- [ ] Self-reviewed the diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.changeset/**'
+      - 'apps/docs/**'
   pull_request:
     branches: [main]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,44 @@
-name: Release
+name: Publish
 
 on:
   push:
     branches: [main]
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  release:
-    name: Release
+  check:
+    name: Check for changesets
     runs-on: ubuntu-latest
+    outputs:
+      has_changesets: ${{ steps.count.outputs.has_changesets }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count changeset files
+        id: count
+        run: |
+          count=$(find .changeset -name '*.md' ! -name 'README.md' | wc -l | tr -d ' ')
+          echo "changeset_count=$count"
+          if [ "$count" -gt "0" ]; then
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    name: Publish packages
+    runs-on: ubuntu-latest
+    needs: [check]
+    if: needs.check.outputs.has_changesets == 'true'
     permissions:
       contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
-          # Fetch full history so Changesets can diff correctly
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
@@ -36,11 +56,8 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          # Script that publishes all public packages to npm
           publish: pnpm changeset publish
-          # Commit message for the version bump commit
           commit: 'chore: version packages'
-          # PR title created by the Changesets action
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,24 @@ pnpm install
 pnpm dev          # starts apps/web on :3000
 ```
 
+## Branching
+
+We use [GitHub Flow](https://docs.github.com/en/get-started/using-git/github-flow):
+
+1. Create a branch from `main` with a descriptive prefix:
+   - `feat/` — new feature
+   - `fix/` — bug fix
+   - `chore/` — tooling, CI, deps
+   - `docs/` — documentation
+   - `test/` — test additions
+   - `refactor/` — code restructuring
+
+2. Make your changes and push the branch.
+
+3. Open a pull request. The PR template will guide you through the checklist.
+
+4. CI must pass before merging. All PRs are squash-merged into `main`.
+
 ## Commands
 
 ```bash
@@ -102,7 +120,7 @@ Fix WebSocket reconnect race condition when the upstream closes unexpectedly.
 
 ## Release process (maintainers only)
 
-Releases are automated via the `release.yml` GitHub Actions workflow:
+Releases are automated via the `publish.yml` GitHub Actions workflow:
 
 1. When changesets land on `main`, the Changesets action opens (or updates) a **"Version Packages"** PR.
 2. That PR bumps `package.json` versions and updates `CHANGELOG.md` files for all affected packages.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   <p><strong>Your AI agents, visible.</strong></p>
 
 [![npm version](https://img.shields.io/npm/v/clawboo?color=E94560&label=clawboo&style=flat-square)](https://www.npmjs.com/package/clawboo)
+[![CI](https://github.com/clawboo/clawboo/actions/workflows/ci.yml/badge.svg)](https://github.com/clawboo/clawboo/actions/workflows/ci.yml)
 [![GitHub Stars](https://img.shields.io/github/stars/clawboo/clawboo?style=flat-square&color=FBBF24)](https://github.com/clawboo/clawboo/stargazers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-34D399?style=flat-square)](./LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)


### PR DESCRIPTION
## Summary

- Replace `release.yml` with `publish.yml` — adds a 10-second changeset check that skips the expensive build+publish step when no changesets exist (saves ~2min per push)
- Add `paths-ignore` to `ci.yml` push trigger so docs-only changes skip CI
- Add PR template, bug report and feature request issue templates
- Add CI badge to README
- Update CONTRIBUTING.md with branching strategy and new workflow name

## Type

- [x] Chore (CI, deps, config)

## Changeset

- [x] Added changeset (or not needed — docs/CI/web-only change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff