### PR TITLE
feat(graph): add hover cascade, floating nodes, and improved layout

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts'
+import './.next/dev/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -67,6 +67,7 @@ export function GhostGraph() {
     updateNodePosition,
     connectMode,
     setConnectMode,
+    setHoveredNodeId,
   } = useGraphStore()
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
@@ -156,6 +157,18 @@ export function GhostGraph() {
     })
   }, [])
 
+  // ── Hover cascade handlers ────────────────────────────────────────────────
+  const onNodeMouseEnter: NodeMouseHandler<Node> = useCallback(
+    (_event, node) => {
+      setHoveredNodeId(node.id)
+    },
+    [setHoveredNodeId],
+  )
+
+  const onNodeMouseLeave: NodeMouseHandler<Node> = useCallback(() => {
+    setHoveredNodeId(null)
+  }, [setHoveredNodeId])
+
   const onConnect = useCallback(
     async (connection: Connection) => {
       const sourceNode = nodes.find((n) => n.id === connection.source)
@@ -202,7 +215,9 @@ export function GhostGraph() {
         id: `dep-${sourceAgentId}-${targetAgentId}`,
         type: 'dependency',
         source: connection.source,
+        sourceHandle: 'center',
         target: connection.target,
+        targetHandle: 'center-target',
         data: {},
       }
       const store = useGraphStore.getState()
@@ -264,7 +279,8 @@ export function GhostGraph() {
   const onPaneClick = useCallback(() => {
     setSelectedEdgeId(null)
     setContextMenu(null)
-  }, [setSelectedEdgeId])
+    setHoveredNodeId(null)
+  }, [setSelectedEdgeId, setHoveredNodeId])
 
   const handleDeleteEdge = useCallback(
     async (edgeId: string) => {
@@ -321,6 +337,8 @@ export function GhostGraph() {
         onEdgeClick={onEdgeClick}
         onNodeClick={onNodeClick}
         onNodeContextMenu={onNodeContextMenu}
+        onNodeMouseEnter={onNodeMouseEnter}
+        onNodeMouseLeave={onNodeMouseLeave}
         onPaneClick={onPaneClick}
         onConnect={onConnect}
         isValidConnection={isValidConnection}
@@ -337,9 +355,9 @@ export function GhostGraph() {
       >
         <Background
           variant={BackgroundVariant.Dots}
-          gap={22}
+          gap={32}
           size={1}
-          color="rgba(255,255,255,0.04)"
+          color="rgba(255,255,255,0.03)"
         />
         <Controls
           style={{

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -26,6 +26,7 @@ import { useGraphStore } from './store'
 import { useGraphData } from './useGraphData'
 import { useGraphPersistence } from './useGraphPersistence'
 import { computeElkLayout } from './useGraphLayout'
+import { computeOrbitalPositions } from './computeOrbitalPositions'
 import { nodeTypes } from './nodes/nodeTypes'
 import { edgeTypes } from './edges/edgeTypes'
 import { ConnectionLine } from './edges/ConnectionLine'
@@ -84,9 +85,10 @@ export function GhostGraph() {
   useGraphData()
   const { savePositions } = useGraphPersistence()
 
-  // ── ELK auto-layout ──────────────────────────────────────────────────────────
-  // Runs once after ReactFlow measures node dimensions; re-runs when node count
-  // changes or when the user clicks "Re-layout" (layoutKey bump).
+  // ── Two-layer auto-layout ────────────────────────────────────────────────────
+  // Layer 1: ELK positions boo nodes using dependency edges only (async).
+  // Layer 2: Orbital positions skill/resource nodes around their parent boo (sync).
+  // Re-runs when node count changes or user clicks "Re-layout" (layoutKey bump).
   useEffect(() => {
     if (!nodesInitialized || nodes.length === 0) return
 
@@ -101,11 +103,24 @@ export function GhostGraph() {
 
     const generation = ++elkGenerationRef.current
 
-    void computeElkLayout(nodes, edges, savedPositions).then((layoutedNodes) => {
+    // Layer 1: Only boo nodes + dependency edges go through ELK
+    const booNodes = nodes.filter((n) => n.type === 'boo')
+    const nonBooNodes = nodes.filter((n) => n.type !== 'boo')
+    const depEdges = edges.filter((e) => e.type === 'dependency')
+
+    void computeElkLayout(booNodes, depEdges, savedPositions).then((layoutedBooNodes) => {
       // Skip stale results — a newer ELK computation has started
       if (generation !== elkGenerationRef.current) return
 
-      setNodes(layoutedNodes)
+      // Layer 2: Position skills/resources in orbital arcs around their parent boo
+      const orbitalNodes = computeOrbitalPositions(
+        layoutedBooNodes,
+        nonBooNodes,
+        edges, // full edges needed for parent-child mapping
+        savedPositions,
+      )
+
+      setNodes([...layoutedBooNodes, ...orbitalNodes])
       setHasRunLayout(true)
       requestAnimationFrame(() => {
         void fitView({ padding: 0.15, duration: 500 })

--- a/apps/web/src/features/graph/__tests__/store.test.ts
+++ b/apps/web/src/features/graph/__tests__/store.test.ts
@@ -17,6 +17,9 @@ describe('useGraphStore', () => {
       filesError: null,
       refreshKey: 0,
       connectMode: false,
+      hoveredNodeId: null,
+      highlightedNodeIds: null,
+      highlightedEdgeIds: null,
     })
   })
 
@@ -107,6 +110,53 @@ describe('useGraphStore', () => {
       useGraphStore.getState().updateNodePosition('n2', { x: 30, y: 40 })
       expect(useGraphStore.getState().savedPositions.n1).toEqual({ x: 10, y: 20 })
       expect(useGraphStore.getState().savedPositions.n2).toEqual({ x: 30, y: 40 })
+    })
+  })
+
+  describe('hover cascade', () => {
+    it('defaults to null', () => {
+      const s = useGraphStore.getState()
+      expect(s.hoveredNodeId).toBeNull()
+      expect(s.highlightedNodeIds).toBeNull()
+      expect(s.highlightedEdgeIds).toBeNull()
+    })
+
+    it('setHoveredNodeId(null) clears all hover state', () => {
+      useGraphStore.getState().setHoveredNodeId('boo-a1')
+      useGraphStore.getState().setHoveredNodeId(null)
+      const s = useGraphStore.getState()
+      expect(s.hoveredNodeId).toBeNull()
+      expect(s.highlightedNodeIds).toBeNull()
+      expect(s.highlightedEdgeIds).toBeNull()
+    })
+
+    it('populates connected sets from edges', () => {
+      useGraphStore.setState({
+        edges: [
+          { id: 'e1', source: 'boo-a1', target: 'skill-a1-bash', type: 'skill', data: {} },
+          { id: 'e2', source: 'boo-a1', target: 'boo-a2', type: 'dependency', data: {} },
+          { id: 'e3', source: 'boo-a2', target: 'skill-a2-web', type: 'skill', data: {} },
+        ],
+      })
+
+      useGraphStore.getState().setHoveredNodeId('boo-a1')
+      const s = useGraphStore.getState()
+
+      expect(s.hoveredNodeId).toBe('boo-a1')
+      expect(s.highlightedNodeIds).toEqual(new Set(['boo-a1', 'skill-a1-bash', 'boo-a2']))
+      expect(s.highlightedEdgeIds).toEqual(new Set(['e1', 'e2']))
+    })
+
+    it('hovering node with no edges highlights only itself', () => {
+      useGraphStore.setState({
+        edges: [{ id: 'e1', source: 'boo-a1', target: 'boo-a2', type: 'dependency', data: {} }],
+      })
+
+      useGraphStore.getState().setHoveredNodeId('boo-a3')
+      const s = useGraphStore.getState()
+
+      expect(s.highlightedNodeIds).toEqual(new Set(['boo-a3']))
+      expect(s.highlightedEdgeIds).toEqual(new Set())
     })
   })
 

--- a/apps/web/src/features/graph/computeOrbitalPositions.ts
+++ b/apps/web/src/features/graph/computeOrbitalPositions.ts
@@ -1,0 +1,194 @@
+import type { GraphNode, GraphEdge, LayoutData } from './types'
+
+// ─── FNV-1a hash (same as useFloatingMotion.ts — copied to avoid coupling) ──
+
+function fnv1a(str: string): number {
+  let hash = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const SKILL_RADIUS = { min: 130, max: 160 }
+const RESOURCE_RADIUS = { min: 180, max: 220 }
+const JITTER_RANGE = 12
+
+// Half of ELK default envelope for boo nodes (180×80)
+const BOO_HALF_W = 90
+const BOO_HALF_H = 40
+
+// Node dimensions for centering orbital children
+const SKILL_SIZE = 38 // CIRCLE const in SkillNode.tsx
+const RESOURCE_W = 64
+const RESOURCE_H = 70
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function computeCentroid(booNodes: GraphNode[]): { cx: number; cy: number } {
+  if (booNodes.length === 0) return { cx: 0, cy: 0 }
+  if (booNodes.length === 1) {
+    // Single boo: fake centroid above so children orbit downward
+    return {
+      cx: booNodes[0]!.position.x + BOO_HALF_W,
+      cy: booNodes[0]!.position.y + BOO_HALF_H - 200,
+    }
+  }
+  let sumX = 0
+  let sumY = 0
+  for (const n of booNodes) {
+    sumX += n.position.x + BOO_HALF_W
+    sumY += n.position.y + BOO_HALF_H
+  }
+  return { cx: sumX / booNodes.length, cy: sumY / booNodes.length }
+}
+
+function awayAngle(booPos: { x: number; y: number }, centroid: { cx: number; cy: number }): number {
+  const dx = booPos.x + BOO_HALF_W - centroid.cx
+  const dy = booPos.y + BOO_HALF_H - centroid.cy
+  if (dx === 0 && dy === 0) return Math.PI / 2 // fallback: downward
+  return Math.atan2(dy, dx)
+}
+
+function arcSpread(count: number): number {
+  if (count <= 1) return 0
+  // Full circle: 2π × (count-1)/count — leaves one gap-sized slot toward the centroid.
+  // count=2 → 180°, count=3 → 240°, count=5 → 288°, count=10 → 324°, count=16 → 337.5°
+  return 2 * Math.PI * ((count - 1) / count)
+}
+
+function distributeOnArc(
+  parentCenter: { x: number; y: number },
+  baseAngle: number,
+  children: GraphNode[],
+  radiusRange: { min: number; max: number },
+  savedPositions: LayoutData['positions'],
+): GraphNode[] {
+  const count = children.length
+  if (count === 0) return []
+
+  const spread = arcSpread(count)
+  const startAngle = baseAngle - spread / 2
+  const angleStep = count === 1 ? 0 : spread / (count - 1)
+
+  // Max distance from parent center before a saved position is considered stale
+  const staleThreshold = radiusRange.max * 2
+
+  return children.map((node, i) => {
+    // Respect user-dragged positions — but discard stale ones from previous layouts
+    const saved = savedPositions[node.id]
+    if (saved) {
+      const nodeW = node.type === 'skill' ? SKILL_SIZE : RESOURCE_W
+      const nodeH = node.type === 'skill' ? SKILL_SIZE : RESOURCE_H
+      const savedCx = saved.x + nodeW / 2
+      const savedCy = saved.y + nodeH / 2
+      const dist = Math.sqrt((parentCenter.x - savedCx) ** 2 + (parentCenter.y - savedCy) ** 2)
+      if (dist <= staleThreshold) {
+        return { ...node, position: saved }
+      }
+      // Stale saved position (e.g. from old layout) — fall through to orbital
+    }
+
+    const angle = startAngle + i * angleStep
+
+    // Deterministic jitter from hash
+    const hash = fnv1a(node.id)
+    const radiusNorm = ((hash >>> 8) & 0xff) / 255
+    const jitterNorm = ((hash >>> 0) & 0xff) / 255
+
+    const baseRadius = radiusRange.min + radiusNorm * (radiusRange.max - radiusRange.min)
+    const jitterOffset = (jitterNorm - 0.5) * 2 * JITTER_RANGE
+    const radius = baseRadius + jitterOffset
+
+    // Center the child node on the orbital point
+    const nodeW = node.type === 'skill' ? SKILL_SIZE : RESOURCE_W
+    const nodeH = node.type === 'skill' ? SKILL_SIZE : RESOURCE_H
+
+    const x = parentCenter.x + Math.cos(angle) * radius - nodeW / 2
+    const y = parentCenter.y + Math.sin(angle) * radius - nodeH / 2
+
+    return { ...node, position: { x, y } }
+  })
+}
+
+// ─── Main function ───────────────────────────────────────────────────────────
+
+export function computeOrbitalPositions(
+  booNodes: GraphNode[],
+  nonBooNodes: GraphNode[],
+  edges: GraphEdge[],
+  savedPositions: LayoutData['positions'],
+): GraphNode[] {
+  if (nonBooNodes.length === 0) return []
+  if (booNodes.length === 0) return nonBooNodes
+
+  // 1. Build parent → children map from edges
+  const childrenByBoo = new Map<string, { skills: GraphNode[]; resources: GraphNode[] }>()
+
+  for (const node of nonBooNodes) {
+    const parentEdge = edges.find((e) => e.target === node.id)
+    if (!parentEdge) continue
+    const parentBooId = parentEdge.source
+
+    let entry = childrenByBoo.get(parentBooId)
+    if (!entry) {
+      entry = { skills: [], resources: [] }
+      childrenByBoo.set(parentBooId, entry)
+    }
+    if (node.type === 'skill') entry.skills.push(node)
+    else if (node.type === 'resource') entry.resources.push(node)
+  }
+
+  // Sort children by ID for deterministic ordering
+  for (const entry of childrenByBoo.values()) {
+    entry.skills.sort((a, b) => a.id.localeCompare(b.id))
+    entry.resources.sort((a, b) => a.id.localeCompare(b.id))
+  }
+
+  // 2. Compute centroid of all boo positions
+  const centroid = computeCentroid(booNodes)
+
+  // 3. Position each boo's children in orbital arcs
+  const result: GraphNode[] = []
+
+  for (const booNode of booNodes) {
+    const children = childrenByBoo.get(booNode.id)
+    if (!children) continue
+
+    const parentCenter = {
+      x: booNode.position.x + BOO_HALF_W,
+      y: booNode.position.y + BOO_HALF_H,
+    }
+    const base = awayAngle(booNode.position, centroid)
+
+    // Skills: inner arc
+    result.push(
+      ...distributeOnArc(parentCenter, base, children.skills, SKILL_RADIUS, savedPositions),
+    )
+
+    // Resources: outer arc with slight angular offset to avoid stacking
+    const resourceOffset = children.skills.length > 0 ? 0.15 : 0
+    result.push(
+      ...distributeOnArc(
+        parentCenter,
+        base + resourceOffset,
+        children.resources,
+        RESOURCE_RADIUS,
+        savedPositions,
+      ),
+    )
+  }
+
+  // 4. Handle orphan non-boo nodes (no parent edge — shouldn't happen)
+  const positionedIds = new Set(result.map((n) => n.id))
+  for (const node of nonBooNodes) {
+    if (!positionedIds.has(node.id)) {
+      result.push({ ...node, position: savedPositions[node.id] ?? node.position })
+    }
+  }
+
+  return result
+}

--- a/apps/web/src/features/graph/edges/ConnectionLine.tsx
+++ b/apps/web/src/features/graph/edges/ConnectionLine.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { getSmoothStepPath } from '@xyflow/react'
+import { getSmoothStepPath, getBezierPath } from '@xyflow/react'
 import type { ConnectionLineComponentProps } from '@xyflow/react'
 
 // Color the in-progress connection line based on source node type:
@@ -20,15 +20,28 @@ export function ConnectionLine({
   toPosition,
   fromNode,
 }: ConnectionLineComponentProps) {
-  const [path] = getSmoothStepPath({
-    sourceX: fromX,
-    sourceY: fromY,
-    targetX: toX,
-    targetY: toY,
-    sourcePosition: fromPosition,
-    targetPosition: toPosition,
-    borderRadius: 10,
-  })
+  // Boo→Boo connections use smooth-step (stepped routing) to match DependencyEdge.
+  // Skill→Boo connections use bezier (organic curves) to match SkillEdge.
+  const useSmoothStep = fromNode?.type === 'boo'
+
+  const [path] = useSmoothStep
+    ? getSmoothStepPath({
+        sourceX: fromX,
+        sourceY: fromY,
+        targetX: toX,
+        targetY: toY,
+        sourcePosition: fromPosition,
+        targetPosition: toPosition,
+        borderRadius: 10,
+      })
+    : getBezierPath({
+        sourceX: fromX,
+        sourceY: fromY,
+        targetX: toX,
+        targetY: toY,
+        sourcePosition: fromPosition,
+        targetPosition: toPosition,
+      })
 
   const color = NODE_TYPE_COLOR[fromNode?.type ?? ''] ?? 'rgba(255,255,255,0.5)'
 

--- a/apps/web/src/features/graph/edges/DependencyEdge.tsx
+++ b/apps/web/src/features/graph/edges/DependencyEdge.tsx
@@ -3,8 +3,11 @@
 import { memo } from 'react'
 import { BaseEdge, getSmoothStepPath } from '@xyflow/react'
 import type { EdgeProps } from '@xyflow/react'
+import { useGraphStore } from '../store'
 
 // ─── DependencyEdge — fast animated red dashes: Boo → Boo ────────────────────
+// Stays smooth-step (stepped routing) — visual contrast with organic bezier
+// curves on skill/resource edges is intentional information design.
 
 export const DependencyEdge = memo(function DependencyEdge({
   id,
@@ -26,16 +29,22 @@ export const DependencyEdge = memo(function DependencyEdge({
     borderRadius: 10,
   })
 
+  // Hover cascade — brighten when connected to hovered node, dim otherwise
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedEdgeIds?.has(id) ?? false),
+  )
+
   return (
     <BaseEdge
       id={id}
       path={edgePath}
       style={{
-        stroke: selected ? '#E94560' : 'rgba(233,69,96,0.65)',
+        stroke: selected ? '#E94560' : 'rgba(233,69,96,0.55)',
         strokeWidth: selected ? 2.5 : 1.5,
         strokeDasharray: '8 6',
         animation: 'marchingAnts 0.38s linear infinite',
-        transition: 'stroke 0.15s, stroke-width 0.15s',
+        transition: 'stroke 0.15s, stroke-width 0.15s, opacity 0.2s ease',
+        opacity: isHighlighted ? 1 : 0.12,
       }}
     />
   )

--- a/apps/web/src/features/graph/edges/ResourceEdge.tsx
+++ b/apps/web/src/features/graph/edges/ResourceEdge.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { memo } from 'react'
-import { BaseEdge, getSmoothStepPath } from '@xyflow/react'
+import { BaseEdge, getBezierPath } from '@xyflow/react'
 import type { EdgeProps } from '@xyflow/react'
+import { useGraphStore } from '../store'
 
-// ─── ResourceEdge — slow animated amber dashes: Boo → Resource ───────────────
+// ─── ResourceEdge — slow animated amber bezier curves: Boo → Resource ─────────
 
 export const ResourceEdge = memo(function ResourceEdge({
   id,
@@ -16,26 +17,31 @@ export const ResourceEdge = memo(function ResourceEdge({
   targetPosition,
   selected,
 }: EdgeProps) {
-  const [edgePath] = getSmoothStepPath({
+  const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
     targetX,
     targetY,
     sourcePosition,
     targetPosition,
-    borderRadius: 10,
   })
+
+  // Hover cascade — brighten when connected to hovered node, dim otherwise
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedEdgeIds?.has(id) ?? false),
+  )
 
   return (
     <BaseEdge
       id={id}
       path={edgePath}
       style={{
-        stroke: selected ? '#FBBF24' : 'rgba(251,191,36,0.5)',
+        stroke: selected ? '#FBBF24' : 'rgba(251,191,36,0.30)',
         strokeWidth: selected ? 2 : 1,
         strokeDasharray: '8 6',
         animation: 'marchingAnts 0.9s linear infinite',
-        transition: 'stroke 0.15s, stroke-width 0.15s',
+        transition: 'stroke 0.15s, stroke-width 0.15s, opacity 0.2s ease',
+        opacity: isHighlighted ? 1 : 0.12,
       }}
     />
   )

--- a/apps/web/src/features/graph/edges/SkillEdge.tsx
+++ b/apps/web/src/features/graph/edges/SkillEdge.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { memo } from 'react'
-import { BaseEdge, getSmoothStepPath } from '@xyflow/react'
+import { BaseEdge, getBezierPath } from '@xyflow/react'
 import type { EdgeProps } from '@xyflow/react'
+import { useGraphStore } from '../store'
 
-// ─── SkillEdge — animated mint dashes: Boo → Skill ───────────────────────────
+// ─── SkillEdge — animated mint bezier curves: Boo → Skill ─────────────────────
 
 export const SkillEdge = memo(function SkillEdge({
   id,
@@ -16,26 +17,31 @@ export const SkillEdge = memo(function SkillEdge({
   targetPosition,
   selected,
 }: EdgeProps) {
-  const [edgePath] = getSmoothStepPath({
+  const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
     targetX,
     targetY,
     sourcePosition,
     targetPosition,
-    borderRadius: 10,
   })
+
+  // Hover cascade — brighten when connected to hovered node, dim otherwise
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedEdgeIds?.has(id) ?? false),
+  )
 
   return (
     <BaseEdge
       id={id}
       path={edgePath}
       style={{
-        stroke: selected ? '#34D399' : 'rgba(52,211,153,0.5)',
-        strokeWidth: selected ? 2 : 1.5,
+        stroke: selected ? '#34D399' : 'rgba(52,211,153,0.35)',
+        strokeWidth: selected ? 2 : isHighlighted ? 1.5 : 1.5,
         strokeDasharray: '8 6',
         animation: 'marchingAnts 0.6s linear infinite',
-        transition: 'stroke 0.15s, stroke-width 0.15s',
+        transition: 'stroke 0.15s, stroke-width 0.15s, opacity 0.2s ease',
+        opacity: isHighlighted ? 1 : 0.12,
       }}
     />
   )

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -67,12 +67,21 @@ const handleConnecting = {
   transition: 'opacity 0.15s, background 0.15s, width 0.15s, height 0.15s',
 }
 
-// ─── BooNode dimensions ───────────────────────────────────────────────────────
-// BooAvatar viewBox is 100×92 → aspect = 0.92
-// At BOO_W=60: BOO_H = round(60 × 0.92) = 55
-
-const BOO_W = 60
-const BOO_H = Math.round(BOO_W * 0.92) // 55
+// Invisible center handle style — used for edge path routing only
+const centerHandleStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  opacity: 0,
+  pointerEvents: 'none',
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  border: 'none',
+  background: 'transparent',
+}
 
 // ─── BooNode ──────────────────────────────────────────────────────────────────
 
@@ -94,6 +103,16 @@ export const BooNode = memo(function BooNode({
   )
   const lastSeenLabel = status !== 'running' ? formatLastSeen(lastSeenAt) : null
 
+  // Hover cascade — dim when another node is hovered
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedNodeIds?.has(`boo-${agentId}`) ?? false),
+  )
+
+  // Degree-aware sizing: +3px per connected edge, capped at +18px
+  const edgeCount = data.edgeCount ?? 0
+  const booW = Math.min(60 + edgeCount * 3, 78)
+  const booH = Math.round(booW * 0.92)
+
   // Drop-shadow animation driven by status
   const dropShadow = glow
     ? glow.pulse
@@ -106,28 +125,27 @@ export const BooNode = memo(function BooNode({
     : 'drop-shadow(0 0 0px rgba(0,0,0,0))'
 
   return (
-    // Node root: exactly BOO_W × BOO_H.
-    // overflow: visible lets the name + status label render below
-    // without inflating the React Flow measured size.
     <div
       className="group"
       style={{
-        width: BOO_W,
-        height: BOO_H,
+        width: booW,
+        height: booH,
         position: 'relative',
         overflow: 'visible',
         cursor: 'pointer',
+        opacity: isHighlighted ? 1 : 0.22,
+        transition: 'opacity 0.2s ease',
       }}
     >
       {/* ── BooAvatar + glow ──────────────────────────────────────────────── */}
       <motion.div
-        style={{ width: BOO_W, height: BOO_H, position: 'relative' }}
+        style={{ width: booW, height: booH, position: 'relative' }}
         animate={{ filter: dropShadow }}
         transition={
           glow?.pulse ? { duration: 2.2, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.4 }
         }
       >
-        <BooAvatar seed={agentId} size={BOO_W} />
+        <BooAvatar seed={agentId} size={booW} />
       </motion.div>
 
       {/* ── Approval alert ring (pulsing amber) ───────────────────────────── */}
@@ -163,7 +181,7 @@ export const BooNode = memo(function BooNode({
       <div
         style={{
           position: 'absolute',
-          top: BOO_H + 8,
+          top: booH + 8,
           left: '50%',
           transform: 'translateX(-50%)',
           fontSize: 12,
@@ -185,7 +203,7 @@ export const BooNode = memo(function BooNode({
       <div
         style={{
           position: 'absolute',
-          top: BOO_H + 26,
+          top: booH + 26,
           left: '50%',
           transform: 'translateX(-50%)',
           display: 'flex',
@@ -225,7 +243,7 @@ export const BooNode = memo(function BooNode({
         <div
           style={{
             position: 'absolute',
-            top: BOO_H + 40,
+            top: booH + 40,
             left: '50%',
             transform: 'translateX(-50%)',
             fontSize: 9,
@@ -238,8 +256,7 @@ export const BooNode = memo(function BooNode({
         </div>
       )}
 
-      {/* ── Handles ──────────────────────────────────────────────────────── */}
-      {/* Top: center of ghost head — target for incoming connections */}
+      {/* ── Interactive handles ─────────────────────────────────────────── */}
       <Handle
         type="target"
         position={Position.Top}
@@ -248,7 +265,6 @@ export const BooNode = memo(function BooNode({
         }
         style={isConnecting || connectMode ? handleConnecting : handleBase}
       />
-      {/* Bottom: between ghost bumps — source for outgoing connections */}
       <Handle
         type="source"
         position={Position.Bottom}
@@ -257,7 +273,6 @@ export const BooNode = memo(function BooNode({
         }
         style={isConnecting || connectMode ? handleConnecting : handleBase}
       />
-      {/* Right: ghost body mid-height — source for skill/resource edges */}
       <Handle
         type="source"
         id="right"
@@ -267,6 +282,10 @@ export const BooNode = memo(function BooNode({
         }
         style={isConnecting || connectMode ? handleConnecting : handleBase}
       />
+
+      {/* ── Center handles — invisible, for edge path routing only ──────── */}
+      <Handle id="center" type="source" position={Position.Top} style={centerHandleStyle} />
+      <Handle id="center-target" type="target" position={Position.Top} style={centerHandleStyle} />
     </div>
   )
 })

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -7,6 +7,7 @@ import { motion } from 'framer-motion'
 import { BooAvatar } from '@clawboo/ui'
 import type { BooNodeData } from '../types'
 import { useGraphStore } from '../store'
+import { useFloatingMotion } from '../useFloatingMotion'
 import { useApprovalsStore } from '@/stores/approvals'
 import { useFleetStore } from '@/stores/fleet'
 
@@ -88,8 +89,10 @@ const centerHandleStyle: React.CSSProperties = {
 export const BooNode = memo(function BooNode({
   data,
   selected,
+  dragging,
 }: NodeProps<Node<BooNodeData, 'boo'>>) {
   const { agentId, name, status } = data
+  const floatRef = useFloatingMotion(data.agentId, 'boo', dragging)
   const glow = STATUS_GLOW[status] ?? null
   const connection = useConnection()
   const isConnecting = connection.inProgress
@@ -125,167 +128,174 @@ export const BooNode = memo(function BooNode({
     : 'drop-shadow(0 0 0px rgba(0,0,0,0))'
 
   return (
-    <div
-      className="group"
-      style={{
-        width: booW,
-        height: booH,
-        position: 'relative',
-        overflow: 'visible',
-        cursor: 'pointer',
-        opacity: isHighlighted ? 1 : 0.22,
-        transition: 'opacity 0.2s ease',
-      }}
-    >
-      {/* ── BooAvatar + glow ──────────────────────────────────────────────── */}
-      <motion.div
-        style={{ width: booW, height: booH, position: 'relative' }}
-        animate={{ filter: dropShadow }}
-        transition={
-          glow?.pulse ? { duration: 2.2, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.4 }
-        }
+    <div ref={floatRef}>
+      <div
+        className="group"
+        style={{
+          width: booW,
+          height: booH,
+          position: 'relative',
+          overflow: 'visible',
+          cursor: 'pointer',
+          opacity: isHighlighted ? 1 : 0.22,
+          transition: 'opacity 0.2s ease',
+        }}
       >
-        <BooAvatar seed={agentId} size={booW} />
-      </motion.div>
-
-      {/* ── Approval alert ring (pulsing amber) ───────────────────────────── */}
-      {hasPendingApproval && (
+        {/* ── BooAvatar + glow ──────────────────────────────────────────────── */}
         <motion.div
-          animate={{ scale: [1, 1.15, 1], opacity: [0.8, 1, 0.8] }}
-          transition={{ duration: 1.1, repeat: Infinity, ease: 'easeInOut' }}
-          style={{
-            position: 'absolute',
-            inset: -5,
-            borderRadius: 10,
-            border: '2.5px solid #FBBF24',
-            boxShadow: '0 0 12px rgba(251,191,36,0.55)',
-            pointerEvents: 'none',
-          }}
-        />
-      )}
+          style={{ width: booW, height: booH, position: 'relative' }}
+          animate={{ filter: dropShadow }}
+          transition={
+            glow?.pulse ? { duration: 2.2, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.4 }
+          }
+        >
+          <BooAvatar seed={agentId} size={booW} />
+        </motion.div>
 
-      {/* ── Selection ring ────────────────────────────────────────────────── */}
-      {selected && (
-        <div
-          style={{
-            position: 'absolute',
-            inset: -3,
-            borderRadius: 8,
-            border: '2px solid rgba(233,69,96,0.7)',
-            pointerEvents: 'none',
-          }}
-        />
-      )}
-
-      {/* ── Name label ───────────────────────────────────────────────────── */}
-      <div
-        style={{
-          position: 'absolute',
-          top: booH + 8,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          fontSize: 12,
-          fontWeight: 600,
-          color: selected ? '#E94560' : '#E8E8E8',
-          fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
-          whiteSpace: 'nowrap',
-          maxWidth: 96,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          textAlign: 'center',
-          letterSpacing: '0.01em',
-        }}
-      >
-        {name}
-      </div>
-
-      {/* ── Status dot + label ────────────────────────────────────────────── */}
-      <div
-        style={{
-          position: 'absolute',
-          top: booH + 26,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 4,
-        }}
-      >
-        {status === 'running' ? (
+        {/* ── Approval alert ring (pulsing amber) ───────────────────────────── */}
+        {hasPendingApproval && (
           <motion.div
-            style={{ width: 5, height: 5, borderRadius: '50%', background: STATUS_DOT.running }}
-            animate={{ opacity: [1, 0.2, 1] }}
-            transition={{ duration: 1.1, repeat: Infinity }}
-          />
-        ) : (
-          <div
+            animate={{ scale: [1, 1.15, 1], opacity: [0.8, 1, 0.8] }}
+            transition={{ duration: 1.1, repeat: Infinity, ease: 'easeInOut' }}
             style={{
-              width: 5,
-              height: 5,
-              borderRadius: '50%',
-              background: STATUS_DOT[status] ?? STATUS_DOT.idle,
+              position: 'absolute',
+              inset: -5,
+              borderRadius: 10,
+              border: '2.5px solid #FBBF24',
+              boxShadow: '0 0 12px rgba(251,191,36,0.55)',
+              pointerEvents: 'none',
             }}
           />
         )}
-        <span
-          style={{
-            fontSize: 10,
-            color: 'rgba(232,232,232,0.38)',
-            letterSpacing: '0.05em',
-          }}
-        >
-          {STATUS_LABEL[status] ?? 'idle'}
-        </span>
-      </div>
 
-      {/* ── Last seen label ────────────────────────────────────────────── */}
-      {lastSeenLabel && (
+        {/* ── Selection ring ────────────────────────────────────────────────── */}
+        {selected && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: -3,
+              borderRadius: 8,
+              border: '2px solid rgba(233,69,96,0.7)',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+
+        {/* ── Name label ───────────────────────────────────────────────────── */}
         <div
           style={{
             position: 'absolute',
-            top: booH + 40,
+            top: booH + 8,
             left: '50%',
             transform: 'translateX(-50%)',
-            fontSize: 9,
-            color: 'rgba(232,232,232,0.25)',
+            fontSize: 12,
+            fontWeight: 600,
+            color: selected ? '#E94560' : '#E8E8E8',
+            fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
             whiteSpace: 'nowrap',
-            letterSpacing: '0.03em',
+            maxWidth: 96,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            textAlign: 'center',
+            letterSpacing: '0.01em',
           }}
         >
-          {lastSeenLabel}
+          {name}
         </div>
-      )}
 
-      {/* ── Interactive handles ─────────────────────────────────────────── */}
-      <Handle
-        type="target"
-        position={Position.Top}
-        className={
-          isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-        }
-        style={isConnecting || connectMode ? handleConnecting : handleBase}
-      />
-      <Handle
-        type="source"
-        position={Position.Bottom}
-        className={
-          isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-        }
-        style={isConnecting || connectMode ? handleConnecting : handleBase}
-      />
-      <Handle
-        type="source"
-        id="right"
-        position={Position.Right}
-        className={
-          isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-        }
-        style={isConnecting || connectMode ? handleConnecting : handleBase}
-      />
+        {/* ── Status dot + label ────────────────────────────────────────────── */}
+        <div
+          style={{
+            position: 'absolute',
+            top: booH + 26,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+          }}
+        >
+          {status === 'running' ? (
+            <motion.div
+              style={{ width: 5, height: 5, borderRadius: '50%', background: STATUS_DOT.running }}
+              animate={{ opacity: [1, 0.2, 1] }}
+              transition={{ duration: 1.1, repeat: Infinity }}
+            />
+          ) : (
+            <div
+              style={{
+                width: 5,
+                height: 5,
+                borderRadius: '50%',
+                background: STATUS_DOT[status] ?? STATUS_DOT.idle,
+              }}
+            />
+          )}
+          <span
+            style={{
+              fontSize: 10,
+              color: 'rgba(232,232,232,0.38)',
+              letterSpacing: '0.05em',
+            }}
+          >
+            {STATUS_LABEL[status] ?? 'idle'}
+          </span>
+        </div>
 
-      {/* ── Center handles — invisible, for edge path routing only ──────── */}
-      <Handle id="center" type="source" position={Position.Top} style={centerHandleStyle} />
-      <Handle id="center-target" type="target" position={Position.Top} style={centerHandleStyle} />
+        {/* ── Last seen label ────────────────────────────────────────────── */}
+        {lastSeenLabel && (
+          <div
+            style={{
+              position: 'absolute',
+              top: booH + 40,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              fontSize: 9,
+              color: 'rgba(232,232,232,0.25)',
+              whiteSpace: 'nowrap',
+              letterSpacing: '0.03em',
+            }}
+          >
+            {lastSeenLabel}
+          </div>
+        )}
+
+        {/* ── Interactive handles ─────────────────────────────────────────── */}
+        <Handle
+          type="target"
+          position={Position.Top}
+          className={
+            isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }
+          style={isConnecting || connectMode ? handleConnecting : handleBase}
+        />
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          className={
+            isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }
+          style={isConnecting || connectMode ? handleConnecting : handleBase}
+        />
+        <Handle
+          type="source"
+          id="right"
+          position={Position.Right}
+          className={
+            isConnecting || connectMode ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }
+          style={isConnecting || connectMode ? handleConnecting : handleBase}
+        />
+
+        {/* ── Center handles — invisible, for edge path routing only ──────── */}
+        <Handle id="center" type="source" position={Position.Top} style={centerHandleStyle} />
+        <Handle
+          id="center-target"
+          type="target"
+          position={Position.Top}
+          style={centerHandleStyle}
+        />
+      </div>
     </div>
   )
 })

--- a/apps/web/src/features/graph/nodes/ResourceNode.tsx
+++ b/apps/web/src/features/graph/nodes/ResourceNode.tsx
@@ -3,6 +3,7 @@
 import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
+import { useGraphStore } from '../store'
 import type { ResourceNodeData } from '../types'
 
 // ─── Handle style ─────────────────────────────────────────────────────────────
@@ -14,21 +15,44 @@ const handleStyle = {
   height: 7,
 }
 
+// Invisible center handle style — used for edge path routing only
+const centerHandleStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  opacity: 0,
+  pointerEvents: 'none',
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  border: 'none',
+  background: 'transparent',
+}
+
 // ─── ResourceNode — amber-tinted card with service icon ───────────────────────
 
 export const ResourceNode = memo(function ResourceNode({
+  id: nodeId,
   data,
 }: NodeProps<Node<ResourceNodeData, 'resource'>>) {
   const { name, serviceIcon } = data
 
+  // Hover cascade — dim when another node is hovered
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedNodeIds?.has(nodeId) ?? false),
+  )
+
   return (
-    // Node root: 64×70 card. Overflow visible for potential future labels.
     <div
       style={{
         width: 64,
         height: 70,
         position: 'relative',
         overflow: 'visible',
+        opacity: isHighlighted ? 1 : 0.22,
+        transition: 'opacity 0.2s ease',
       }}
     >
       <div
@@ -70,6 +94,9 @@ export const ResourceNode = memo(function ResourceNode({
 
       {/* Left handle — vertically centered (default 50% of 70px = 35px) */}
       <Handle type="target" position={Position.Left} style={handleStyle} />
+
+      {/* Center handle — invisible, for edge path routing only */}
+      <Handle id="center" type="target" position={Position.Left} style={centerHandleStyle} />
     </div>
   )
 })

--- a/apps/web/src/features/graph/nodes/SkillNode.tsx
+++ b/apps/web/src/features/graph/nodes/SkillNode.tsx
@@ -6,6 +6,7 @@ import type { NodeProps, Node } from '@xyflow/react'
 import { AgentPickerDropdown } from '@/features/marketplace/AgentPickerDropdown'
 import { installSkillForAgent } from '../operations/installSkill'
 import { useGraphStore } from '../store'
+import { useFloatingMotion } from '../useFloatingMotion'
 import type { SkillNodeData, SkillCategory } from '../types'
 
 // ─── Category → colour + icon ─────────────────────────────────────────────────
@@ -51,8 +52,10 @@ const centerHandleStyle: React.CSSProperties = {
 export const SkillNode = memo(function SkillNode({
   id: nodeId,
   data,
+  dragging,
 }: NodeProps<Node<SkillNodeData, 'skill'>>) {
   const { name, category, description } = data
+  const floatRef = useFloatingMotion(nodeId, 'skill', dragging)
   const { color, icon } = CATEGORY[category] ?? CATEGORY.other
   const [showPicker, setShowPicker] = useState(false)
 
@@ -62,110 +65,112 @@ export const SkillNode = memo(function SkillNode({
   )
 
   return (
-    <div
-      title={description ?? name}
-      className="group"
-      style={{
-        width: CIRCLE,
-        height: CIRCLE,
-        position: 'relative',
-        overflow: 'visible',
-        opacity: isHighlighted ? 1 : 0.22,
-        transition: 'opacity 0.2s ease',
-      }}
-    >
-      {/* Filled circle */}
+    <div ref={floatRef}>
       <div
+        title={description ?? name}
+        className="group"
         style={{
           width: CIRCLE,
           height: CIRCLE,
-          borderRadius: '50%',
-          background: `${color}18`,
-          border: `2px solid ${color}55`,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          boxShadow: `0 0 14px ${color}28, inset 0 1px 0 rgba(255,255,255,0.06)`,
+          position: 'relative',
+          overflow: 'visible',
+          opacity: isHighlighted ? 1 : 0.22,
+          transition: 'opacity 0.2s ease',
         }}
       >
-        <span style={{ fontSize: 16, lineHeight: 1, userSelect: 'none' }}>{icon}</span>
-      </div>
-
-      {/* Install button — appears on hover */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation()
-          setShowPicker((v) => !v)
-        }}
-        className="opacity-0 group-hover:opacity-100"
-        style={{
-          position: 'absolute',
-          top: -6,
-          right: -14,
-          background: '#34D399',
-          color: '#0A0E1A',
-          border: 'none',
-          borderRadius: 4,
-          fontSize: 9,
-          fontWeight: 700,
-          padding: '2px 6px',
-          cursor: 'pointer',
-          transition: 'opacity 0.15s',
-          whiteSpace: 'nowrap',
-          letterSpacing: '0.02em',
-        }}
-      >
-        Install →
-      </button>
-
-      {/* Agent picker dropdown */}
-      {showPicker && (
-        <AgentPickerDropdown
-          onSelect={(agentId, agentName) => {
-            void installSkillForAgent(name, agentId, agentName)
+        {/* Filled circle */}
+        <div
+          style={{
+            width: CIRCLE,
+            height: CIRCLE,
+            borderRadius: '50%',
+            background: `${color}18`,
+            border: `2px solid ${color}55`,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            boxShadow: `0 0 14px ${color}28, inset 0 1px 0 rgba(255,255,255,0.06)`,
           }}
-          onClose={() => setShowPicker(false)}
-          style={{ top: CIRCLE + 4, left: '50%', transform: 'translateX(-50%)' }}
+        >
+          <span style={{ fontSize: 16, lineHeight: 1, userSelect: 'none' }}>{icon}</span>
+        </div>
+
+        {/* Install button — appears on hover */}
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            setShowPicker((v) => !v)
+          }}
+          className="opacity-0 group-hover:opacity-100"
+          style={{
+            position: 'absolute',
+            top: -6,
+            right: -14,
+            background: '#34D399',
+            color: '#0A0E1A',
+            border: 'none',
+            borderRadius: 4,
+            fontSize: 9,
+            fontWeight: 700,
+            padding: '2px 6px',
+            cursor: 'pointer',
+            transition: 'opacity 0.15s',
+            whiteSpace: 'nowrap',
+            letterSpacing: '0.02em',
+          }}
+        >
+          Install →
+        </button>
+
+        {/* Agent picker dropdown */}
+        {showPicker && (
+          <AgentPickerDropdown
+            onSelect={(agentId, agentName) => {
+              void installSkillForAgent(name, agentId, agentName)
+            }}
+            onClose={() => setShowPicker(false)}
+            style={{ top: CIRCLE + 4, left: '50%', transform: 'translateX(-50%)' }}
+          />
+        )}
+
+        {/* Name below circle */}
+        <div
+          style={{
+            position: 'absolute',
+            top: CIRCLE + 6,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            fontSize: 11,
+            fontWeight: 500,
+            color: color,
+            whiteSpace: 'nowrap',
+            maxWidth: 84,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            textAlign: 'center',
+            letterSpacing: '0.02em',
+          }}
+        >
+          {name}
+        </div>
+
+        {/* Left handle — target for incoming edges from BooNodes */}
+        <Handle
+          type="target"
+          position={Position.Left}
+          style={{ ...handleStyle, borderColor: `${color}55` }}
         />
-      )}
+        {/* Right handle — source for drag-to-install onto BooNodes */}
+        <Handle
+          type="source"
+          id="install"
+          position={Position.Right}
+          style={{ ...handleStyle, borderColor: `${color}55` }}
+        />
 
-      {/* Name below circle */}
-      <div
-        style={{
-          position: 'absolute',
-          top: CIRCLE + 6,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          fontSize: 11,
-          fontWeight: 500,
-          color: color,
-          whiteSpace: 'nowrap',
-          maxWidth: 84,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          textAlign: 'center',
-          letterSpacing: '0.02em',
-        }}
-      >
-        {name}
+        {/* Center handle — invisible, for edge path routing only */}
+        <Handle id="center" type="target" position={Position.Left} style={centerHandleStyle} />
       </div>
-
-      {/* Left handle — target for incoming edges from BooNodes */}
-      <Handle
-        type="target"
-        position={Position.Left}
-        style={{ ...handleStyle, borderColor: `${color}55` }}
-      />
-      {/* Right handle — source for drag-to-install onto BooNodes */}
-      <Handle
-        type="source"
-        id="install"
-        position={Position.Right}
-        style={{ ...handleStyle, borderColor: `${color}55` }}
-      />
-
-      {/* Center handle — invisible, for edge path routing only */}
-      <Handle id="center" type="target" position={Position.Left} style={centerHandleStyle} />
     </div>
   )
 })

--- a/apps/web/src/features/graph/nodes/SkillNode.tsx
+++ b/apps/web/src/features/graph/nodes/SkillNode.tsx
@@ -5,6 +5,7 @@ import { Handle, Position } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { AgentPickerDropdown } from '@/features/marketplace/AgentPickerDropdown'
 import { installSkillForAgent } from '../operations/installSkill'
+import { useGraphStore } from '../store'
 import type { SkillNodeData, SkillCategory } from '../types'
 
 // ─── Category → colour + icon ─────────────────────────────────────────────────
@@ -18,7 +19,7 @@ const CATEGORY: Record<SkillCategory, { color: string; icon: string }> = {
   other: { color: '#6B7280', icon: '🔧' },
 }
 
-const CIRCLE = 52 // circle diameter in px
+const CIRCLE = 38 // circle diameter in px (reduced from 52 — skills feel subordinate to Boo nodes)
 
 // ─── Handle style ─────────────────────────────────────────────────────────────
 
@@ -29,18 +30,38 @@ const handleStyle = {
   height: 7,
 }
 
+// Invisible center handle style — used for edge path routing only
+const centerHandleStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  opacity: 0,
+  pointerEvents: 'none',
+  width: 1,
+  height: 1,
+  minWidth: 0,
+  minHeight: 0,
+  border: 'none',
+  background: 'transparent',
+}
+
 // ─── SkillNode ────────────────────────────────────────────────────────────────
 
 export const SkillNode = memo(function SkillNode({
+  id: nodeId,
   data,
 }: NodeProps<Node<SkillNodeData, 'skill'>>) {
   const { name, category, description } = data
   const { color, icon } = CATEGORY[category] ?? CATEGORY.other
   const [showPicker, setShowPicker] = useState(false)
 
+  // Hover cascade — dim when another node is hovered
+  const isHighlighted = useGraphStore(
+    (s) => s.hoveredNodeId === null || (s.highlightedNodeIds?.has(nodeId) ?? false),
+  )
+
   return (
-    // Node root: exactly the circle bounding box.
-    // Name label overflows below via absolute positioning.
     <div
       title={description ?? name}
       className="group"
@@ -49,6 +70,8 @@ export const SkillNode = memo(function SkillNode({
         height: CIRCLE,
         position: 'relative',
         overflow: 'visible',
+        opacity: isHighlighted ? 1 : 0.22,
+        transition: 'opacity 0.2s ease',
       }}
     >
       {/* Filled circle */}
@@ -65,7 +88,7 @@ export const SkillNode = memo(function SkillNode({
           boxShadow: `0 0 14px ${color}28, inset 0 1px 0 rgba(255,255,255,0.06)`,
         }}
       >
-        <span style={{ fontSize: 22, lineHeight: 1, userSelect: 'none' }}>{icon}</span>
+        <span style={{ fontSize: 16, lineHeight: 1, userSelect: 'none' }}>{icon}</span>
       </div>
 
       {/* Install button — appears on hover */}
@@ -77,8 +100,8 @@ export const SkillNode = memo(function SkillNode({
         className="opacity-0 group-hover:opacity-100"
         style={{
           position: 'absolute',
-          top: -8,
-          right: -16,
+          top: -6,
+          right: -14,
           background: '#34D399',
           color: '#0A0E1A',
           border: 'none',
@@ -140,6 +163,9 @@ export const SkillNode = memo(function SkillNode({
         position={Position.Right}
         style={{ ...handleStyle, borderColor: `${color}55` }}
       />
+
+      {/* Center handle — invisible, for edge path routing only */}
+      <Handle id="center" type="target" position={Position.Left} style={centerHandleStyle} />
     </div>
   )
 })

--- a/apps/web/src/features/graph/store.ts
+++ b/apps/web/src/features/graph/store.ts
@@ -57,6 +57,12 @@ interface GraphStore {
   /** When true, BooNode handles are always visible for easier edge drawing. */
   connectMode: boolean
   setConnectMode: (v: boolean) => void
+
+  /** Hover cascade — highlights hovered node's cluster, dims everything else. */
+  hoveredNodeId: string | null
+  highlightedNodeIds: Set<string> | null
+  highlightedEdgeIds: Set<string> | null
+  setHoveredNodeId: (id: string | null) => void
 }
 
 // ─── Store instance ───────────────────────────────────────────────────────────
@@ -120,4 +126,28 @@ export const useGraphStore = create<GraphStore>((set) => ({
 
   connectMode: false,
   setConnectMode: (v) => set({ connectMode: v }),
+
+  hoveredNodeId: null,
+  highlightedNodeIds: null,
+  highlightedEdgeIds: null,
+  setHoveredNodeId: (id) =>
+    set((state) => {
+      if (id === null) {
+        return { hoveredNodeId: null, highlightedNodeIds: null, highlightedEdgeIds: null }
+      }
+      const connectedNodes = new Set<string>([id])
+      const connectedEdges = new Set<string>()
+      for (const edge of state.edges) {
+        if (edge.source === id || edge.target === id) {
+          connectedNodes.add(edge.source)
+          connectedNodes.add(edge.target)
+          connectedEdges.add(edge.id)
+        }
+      }
+      return {
+        hoveredNodeId: id,
+        highlightedNodeIds: connectedNodes,
+        highlightedEdgeIds: connectedEdges,
+      }
+    }),
 }))

--- a/apps/web/src/features/graph/types.ts
+++ b/apps/web/src/features/graph/types.ts
@@ -14,6 +14,7 @@ export interface BooNodeData extends Record<string, unknown> {
   status: AgentStatus
   model: string | null
   isStreaming: boolean
+  edgeCount?: number
 }
 
 export interface SkillNodeData extends Record<string, unknown> {

--- a/apps/web/src/features/graph/useFloatingMotion.ts
+++ b/apps/web/src/features/graph/useFloatingMotion.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef } from 'react'
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type FloatingNodeType = 'boo' | 'skill'
+
+interface MotionParams {
+  phase: number
+  amplitudeX: number
+  amplitudeY: number
+  speedX: number
+  speedY: number
+}
+
+// ─── Amplitude ranges by node type ───────────────────────────────────────────
+
+const AMPLITUDE: Record<
+  FloatingNodeType,
+  { minX: number; maxX: number; minY: number; maxY: number }
+> = {
+  boo: { minX: 3, maxX: 5, minY: 3, maxY: 5 },
+  skill: { minX: 1.5, maxX: 3, minY: 1.5, maxY: 3 },
+}
+
+// Speed range (radians per ms) — yields ~2–4 second cycles
+const SPEED_MIN = 0.0004
+const SPEED_MAX = 0.0008
+
+// ─── FNV-1a hash ─────────────────────────────────────────────────────────────
+
+function fnv1a(str: string): number {
+  let hash = 2166136261
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+// ─── Derive deterministic motion params from node ID + type ──────────────────
+
+function deriveParams(nodeId: string, type: FloatingNodeType): MotionParams {
+  const hash = fnv1a(nodeId)
+  const amp = AMPLITUDE[type]
+
+  // Extract 4 normalized values (0–1) from different byte ranges of the hash
+  const n0 = ((hash >>> 0) & 0xff) / 255
+  const n1 = ((hash >>> 8) & 0xff) / 255
+  const n2 = ((hash >>> 16) & 0xff) / 255
+  const n3 = ((hash >>> 24) & 0xff) / 255
+
+  return {
+    phase: n0 * Math.PI * 2,
+    amplitudeX: amp.minX + n1 * (amp.maxX - amp.minX),
+    amplitudeY: amp.minY + n2 * (amp.maxY - amp.minY),
+    speedX: SPEED_MIN + n3 * (SPEED_MAX - SPEED_MIN),
+    speedY: SPEED_MIN + n0 * (SPEED_MAX - SPEED_MIN),
+  }
+}
+
+// ─── Singleton RAF loop ──────────────────────────────────────────────────────
+//
+// One global requestAnimationFrame loop shared across all floating nodes.
+// Starts when the first subscriber mounts, stops when the last unmounts.
+// Frame rate capped at ~60fps to avoid burning CPU on high-refresh displays.
+
+type Subscriber = (time: number) => void
+
+const subscribers = new Set<Subscriber>()
+let rafId: number | null = null
+let lastFrameTime = 0
+
+function onFrame(now: number): void {
+  if (now - lastFrameTime >= 16) {
+    lastFrameTime = now
+    for (const sub of subscribers) sub(now)
+  }
+  if (subscribers.size > 0) {
+    rafId = requestAnimationFrame(onFrame)
+  } else {
+    rafId = null
+  }
+}
+
+function subscribe(sub: Subscriber): () => void {
+  subscribers.add(sub)
+  if (subscribers.size === 1) {
+    rafId = requestAnimationFrame(onFrame)
+  }
+  return () => {
+    subscribers.delete(sub)
+    if (subscribers.size === 0 && rafId !== null) {
+      cancelAnimationFrame(rafId)
+      rafId = null
+    }
+  }
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+//
+// Returns a ref callback to attach to a wrapper <div>. Each frame, the hook
+// writes a CSS transform directly to the DOM — zero React re-renders.
+//
+// When isDragging is true, the transform is cleared so the float doesn't fight
+// the user's drag gesture.
+
+export function useFloatingMotion(
+  nodeId: string,
+  type: FloatingNodeType,
+  isDragging?: boolean,
+): React.RefCallback<HTMLDivElement> {
+  const paramsRef = useRef<MotionParams>(deriveParams(nodeId, type))
+  const elementRef = useRef<HTMLDivElement | null>(null)
+  const isDraggingRef = useRef(isDragging)
+  isDraggingRef.current = isDragging
+
+  // Recompute params if nodeId or type changes (rare — usually stable)
+  useEffect(() => {
+    paramsRef.current = deriveParams(nodeId, type)
+  }, [nodeId, type])
+
+  // Subscribe to the singleton RAF loop
+  useEffect(() => {
+    return subscribe((time) => {
+      const el = elementRef.current
+      if (!el) return
+
+      if (isDraggingRef.current) {
+        el.style.transform = ''
+        return
+      }
+
+      const { phase, amplitudeX, amplitudeY, speedX, speedY } = paramsRef.current
+      const x = Math.sin(time * speedX + phase) * amplitudeX
+      const y = Math.cos(time * speedY + phase * 0.7) * amplitudeY
+      el.style.transform = `translate(${x.toFixed(2)}px, ${y.toFixed(2)}px)`
+    })
+  }, [])
+
+  return useCallback((el: HTMLDivElement | null) => {
+    elementRef.current = el
+  }, [])
+}

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -168,8 +168,9 @@ function buildGraphElements(
           id: `skilledge-${agent.id}-${skill.id}`,
           type: 'skill',
           source: `boo-${agent.id}`,
-          sourceHandle: 'right',
+          sourceHandle: 'center',
           target: nodeId,
+          targetHandle: 'center',
           data: {},
         })
       }
@@ -191,8 +192,9 @@ function buildGraphElements(
           id: `resourceedge-${agent.id}-${resource.id}`,
           type: 'resource',
           source: `boo-${agent.id}`,
-          sourceHandle: 'right',
+          sourceHandle: 'center',
           target: nodeId,
+          targetHandle: 'center',
           data: {},
         })
       }
@@ -213,15 +215,28 @@ function buildGraphElements(
           id: `dep-${agent.id}-${targetId}`,
           type: 'dependency',
           source: `boo-${agent.id}`,
+          sourceHandle: 'center',
           target: `boo-${targetId}`,
+          targetHandle: 'center-target',
           data: {},
         })
       }
     }
   }
 
+  // Compute edge counts per boo node for degree-aware sizing
+  const allEdges = [...depEdges, ...skillEdges, ...resourceEdges]
+  const edgeCounts = new Map<string, number>()
+  for (const edge of allEdges) {
+    edgeCounts.set(edge.source, (edgeCounts.get(edge.source) ?? 0) + 1)
+    edgeCounts.set(edge.target, (edgeCounts.get(edge.target) ?? 0) + 1)
+  }
+  for (const node of booNodes) {
+    ;(node.data as BooNodeData).edgeCount = edgeCounts.get(node.id) ?? 0
+  }
+
   return {
     rawNodes: [...booNodes, ...skillNodes, ...resourceNodes],
-    rawEdges: [...depEdges, ...skillEdges, ...resourceEdges],
+    rawEdges: allEdges,
   }
 }

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -13,8 +13,11 @@ const elk = new ELK()
 const ELK_OPTIONS = {
   'elk.algorithm': 'layered',
   'elk.direction': 'DOWN',
-  'elk.spacing.nodeNode': '60',
-  'elk.layered.spacing.nodeNodeBetweenLayers': '110',
+  // Spacing accounts for orbital children (skills 130-160px, resources 180-220px from center).
+  // Same-layer (horizontal): 2×220 - boo_width(180) + margin ≈ 300
+  // Between-layers (vertical): 2×220 - boo_height(80) + margin ≈ 400
+  'elk.spacing.nodeNode': '300',
+  'elk.layered.spacing.nodeNodeBetweenLayers': '400',
   'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
   'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
   'elk.padding': '[top=40, left=40, bottom=40, right=40]',

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -24,14 +24,14 @@ const ELK_OPTIONS = {
 
 function defaultWidth(nodeType: string | undefined): number {
   if (nodeType === 'boo') return 180
-  if (nodeType === 'skill') return 140
+  if (nodeType === 'skill') return 100
   if (nodeType === 'resource') return 140
   return 160
 }
 
 function defaultHeight(nodeType: string | undefined): number {
   if (nodeType === 'boo') return 80
-  if (nodeType === 'skill') return 40
+  if (nodeType === 'skill') return 30
   if (nodeType === 'resource') return 64
   return 60
 }


### PR DESCRIPTION
## Summary

- Adds hover cascade behavior in `GhostGraph` and related components, with connected node/edge visual feedback on hover.
- Introduces floating motion effects for `BooNode` and `SkillNode` for a more dynamic graph experience.
- Improves layout with two-layer positioning, orbital placement for skill/resource nodes, and spacing updates for better readability.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset 
- [x] Not needed for this PR

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff