### PR TITLE
feat(graph): refine BooNode interactions, edge routing, and group chat avatars

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -76,6 +76,22 @@ body {
   background: rgba(255, 255, 255, 0.22);
 }
 
+/* React Flow Boo nodes — restrict the hit area to the rendered Boo shape only.
+   The Boo is centered inside a 340×340 envelope so its visual position aligns
+   with where ELK plans edges. Without this rule, the empty area around the
+   visible Boo (up to ~265px wide of empty space when the Boo is in circle
+   mode) would still capture hover / click / drag events, making the Boo feel
+   like it's selecting from way too far. The `.group` selector matches the
+   morph wrapper inside BooNode, where the actual avatar / card is rendered.
+   `!important` is needed to override React Flow's default
+   `.react-flow__node { pointer-events: all }` which has equal specificity. */
+.react-flow__node-boo {
+  pointer-events: none !important;
+}
+.react-flow__node-boo .group {
+  pointer-events: auto !important;
+}
+
 /* React Flow controls — blend with dark theme */
 .react-flow__controls-button {
   background: #111827 !important;

--- a/apps/web/src/features/agent-detail/MiniGraph.tsx
+++ b/apps/web/src/features/agent-detail/MiniGraph.tsx
@@ -35,8 +35,16 @@ import type { GraphNode, GraphEdge, BooNodeData, SkillNodeData } from '@/feature
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const BOO_CENTER = { x: 200, y: 100 }
-const BOO_HALF_W = 90
-const BOO_HALF_H = 40
+// Offset from each Boo's React Flow `node.position` (top-left of the
+// envelope) to its visual center. The Boo renders centered inside its
+// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the center is
+// at half the envelope size — same anchor used by `computeOrbitalPositions`,
+// the global `graphPhysics` singleton, and `TeamHaloLayer`. Without this,
+// the local physics engine would compute Boo center 80px left + 130px above
+// the actual visual center, slowly drifting orbital children off their
+// layout positions during drag interactions.
+const BOO_HALF_W = 170
+const BOO_HALF_H = 170
 
 // Physics constants (simplified from graphPhysics.ts — local per mini graph)
 const SPRING_STRENGTH = 0.035
@@ -380,9 +388,24 @@ function MiniGraphInner({ agentId }: { agentId: string }) {
       return
     }
 
-    // Dedupe: only re-layout if nodes actually changed
+    // Dedupe: only re-layout if the node STRUCTURE changed (different IDs).
+    // For pure data changes (e.g. agent.status flipping idle ↔ running, which
+    // drives BooNode's dual-shape morph), keep existing positions and patch
+    // only the data field. Without this, the BooNode in MiniGraph would
+    // never see the new status and never morph from circle to card.
     const rawKey = rawNodes.map((n) => n.id).join('|')
-    if (rawKey === prevRawKeyRef.current && layoutDoneRef.current) return
+    if (rawKey === prevRawKeyRef.current && layoutDoneRef.current) {
+      const rawById = new Map(rawNodes.map((n) => [n.id, n]))
+      setNodes((existing) =>
+        existing.map((n) => {
+          const fresh = rawById.get(n.id)
+          if (!fresh) return n
+          // Keep position (from layout), update data (status / isStreaming / etc.)
+          return { ...n, data: fresh.data } as GraphNode
+        }),
+      )
+      return
+    }
     prevRawKeyRef.current = rawKey
 
     const booNodes = rawNodes.filter((n) => n.type === 'boo')

--- a/apps/web/src/features/graph/TeamHaloLayer.tsx
+++ b/apps/web/src/features/graph/TeamHaloLayer.tsx
@@ -20,12 +20,12 @@ import type { GraphNode, BooNodeData } from './types'
 const HALO_PADDING = 40
 const LABEL_OFFSET = 20 // lift label above topmost hull vertex
 
-// Default BooNode footprint (matches the 220×120 card defined in
-// `nodes/BooNode.tsx` via BOO_CARD_WIDTH / BOO_CARD_HEIGHT). Used as a
-// fallback for hull inflation when React Flow hasn't measured a node
-// yet; once measured, `node.width` / `node.height` are preferred.
-const DEFAULT_BOO_W = 220
-const DEFAULT_BOO_H = 120
+// Offset from each Boo's React Flow `node.position` (top-left of the
+// envelope) to its visual center. The Boo renders centered inside its
+// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the visual
+// center is at half the envelope size — same anchor used by
+// `computeOrbitalPositions.ts` and `graphPhysics.ts`.
+const BOO_CENTER_OFFSET = 170
 
 interface Point {
   x: number
@@ -165,11 +165,12 @@ export function rectToRoundedPath(x: number, y: number, w: number, h: number, r:
 }
 
 function nodeCenter(node: GraphNode): Point {
-  const w = (node.width as number | undefined) ?? DEFAULT_BOO_W
-  const h = (node.height as number | undefined) ?? DEFAULT_BOO_H
+  // The Boo's visual center is at envelope center, not at half its measured
+  // DOM size — `node.width` / `node.height` measure the inner shape (75–78px
+  // circle or 220×120 card) which sits centered inside the envelope.
   return {
-    x: node.position.x + w / 2,
-    y: node.position.y + h / 2,
+    x: node.position.x + BOO_CENTER_OFFSET,
+    y: node.position.y + BOO_CENTER_OFFSET,
   }
 }
 

--- a/apps/web/src/features/graph/__tests__/pickLatestActivity.test.ts
+++ b/apps/web/src/features/graph/__tests__/pickLatestActivity.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import type { TranscriptEntry } from '@clawboo/protocol'
+import { pickLatestActivity } from '../nodes/pickLatestActivity'
+
+// Minimal builder for transcript entries — only fills the fields the helper
+// actually inspects (`kind`, `text`). Anything else is filler.
+function entry(kind: TranscriptEntry['kind'], text: string, index: number): TranscriptEntry {
+  return {
+    entryId: `e${index}`,
+    role: 'assistant',
+    kind,
+    text,
+    sessionKey: 'agent:a1:main',
+    runId: null,
+    source: 'runtime-chat',
+    timestampMs: 1_000_000 + index,
+    sequenceKey: index,
+    confirmed: true,
+    fingerprint: `fp-${index}`,
+  }
+}
+
+describe('pickLatestActivity', () => {
+  it('returns streaming when streaming text is present, even with empty entries', () => {
+    const result = pickLatestActivity('hello mid-stream', [])
+    expect(result).toEqual({ kind: 'streaming', text: 'hello mid-stream' })
+  })
+
+  it('streaming text wins over a more recent committed assistant entry', () => {
+    const entries = [entry('assistant', 'older committed reply', 1)]
+    const result = pickLatestActivity('newer streaming chunk', entries)
+    expect(result).toEqual({ kind: 'streaming', text: 'newer streaming chunk' })
+  })
+
+  it('falls back to latest assistant entry when no streaming text', () => {
+    const entries = [
+      entry('assistant', 'first reply', 1),
+      entry('tool', '[[tool]] some_tool', 2),
+      entry('assistant', 'most recent reply', 3),
+    ]
+    const result = pickLatestActivity(null, entries)
+    expect(result).toEqual({ kind: 'assistant', text: 'most recent reply' })
+  })
+
+  it('formats latest tool entry as [[tool: <label>]]', () => {
+    const entries = [
+      entry('user', 'do the thing', 1),
+      entry('tool', '[[tool]] run_shell\n```json\n{"cmd":"ls"}\n```', 2),
+    ]
+    const result = pickLatestActivity(null, entries)
+    expect(result).toEqual({ kind: 'tool', text: '[[tool: run_shell]]' })
+  })
+
+  it('skips thinking and walks back to the prior assistant entry', () => {
+    const entries = [
+      entry('assistant', 'older response', 1),
+      entry('thinking', 'private reasoning the user should not see', 2),
+    ]
+    const result = pickLatestActivity(null, entries)
+    expect(result).toEqual({ kind: 'assistant', text: 'older response' })
+  })
+
+  it('returns null when entries are empty and no streaming text', () => {
+    expect(pickLatestActivity(null, [])).toBeNull()
+    expect(pickLatestActivity('', [])).toBeNull()
+    expect(pickLatestActivity('   ', [])).toBeNull()
+    expect(pickLatestActivity(null, null)).toBeNull()
+  })
+})

--- a/apps/web/src/features/graph/computeOrbitalPositions.ts
+++ b/apps/web/src/features/graph/computeOrbitalPositions.ts
@@ -13,16 +13,19 @@ function fnv1a(str: string): number {
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const SKILL_RADIUS = { min: 100, max: 190 }
-const RESOURCE_RADIUS = { min: 180, max: 220 }
+// Inner skill ring sits clear of the 220×120 card's diagonal half-extent
+// (~125px) plus a 25px gap. Outer resource ring sits beyond the inner ring
+// with enough angular variance that the two rings don't visually merge.
+const SKILL_RADIUS = { min: 150, max: 220 }
+const RESOURCE_RADIUS = { min: 230, max: 285 }
 const JITTER_RANGE = 12
 
-// Half-sizes of the BooNode card (220×120). Used to centre the orbital
-// children fan around each parent Boo's centre rather than its top-left
-// corner. Stays in sync with the BOO_CARD_WIDTH / BOO_CARD_HEIGHT
-// constants in `nodes/BooNode.tsx`.
-const BOO_HALF_W = 110
-const BOO_HALF_H = 60
+// Offset from each Boo's React Flow `node.position` (top-left of the
+// envelope) to its visual center. The Boo renders centered inside its
+// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the center is
+// at half the envelope size in each dimension.
+const BOO_HALF_W = 170
+const BOO_HALF_H = 170
 
 // Node dimensions for centering orbital children
 const SKILL_SIZE = 38 // CIRCLE const in SkillNode.tsx

--- a/apps/web/src/features/graph/edges/DependencyEdge.tsx
+++ b/apps/web/src/features/graph/edges/DependencyEdge.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { BaseEdge, getSmoothStepPath } from '@xyflow/react'
+import { BaseEdge, getBezierPath, getSmoothStepPath } from '@xyflow/react'
 import type { EdgeProps } from '@xyflow/react'
 import { useGraphStore } from '../store'
 
@@ -44,17 +44,37 @@ export const DependencyEdge = memo(function DependencyEdge({
   selected,
   data,
 }: EdgeProps) {
-  const [edgePath] = getSmoothStepPath({
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-    sourcePosition,
-    targetPosition,
-    borderRadius: 10,
-  })
-
   const isPrimary = (data as DependencyEdgeData | undefined)?.isPrimary !== false
+
+  // Primary edges (BFS spanning tree) use orthogonal smooth-step — the
+  // standard org-chart shape. Secondary collaboration edges use bezier
+  // curves so they (a) are visually distinct from the structural backbone,
+  // and (b) naturally fan AWAY from the leader-to-children row instead of
+  // stacking on top of each other (which produced the "messy bundle" effect
+  // when many secondary edges were revealed by hovering a teammate Boo in
+  // a wide row of siblings).
+  const [edgePath] = isPrimary
+    ? getSmoothStepPath({
+        sourceX,
+        sourceY,
+        targetX,
+        targetY,
+        sourcePosition,
+        targetPosition,
+        borderRadius: 10,
+      })
+    : getBezierPath({
+        sourceX,
+        sourceY,
+        targetX,
+        targetY,
+        sourcePosition,
+        targetPosition,
+        // Bumped curvature pulls secondary edges further off the primary
+        // hierarchy line, making them read as "lateral" rather than
+        // "structural".
+        curvature: 0.45,
+      })
 
   // Hover-aware visibility:
   //   - Primary: full opacity at rest; dimmed when ANOTHER node is hovered.
@@ -72,8 +92,10 @@ export const DependencyEdge = memo(function DependencyEdge({
     // cluster doesn't include this edge.
     opacity = hoveredNodeId === null || isConnectedToHovered ? 1 : 0.18
   } else {
-    // Secondary collaboration edge: hidden at rest, fade in on hover.
-    opacity = isConnectedToHovered ? 0.55 : 0
+    // Secondary collaboration edge: hidden at rest, fade in subtly on hover.
+    // Lower opacity (0.4 vs primary's 1.0) makes the hierarchy stay readable
+    // even with many secondary edges revealed simultaneously.
+    opacity = isConnectedToHovered ? 0.4 : 0
   }
 
   return (

--- a/apps/web/src/features/graph/edges/DependencyEdge.tsx
+++ b/apps/web/src/features/graph/edges/DependencyEdge.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react'
-import { BaseEdge, getBezierPath, getSmoothStepPath } from '@xyflow/react'
+import { BaseEdge, getBezierPath, getSmoothStepPath, useStore } from '@xyflow/react'
 import type { EdgeProps } from '@xyflow/react'
 import { useGraphStore } from '../store'
 
@@ -8,9 +8,7 @@ import { useGraphStore } from '../store'
 // Smooth-step (orthogonal) path with a small accent-red arrowhead at the
 // target end. The arrowhead conveys direction (leader → teammate routing)
 // at a glance, which is what gives the canvas its flow-chart feel under
-// the layered ELK layout. The marching-ants animation that used to live
-// here is dropped — the arrowhead is a clearer direction cue than animated
-// dashes, and removing the constant motion makes the canvas calmer.
+// the layered ELK layout.
 //
 // `markerEnd` references `url(#dependency-arrow)` defined once in
 // `<EdgeMarkers />` (mounted near the top of `GhostGraph`).
@@ -19,17 +17,96 @@ import { useGraphStore } from '../store'
 //   - Primary edges (BFS spanning tree from team leader) are always
 //     visible; they form the readable hierarchy backbone.
 //   - Secondary edges (every other routing rule) are HIDDEN at rest and
-//     fade in only when their source or target Boo is hovered. This keeps
-//     the canvas as readable as a real org chart while still letting the
-//     user discover lateral collaboration paths on demand.
+//     fade in only when their source or target Boo is hovered.
 //   - The `isPrimary` flag is set in `useGraphData.buildGraphElements`
 //     via `computeSpanningTree`. ELK only sees primary edges (filtered
 //     in `GhostGraph.tsx`) so the layout itself isn't tangled by
 //     secondary routes.
+//
+// **Trunk-and-branches rendering** for parents with multiple primary
+// children. Without it, each parent → child edge draws its OWN vertical
+// from the parent + horizontal at the elbow Y, and N stacked smooth-step
+// paths produce a "rope" of 2–3 visible parallel lines — sub-pixel
+// rendering differences make perfectly-overlapping strokes appear doubled.
+// The fix:
+//   - One sibling per parent is marked `isTrunkLeader: true` in
+//     `useGraphData.ts` and renders the SHARED trunk anatomy as TWO
+//     continuous subpaths (left half and right half), so the source
+//     vertical, the trunk-to-corner arcs, and the corner branches form
+//     uninterrupted strokes that visually flow into each other. Two
+//     subpaths (instead of one big path) are needed so each corner
+//     branch can have its own arrowhead via `marker-end` on its own
+//     `<path>` element.
+//   - Trunk followers (`isTrunkFollower: true`) render ONLY their branch.
+//     Middle followers draw a sharp T-junction; corner followers render
+//     NOTHING because the leader's continuous subpath already drew their
+//     branch.
+// Corner roundedness matches the user's spec: leftmost/rightmost children
+// have rounded arcs where the trunk turns 90° downward into the branch;
+// middle children have sharp T-junctions where the trunk continues past
+// them. The corner radius shrinks if the trunk is narrower than 2×r so
+// the two end-arcs never overlap.
 
 interface DependencyEdgeData extends Record<string, unknown> {
   isPrimary?: boolean
+  isTrunkLeader?: boolean
+  isTrunkFollower?: boolean
+  siblingTargetIds?: string[]
 }
+
+const STROKE = 'rgba(233,69,96,0.65)'
+const STROKE_SELECTED = '#E94560'
+const STROKE_WIDTH = 1.5
+const STROKE_WIDTH_SELECTED = 2.5
+const TRUNK_CORNER_RADIUS = 12
+
+// Build the LEFT half of the trunk leader's path: source vertical → left
+// horizontal → left arc → leftmost branch. One continuous subpath so the
+// stroke flows smoothly through every join. Marker lands at the leftmost
+// target (the path's last point).
+function buildLeftHalfPath(
+  sourceX: number,
+  sourceY: number,
+  elbowY: number,
+  leftmost: { x: number; y: number },
+  cornerR: number,
+): string {
+  return (
+    `M ${sourceX} ${sourceY}` +
+    ` L ${sourceX} ${elbowY}` +
+    ` L ${leftmost.x + cornerR} ${elbowY}` +
+    // Quarter-arc going DOWN-LEFT (counter-clockwise, sweep flag 0)
+    ` A ${cornerR} ${cornerR} 0 0 0 ${leftmost.x} ${elbowY + cornerR}` +
+    ` L ${leftmost.x} ${leftmost.y}`
+  )
+}
+
+// Build the RIGHT half of the trunk leader's path: trunk midpoint → right
+// horizontal → right arc → rightmost branch. Marker lands at the rightmost
+// target.
+function buildRightHalfPath(
+  sourceX: number,
+  elbowY: number,
+  rightmost: { x: number; y: number },
+  cornerR: number,
+): string {
+  return (
+    `M ${sourceX} ${elbowY}` +
+    ` L ${rightmost.x - cornerR} ${elbowY}` +
+    // Quarter-arc going DOWN-RIGHT (clockwise, sweep flag 1)
+    ` A ${cornerR} ${cornerR} 0 0 1 ${rightmost.x} ${elbowY + cornerR}` +
+    ` L ${rightmost.x} ${rightmost.y}`
+  )
+}
+
+// Branch path for middle children (sharp T-junction).
+function buildMiddleBranchPath(targetX: number, targetY: number, elbowY: number): string {
+  return `M ${targetX} ${elbowY} L ${targetX} ${targetY}`
+}
+
+// Stable empty array reference so the useStore selector returns the same
+// reference when there are no sibling targets — avoids re-render churn.
+const EMPTY_SIBLINGS: Array<{ id: string; x: number; y: number }> = []
 
 export const DependencyEdge = memo(function DependencyEdge({
   id,
@@ -44,78 +121,147 @@ export const DependencyEdge = memo(function DependencyEdge({
   selected,
   data,
 }: EdgeProps) {
-  const isPrimary = (data as DependencyEdgeData | undefined)?.isPrimary !== false
+  const edgeData = data as DependencyEdgeData | undefined
+  const isPrimary = edgeData?.isPrimary !== false
+  const isTrunkLeader = isPrimary && edgeData?.isTrunkLeader === true
+  const isTrunkFollower = isPrimary && edgeData?.isTrunkFollower === true
+  const isTrunkParticipant = isTrunkLeader || isTrunkFollower
 
-  // Primary edges (BFS spanning tree) use orthogonal smooth-step — the
-  // standard org-chart shape. Secondary collaboration edges use bezier
-  // curves so they (a) are visually distinct from the structural backbone,
-  // and (b) naturally fan AWAY from the leader-to-children row instead of
-  // stacking on top of each other (which produced the "messy bundle" effect
-  // when many secondary edges were revealed by hovering a teammate Boo in
-  // a wide row of siblings).
-  const [edgePath] = isPrimary
-    ? getSmoothStepPath({
-        sourceX,
-        sourceY,
-        targetX,
-        targetY,
-        sourcePosition,
-        targetPosition,
-        borderRadius: 10,
+  // Pull sibling target positions from React Flow's internal node lookup.
+  // We need them to compute the trunk path AND to know whether THIS edge's
+  // target is the leftmost / rightmost sibling (corner — drawn by trunk
+  // leader's continuous subpath) or a middle one (sharp T-junction drawn
+  // separately). We carry the target ID alongside x/y so that "is this a
+  // corner?" can be resolved by ID comparison rather than X-coordinate
+  // equality. Necessary because React Flow's `targetX` measured handle
+  // position includes the few-pixel offset from `useFloatingMotion`'s
+  // transient transform on the floatRef wrapper, while the position we
+  // read from `nodeLookup` is the static layout position — they differ
+  // by 1–5px. Comparing by ID sidesteps that mismatch entirely.
+  const siblingTargetIds = edgeData?.siblingTargetIds
+  const siblings = useStore<Array<{ id: string; x: number; y: number }>>((rfState) => {
+    if (!isTrunkParticipant || !siblingTargetIds) return EMPTY_SIBLINGS
+    const out: Array<{ id: string; x: number; y: number }> = []
+    for (const tid of siblingTargetIds) {
+      const internal = rfState.nodeLookup.get(tid)
+      if (!internal) continue
+      const w = internal.measured?.width ?? 340
+      const h = internal.measured?.height ?? 340
+      out.push({
+        id: tid,
+        x: internal.position.x + w / 2,
+        y: internal.position.y + h / 2,
       })
-    : getBezierPath({
-        sourceX,
-        sourceY,
-        targetX,
-        targetY,
-        sourcePosition,
-        targetPosition,
-        // Bumped curvature pulls secondary edges further off the primary
-        // hierarchy line, making them read as "lateral" rather than
-        // "structural".
-        curvature: 0.45,
-      })
+    }
+    return out
+  })
 
-  // Hover-aware visibility:
-  //   - Primary: full opacity at rest; dimmed when ANOTHER node is hovered.
-  //   - Secondary: invisible at rest; only fades in when the hovered node is
-  //     this edge's source or target.
-  // We read `hoveredNodeId` directly so each edge can compute its own
-  // visibility without bloating `highlightedEdgeIds` with hide/reveal logic.
   const hoveredNodeId = useGraphStore((s) => s.hoveredNodeId)
   const isConnectedToHovered =
     hoveredNodeId !== null && (hoveredNodeId === source || hoveredNodeId === target)
 
   let opacity: number
   if (isPrimary) {
-    // Primary backbone: full opacity at rest, slight dim when the hover
-    // cluster doesn't include this edge.
     opacity = hoveredNodeId === null || isConnectedToHovered ? 1 : 0.18
   } else {
-    // Secondary collaboration edge: hidden at rest, fade in subtly on hover.
-    // Lower opacity (0.4 vs primary's 1.0) makes the hierarchy stay readable
-    // even with many secondary edges revealed simultaneously.
     opacity = isConnectedToHovered ? 0.4 : 0
   }
 
-  return (
-    <BaseEdge
-      id={id}
-      path={edgePath}
-      markerEnd={opacity > 0 ? 'url(#dependency-arrow)' : undefined}
-      style={{
-        stroke: selected ? '#E94560' : 'rgba(233,69,96,0.65)',
-        strokeWidth: selected ? 2.5 : 1.5,
-        // Secondary edges use a thin dash so they're visually distinct from
-        // primary ones when revealed on hover (a "this is a collaboration
-        // path, not a primary report" cue).
-        strokeDasharray: isPrimary ? undefined : '4 4',
-        transition: 'stroke 0.15s, stroke-width 0.15s, opacity 0.2s ease',
-        opacity,
-        // Make secondary edges click-through when hidden so they don't
-        // intercept events meant for nodes behind them.
-        pointerEvents: opacity > 0 ? 'auto' : 'none',
-      }}
-    />
-  )
+  const stroke = selected ? STROKE_SELECTED : STROKE
+  const strokeWidth = selected ? STROKE_WIDTH_SELECTED : STROKE_WIDTH
+  const baseStyle = {
+    stroke,
+    strokeWidth,
+    fill: 'none',
+    transition: 'stroke 0.15s, stroke-width 0.15s, opacity 0.2s ease',
+    opacity,
+    pointerEvents: opacity > 0 ? ('auto' as const) : ('none' as const),
+  }
+  const markerEnd = opacity > 0 ? 'url(#dependency-arrow)' : undefined
+
+  // ── Branch: secondary collaboration edge — bezier curve so it visually
+  // distinguishes from the primary structural backbone.
+  if (!isPrimary) {
+    const [bezier] = getBezierPath({
+      sourceX,
+      sourceY,
+      targetX,
+      targetY,
+      sourcePosition,
+      targetPosition,
+      curvature: 0.45,
+    })
+    return (
+      <BaseEdge
+        id={id}
+        path={bezier}
+        markerEnd={markerEnd}
+        style={{ ...baseStyle, strokeDasharray: '4 4' }}
+      />
+    )
+  }
+
+  // ── Branch: trunk leader for a parent with 2+ siblings.
+  if (isTrunkLeader && siblings.length >= 2) {
+    const sorted = [...siblings].sort((a, b) => a.x - b.x)
+    const leftmost = sorted[0]!
+    const rightmost = sorted[sorted.length - 1]!
+    const elbowY = (sourceY + sorted[0]!.y) / 2
+    const halfTrunkWidth = (rightmost.x - leftmost.x) / 2
+    const cornerR = Math.min(TRUNK_CORNER_RADIUS, halfTrunkWidth)
+
+    const leftPath = buildLeftHalfPath(sourceX, sourceY, elbowY, leftmost, cornerR)
+    const rightPath = buildRightHalfPath(sourceX, elbowY, rightmost, cornerR)
+
+    // If THIS leader edge's own target is a middle child (not a corner),
+    // draw its branch too — the trunk subpaths only cover the corner
+    // branches. Compare by target ID to avoid the floating-motion X
+    // discrepancy between EdgeProps' targetX and the static layout x.
+    const leaderIsCorner = target === leftmost.id || target === rightmost.id
+    const leaderMiddlePath = leaderIsCorner ? null : buildMiddleBranchPath(targetX, targetY, elbowY)
+
+    return (
+      <>
+        <BaseEdge id={`${id}-left`} path={leftPath} markerEnd={markerEnd} style={baseStyle} />
+        <BaseEdge id={`${id}-right`} path={rightPath} markerEnd={markerEnd} style={baseStyle} />
+        {leaderMiddlePath ? (
+          <BaseEdge
+            id={`${id}-mid`}
+            path={leaderMiddlePath}
+            markerEnd={markerEnd}
+            style={baseStyle}
+          />
+        ) : null}
+      </>
+    )
+  }
+
+  // ── Branch: trunk follower — middle child's sharp T-junction descent.
+  if (isTrunkFollower && siblings.length >= 2) {
+    const sorted = [...siblings].sort((a, b) => a.x - b.x)
+    const leftmostId = sorted[0]!.id
+    const rightmostId = sorted[sorted.length - 1]!.id
+    const isCornerBranch = target === leftmostId || target === rightmostId
+    if (isCornerBranch) {
+      // Corner branch — already drawn by the trunk leader's continuous
+      // subpath. Render nothing to avoid the duplicate-stroke "rope".
+      return null
+    }
+    const elbowY = (sourceY + sorted[0]!.y) / 2
+    const middlePath = buildMiddleBranchPath(targetX, targetY, elbowY)
+    return <BaseEdge id={id} path={middlePath} markerEnd={markerEnd} style={baseStyle} />
+  }
+
+  // ── Branch: single-child primary edge — standard smooth-step (no
+  // trunk-and-branches needed because there's nothing to fork).
+  const [smooth] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: TRUNK_CORNER_RADIUS,
+  })
+  return <BaseEdge id={id} path={smooth} markerEnd={markerEnd} style={baseStyle} />
 })

--- a/apps/web/src/features/graph/graphPhysics.ts
+++ b/apps/web/src/features/graph/graphPhysics.ts
@@ -37,12 +37,13 @@ const BOO_REPULSION_CONSTANT = 500
 const BOO_DAMPING = 0.8
 const BOO_MAX_VELOCITY = 3
 
-// BooNode is now a 220×120 card (see `nodes/BooNode.tsx`'s
-// BOO_CARD_WIDTH / BOO_CARD_HEIGHT exports). Half-sizes used to convert
-// React Flow's top-left position into a centre point for spring math
-// and Boo-Boo collision detection.
-const BOO_HALF_W = 110
-const BOO_HALF_H = 60
+// Offset from each Boo's React Flow `node.position` (top-left of the
+// envelope) to its visual center. The Boo renders centered inside its
+// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the center is
+// at half the envelope size — which is what spring math + Boo-Boo
+// collision detection treat as the Boo "anchor" point.
+const BOO_HALF_W = 170
+const BOO_HALF_H = 170
 
 // Node half-sizes for center computation
 const SKILL_HALF = 19 // 38 / 2

--- a/apps/web/src/features/graph/nodes/BooLiveActivity.tsx
+++ b/apps/web/src/features/graph/nodes/BooLiveActivity.tsx
@@ -1,0 +1,95 @@
+import { memo, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import { useFleetStore } from '@/stores/fleet'
+import { useChatStore } from '@/stores/chat'
+import { pickLatestActivity } from './pickLatestActivity'
+
+// ─── BooLiveActivity ────────────────────────────────────────────────────────
+//
+// Renders the most recent agent activity in a Boo card's middle band when
+// the agent is running. Uses single-value Zustand selectors so updates to
+// other agents' streams don't re-render this Boo (repo precedent:
+// `chatComponents.tsx:472`'s `lastTokenUsage.get(runId)` pattern).
+
+export const BooLiveActivity = memo(function BooLiveActivity({ agentId }: { agentId: string }) {
+  const sessionKey = useFleetStore(
+    (s) => s.agents.find((a) => a.id === agentId)?.sessionKey ?? null,
+  )
+  const streamingText = useChatStore((s) =>
+    sessionKey ? (s.streamingText.get(sessionKey) ?? null) : null,
+  )
+  const entries = useChatStore((s) => (sessionKey ? (s.transcripts.get(sessionKey) ?? null) : null))
+
+  const activity = useMemo(
+    () => pickLatestActivity(streamingText, entries),
+    [streamingText, entries],
+  )
+
+  if (!sessionKey) return null
+  if (!activity) return <InlineTyping />
+
+  const isStreaming = activity.kind === 'streaming'
+  return (
+    <div
+      style={{
+        fontFamily: 'var(--font-mono, "Geist Mono", ui-monospace, monospace)',
+        fontSize: 11,
+        lineHeight: 1.35,
+        color: 'rgba(232,232,232,0.6)',
+        display: '-webkit-box',
+        WebkitLineClamp: 2,
+        WebkitBoxOrient: 'vertical',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'normal',
+        wordBreak: 'break-word',
+        textAlign: 'left',
+        width: '100%',
+      }}
+    >
+      {isStreaming && (
+        <motion.span
+          aria-hidden
+          animate={{ opacity: [0.3, 1, 0.3] }}
+          transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+          style={{
+            display: 'inline-block',
+            width: 4,
+            height: 4,
+            borderRadius: '50%',
+            background: '#34D399',
+            marginRight: 6,
+            verticalAlign: 'middle',
+          }}
+        />
+      )}
+      {activity.text}
+    </div>
+  )
+})
+
+function InlineTyping() {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, opacity: 0.55 }}>
+      {[0, 1, 2].map((i) => (
+        <motion.span
+          key={i}
+          style={{
+            width: 4,
+            height: 4,
+            borderRadius: '50%',
+            background: '#34D399',
+            display: 'inline-block',
+          }}
+          animate={{ opacity: [0.3, 1, 0.3] }}
+          transition={{
+            duration: 1.2,
+            repeat: Infinity,
+            delay: i * 0.15,
+            ease: 'easeInOut',
+          }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useRef, type MutableRefObject } from 'react'
 import { Handle, Position, useConnection } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { motion } from 'framer-motion'
@@ -8,36 +8,73 @@ import { useGraphStore } from '../store'
 import { useFloatingMotion } from '../useFloatingMotion'
 import { useApprovalsStore } from '@/stores/approvals'
 import { useFleetStore } from '@/stores/fleet'
+import { BooLiveActivity } from './BooLiveActivity'
+import { createFlipState, useFlipMorph, type FlipState } from './useFlipMorph'
 
-// ─── BooNode — card-shaped agent surface ─────────────────────────────────────
+// ─── BooNode — dual-shape: idle = circle, active = card ──────────────────────
 //
-// Replaces the previous circle-with-text layout. The card is 220×120 and is
-// composed of three horizontal sections separated by subtle dividers:
+// Two visual modes share one component:
 //
-//   ┌────────────────────────────────────────────┐
-//   │ [avatar 36] Name                ● status   │  HEADER   (44px)
-//   ├────────────────────────────────────────────┤
-//   │                                            │
-//   │      <live preview placeholder>            │  MIDDLE   (52px)
-//   │                                            │
-//   ├────────────────────────────────────────────┤
-//   │ [team]  Dev Team           seen 2m ago     │  FOOTER   (24px)
-//   └────────────────────────────────────────────┘
+//   Idle   (status !== 'running')
+//          ┌────┐
+//          │ ◯  │   ← degree-aware circle (60–78px), avatar fills the disc
+//          └────┘
+//             Name           ← absolute below
+//             ● status       ← absolute below name
+//             seen 2m ago    ← absolute below status (only when not running)
 //
-// The MIDDLE band is reserved real estate for the future "live preview"
-// feature (e.g. a tiny browser thumbnail, terminal tail, or call timeline
-// streamed from the agent). For now it shows a subtle status hint.
+//   Active (status === 'running')
+//          ┌──────────────────────────────────┐
+//          │ [avatar] Name        ● running   │  HEADER  (44px)
+//          ├──────────────────────────────────┤
+//          │  [live activity feed — 2 lines]  │  MIDDLE  (52px)
+//          ├──────────────────────────────────┤
+//          │                                  │  FOOTER  (24px, reserved)
+//          └──────────────────────────────────┘
 //
-// Card-shaped nodes pair well with the layered DOWN ELK layout — flat
-// rectangles tile cleanly into rows, edges enter the top and exit the
-// bottom in predictable lanes, no orbital re-flow needed.
+// The wrapper's width / height / border-radius use a CSS transition for the
+// size-and-shape morph (~280ms cubic-bezier). Inside, the avatar / name /
+// status sub-elements use a manual FLIP technique (see `useFlipMorph.ts`)
+// to slide between their card-mode and circle-mode positions rather than
+// snap. Card-only chrome (header dividers, live activity feed) and
+// circle-only chrome (last-seen) conditionally render.
+//
+// **Why no FM `layout` / `layoutId`** (load-bearing): `ContentArea` wraps the
+// active view in `<AnimatePresence mode="wait">`. Framer Motion's layout
+// system tracks elements globally, so a `layoutId` set on a child of one
+// AnimatePresence panel can match a `layoutId` on a child of the next panel.
+// `BooNode` is mounted in BOTH `GhostGraphPanel` AND `MiniGraph`
+// (via the shared `nodeTypes`), so the same agent's `boo-${agentId}-…`
+// `layoutId`s exist in two render trees during the cross-fade — colliding
+// across the AnimatePresence boundary, jamming `mode="wait"`'s exit cycle,
+// and leaving the previous view (Ghost Graph) on screen so chat / agent
+// detail / group chat panels never mount. CSS transitions + manual FLIP are
+// scoped per element / per BooNode instance and don't interact with parent
+// route transitions, so they're the safe morph mechanism here.
+//
+// The card's middle band renders <BooLiveActivity> — the latest assistant
+// message, in-flight streaming text, or formatted tool call. The footer is
+// intentionally empty (team identity is conveyed by `TeamHaloLayer` and the
+// sidebar). Team badge has been removed from the BooNode entirely.
 
-// ─── Card dimensions (kept in sync with computeElkLayout) ─────────────────────
+// ─── Card dimensions (kept in sync with computeElkLayout) ────────────────────
 
 export const BOO_CARD_WIDTH = 220
 export const BOO_CARD_HEIGHT = 120
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+// ─── Node footprint (matches ELK envelope in useGraphLayout.ts) ──────────────
+// The Boo renders centered inside this footprint so its visual center aligns
+// with the React Flow node's geometric center — which is what ELK plans for
+// when laying out edges and sibling spacing. Without this, the rendered shape
+// (75–78px circle or 220×120 card) sits at the top-left of the envelope and
+// edges visually converge offset from the Boo.
+//
+// Sized so the card's diagonal half-extent (~125px) plus the inner skill ring
+// (150–220px) fit clear inside, with sibling Boos staying spaced when both
+// expand orbital children.
+const BOO_FOOTPRINT = 340
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function formatLastSeen(lastSeenAt: number | null): string | null {
   if (!lastSeenAt) return null
@@ -48,7 +85,7 @@ function formatLastSeen(lastSeenAt: number | null): string | null {
   return `${Math.floor(diff / 86_400_000)}d ago`
 }
 
-// ─── Status → glow / dot / label ──────────────────────────────────────────────
+// ─── Status → glow / dot / label ─────────────────────────────────────────────
 
 type GlowConfig = { color: string; pulse: boolean }
 
@@ -73,7 +110,7 @@ const STATUS_LABEL: Record<string, string> = {
   sleeping: 'sleeping',
 }
 
-// ─── Handle styles ────────────────────────────────────────────────────────────
+// ─── Handle styles ───────────────────────────────────────────────────────────
 
 const handleBase: React.CSSProperties = {
   background: 'transparent',
@@ -107,15 +144,33 @@ const centerHandleStyle: React.CSSProperties = {
   background: 'transparent',
 }
 
-// ─── BooNode ──────────────────────────────────────────────────────────────────
+// CSS transition for the wrapper size + border-radius morph.
+const SHAPE_TRANSITION =
+  'width 0.28s cubic-bezier(0.4, 0, 0.2, 1), ' +
+  'height 0.28s cubic-bezier(0.4, 0, 0.2, 1), ' +
+  'border-radius 0.28s cubic-bezier(0.4, 0, 0.2, 1), ' +
+  'background 0.2s ease, ' +
+  'border-color 0.15s ease, ' +
+  'opacity 0.2s ease'
+
+// ─── BooNode ─────────────────────────────────────────────────────────────────
 
 export const BooNode = memo(function BooNode({
   data,
   selected,
   dragging,
 }: NodeProps<Node<BooNodeData, 'boo'>>) {
-  const { agentId, name, status, teamId, teamName, teamColor, teamEmoji } = data
+  const { agentId, name, status } = data
   const floatRef = useFloatingMotion(agentId, 'boo', dragging)
+  const showCard = status === 'running'
+
+  // FLIP state for the avatar / name / status sub-elements. Owned here at
+  // the BooNode level so the captured rects persist across the
+  // CardContent ↔ CircleContent unmount/remount on each shape morph.
+  const avatarFlip = useRef<FlipState>(createFlipState())
+  const nameFlip = useRef<FlipState>(createFlipState())
+  const statusFlip = useRef<FlipState>(createFlipState())
+
   const glow = STATUS_GLOW[status] ?? null
   const connection = useConnection()
   const isConnecting = connection.inProgress
@@ -127,14 +182,20 @@ export const BooNode = memo(function BooNode({
   const lastSeenAt = useFleetStore(
     (s) => s.agents.find((a) => a.id === agentId)?.lastSeenAt ?? null,
   )
-  const lastSeenLabel = status !== 'running' ? formatLastSeen(lastSeenAt) : null
+  const lastSeenLabel = !showCard ? formatLastSeen(lastSeenAt) : null
 
   // Hover cascade — dim when another node is hovered
   const isHighlighted = useGraphStore(
     (s) => s.hoveredNodeId === null || (s.highlightedNodeIds?.has(`boo-${agentId}`) ?? false),
   )
 
-  // Box-shadow animation driven by status (glow-on-card-edge).
+  // Degree-aware circle sizing (used only in idle shape)
+  const edgeCount = data.edgeCount ?? 0
+  const booW = Math.min(60 + edgeCount * 3, 78)
+  const booH = Math.round(booW * 0.92)
+
+  // Box-shadow animation driven by status (glow at the wrapper edge, works
+  // for both circular and rounded-rect shapes via border-radius inheritance).
   const boxShadow = glow
     ? glow.pulse
       ? [
@@ -143,12 +204,27 @@ export const BooNode = memo(function BooNode({
           `0 0 0 0 ${glow.color}, 0 4px 12px rgba(0,0,0,0.4)`,
         ]
       : `0 0 0 1.5px ${glow.color}, 0 4px 12px rgba(0,0,0,0.4)`
-    : '0 4px 12px rgba(0,0,0,0.4)'
+    : showCard
+      ? '0 4px 12px rgba(0,0,0,0.4)'
+      : '0 0 0 0 rgba(0,0,0,0)'
 
   const cardStatusColor = STATUS_DOT[status] ?? STATUS_DOT.idle
 
   return (
-    <div ref={floatRef}>
+    <div
+      ref={floatRef}
+      style={{
+        width: BOO_FOOTPRINT,
+        height: BOO_FOOTPRINT,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        // The empty area around the morph wrapper shouldn't intercept clicks
+        // meant for siblings or background. Only the rendered Boo shape (the
+        // inner motion.div) re-enables pointer events.
+        pointerEvents: 'none',
+      }}
+    >
       <motion.div
         className="group"
         animate={{ boxShadow }}
@@ -156,21 +232,29 @@ export const BooNode = memo(function BooNode({
           glow?.pulse ? { duration: 2.2, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.4 }
         }
         style={{
-          width: BOO_CARD_WIDTH,
-          height: BOO_CARD_HEIGHT,
+          width: showCard ? BOO_CARD_WIDTH : booW,
+          height: showCard ? BOO_CARD_HEIGHT : booH,
           position: 'relative',
           cursor: 'pointer',
-          borderRadius: 12,
-          background: '#111827',
-          border: selected ? '2px solid rgba(233,69,96,0.7)' : '1px solid rgba(255,255,255,0.08)',
+          pointerEvents: 'auto',
+          borderRadius: showCard ? 12 : '50%',
+          background: showCard ? '#111827' : 'transparent',
+          border: showCard
+            ? selected
+              ? '2px solid rgba(233,69,96,0.7)'
+              : '1px solid rgba(255,255,255,0.08)'
+            : 'none',
           opacity: isHighlighted ? 1 : 0.22,
-          transition: 'opacity 0.2s ease, border-color 0.15s ease',
-          overflow: 'hidden', // keep dividers crisp at the rounded corners
-          display: 'flex',
-          flexDirection: 'column',
+          transition: SHAPE_TRANSITION,
+          // 'visible' (not 'hidden') so children rendering outside the
+          // immediate bounding box (e.g. circle-shape's name + status that sit
+          // BELOW the avatar) aren't clipped at the rounded corner.
+          overflow: 'visible',
+          display: showCard ? 'flex' : 'block',
+          flexDirection: showCard ? 'column' : undefined,
         }}
       >
-        {/* ── Approval pulse (around the whole card) ──────────────────────── */}
+        {/* ── Approval pulse — adapts shape via borderRadius ──────────────── */}
         {hasPendingApproval && (
           <motion.div
             animate={{
@@ -185,7 +269,7 @@ export const BooNode = memo(function BooNode({
             style={{
               position: 'absolute',
               inset: -2,
-              borderRadius: 14,
+              borderRadius: showCard ? 14 : '50%',
               border: '2px solid #FBBF24',
               pointerEvents: 'none',
               zIndex: 1,
@@ -193,161 +277,49 @@ export const BooNode = memo(function BooNode({
           />
         )}
 
-        {/* ── HEADER: avatar + name + status dot ─────────────────────────── */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 10,
-            padding: '10px 12px',
-            borderBottom: '1px solid rgba(255,255,255,0.06)',
-            flexShrink: 0,
-          }}
-        >
-          <div style={{ flexShrink: 0, width: 36, height: 36, position: 'relative' }}>
-            <AgentBooAvatar agentId={agentId} size={36} />
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div
-              style={{
-                fontSize: 13,
-                fontWeight: 600,
-                color: selected ? '#E94560' : '#E8E8E8',
-                fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                letterSpacing: '0.01em',
-                lineHeight: 1.2,
-              }}
-              title={name}
-            >
-              {name}
-            </div>
-            <div
-              style={{
-                fontSize: 10,
-                color: 'rgba(232,232,232,0.45)',
-                marginTop: 2,
-                letterSpacing: '0.04em',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {STATUS_LABEL[status] ?? 'idle'}
-              {lastSeenLabel ? ` · seen ${lastSeenLabel}` : ''}
-            </div>
-          </div>
-          {status === 'running' ? (
-            <motion.div
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: cardStatusColor,
-                flexShrink: 0,
-              }}
-              animate={{ opacity: [1, 0.25, 1] }}
-              transition={{ duration: 1.1, repeat: Infinity }}
-            />
-          ) : (
-            <div
-              style={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: cardStatusColor,
-                flexShrink: 0,
-              }}
-            />
-          )}
-        </div>
+        {/* ── Selection ring on circle (card uses border) ─────────────────── */}
+        {!showCard && selected && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: -3,
+              borderRadius: '50%',
+              border: '2px solid rgba(233,69,96,0.7)',
+              pointerEvents: 'none',
+              zIndex: 1,
+            }}
+          />
+        )}
 
-        {/* ── MIDDLE: live-preview slot (placeholder) ────────────────────── */}
-        <div
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            padding: '6px 12px',
-            color: 'rgba(232,232,232,0.32)',
-            fontSize: 11,
-            fontStyle: 'italic',
-            letterSpacing: '0.02em',
-            textAlign: 'center',
-            position: 'relative',
-            // Subtle "ready for content" gradient wash so the empty band
-            // doesn't look like a bug. Fades to nothing when live preview
-            // content lands here in a future iteration.
-            background:
-              'radial-gradient(circle at center, rgba(52,211,153,0.04) 0%, transparent 60%)',
-          }}
-        >
-          {/* Future home of: browser screenshot, terminal tail, video frame,
-              call timeline, etc. For now: a calm hint at status. */}
-          {status === 'running' ? (
-            <span style={{ color: 'rgba(52,211,153,0.55)', fontStyle: 'normal' }}>working…</span>
-          ) : status === 'error' ? (
-            <span style={{ color: 'rgba(249,115,22,0.65)', fontStyle: 'normal' }}>
-              encountered an error
-            </span>
-          ) : (
-            <span>ready</span>
-          )}
-        </div>
+        {showCard ? (
+          <CardContent
+            agentId={agentId}
+            name={name}
+            selected={selected}
+            status={status}
+            cardStatusColor={cardStatusColor}
+            lastSeenLabel={lastSeenLabel}
+            avatarFlip={avatarFlip}
+            nameFlip={nameFlip}
+            statusFlip={statusFlip}
+          />
+        ) : (
+          <CircleContent
+            agentId={agentId}
+            name={name}
+            selected={selected}
+            status={status}
+            booW={booW}
+            booH={booH}
+            cardStatusColor={cardStatusColor}
+            lastSeenLabel={lastSeenLabel}
+            avatarFlip={avatarFlip}
+            nameFlip={nameFlip}
+            statusFlip={statusFlip}
+          />
+        )}
 
-        {/* ── FOOTER: team badge + last seen ─────────────────────────────── */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            gap: 6,
-            padding: '6px 12px',
-            borderTop: '1px solid rgba(255,255,255,0.06)',
-            fontSize: 10,
-            color: 'rgba(232,232,232,0.4)',
-            flexShrink: 0,
-          }}
-        >
-          {teamId ? (
-            <span
-              title={teamName ?? 'Team'}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 4,
-                padding: '2px 6px',
-                borderRadius: 8,
-                background: `${teamColor ?? '#34D399'}1A`,
-                border: `1px solid ${teamColor ?? 'rgba(255,255,255,0.15)'}`,
-                color: '#E8E8E8',
-                fontSize: 9,
-                fontWeight: 600,
-                letterSpacing: '0.03em',
-                whiteSpace: 'nowrap',
-                maxWidth: 110,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-              }}
-            >
-              {teamEmoji && <span style={{ fontSize: 10 }}>{teamEmoji}</span>}
-              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                {teamName ?? 'Team'}
-              </span>
-            </span>
-          ) : (
-            <span />
-          )}
-          {/* Right slot: future per-Boo metric (tokens, cost, calls). */}
-          <span style={{ whiteSpace: 'nowrap', letterSpacing: '0.04em' }}>
-            {/* Empty for now — placeholder so the footer is balanced. */}
-          </span>
-        </div>
-
-        {/* ── Interactive handles ─────────────────────────────────────────── */}
+        {/* ── Interactive handles (visible on hover / connect) ────────────── */}
         <Handle
           type="target"
           position={Position.Top}
@@ -375,6 +347,10 @@ export const BooNode = memo(function BooNode({
         />
 
         {/* ── Center handles — invisible, for edge path routing only ──────── */}
+        {/* See useGraphData.ts:330–336 for the handle-canonical caveat:
+            'center' is SOURCE-type, 'center-target' is TARGET-type — never
+            swap them when flipping edge source/target during the parent→child
+            edge rewrite. */}
         <Handle id="center" type="source" position={Position.Top} style={centerHandleStyle} />
         <Handle
           id="center-target"
@@ -386,3 +362,261 @@ export const BooNode = memo(function BooNode({
     </div>
   )
 })
+
+// ─── CardContent ─────────────────────────────────────────────────────────────
+
+interface ContentProps {
+  agentId: string
+  name: string
+  selected: boolean | undefined
+  status: BooNodeData['status']
+  cardStatusColor: string
+  lastSeenLabel: string | null
+  avatarFlip: MutableRefObject<FlipState>
+  nameFlip: MutableRefObject<FlipState>
+  statusFlip: MutableRefObject<FlipState>
+}
+
+function CardContent({
+  agentId,
+  name,
+  selected,
+  status,
+  cardStatusColor,
+  lastSeenLabel,
+  avatarFlip,
+  nameFlip,
+  statusFlip,
+}: ContentProps) {
+  const avatarRef = useFlipMorph<HTMLDivElement>(avatarFlip)
+  const nameRef = useFlipMorph<HTMLDivElement>(nameFlip)
+  const statusRef = useFlipMorph<HTMLDivElement>(statusFlip)
+
+  return (
+    <>
+      {/* HEADER */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '10px 12px',
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          flexShrink: 0,
+        }}
+      >
+        <div ref={avatarRef} style={{ flexShrink: 0, width: 36, height: 36, position: 'relative' }}>
+          <AgentBooAvatar agentId={agentId} size={36} />
+        </div>
+        <div ref={nameRef} style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              color: selected ? '#E94560' : '#E8E8E8',
+              fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              letterSpacing: '0.01em',
+              lineHeight: 1.2,
+            }}
+            title={name}
+          >
+            {name}
+          </div>
+          <div
+            style={{
+              fontSize: 10,
+              color: 'rgba(232,232,232,0.45)',
+              marginTop: 2,
+              letterSpacing: '0.04em',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {STATUS_LABEL[status] ?? 'idle'}
+            {lastSeenLabel ? ` · seen ${lastSeenLabel}` : ''}
+          </div>
+        </div>
+        <div ref={statusRef} style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+          {status === 'running' ? (
+            <motion.div
+              style={{ width: 8, height: 8, borderRadius: '50%', background: cardStatusColor }}
+              animate={{ opacity: [1, 0.25, 1] }}
+              transition={{ duration: 1.1, repeat: Infinity }}
+            />
+          ) : (
+            <div
+              style={{ width: 8, height: 8, borderRadius: '50%', background: cardStatusColor }}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* MIDDLE — live activity feed */}
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          padding: '6px 12px',
+          position: 'relative',
+          background:
+            'radial-gradient(circle at center, rgba(52,211,153,0.04) 0%, transparent 60%)',
+          overflow: 'hidden',
+        }}
+      >
+        <BooLiveActivity agentId={agentId} />
+      </div>
+
+      {/* FOOTER — reserved real estate (per-Boo metric slot, future) */}
+      <div
+        style={{
+          padding: '6px 12px',
+          borderTop: '1px solid rgba(255,255,255,0.06)',
+          fontSize: 10,
+          color: 'rgba(232,232,232,0.4)',
+          flexShrink: 0,
+          minHeight: 24,
+        }}
+      />
+    </>
+  )
+}
+
+// ─── CircleContent ───────────────────────────────────────────────────────────
+
+interface CircleProps extends ContentProps {
+  booW: number
+  booH: number
+}
+
+function CircleContent({
+  agentId,
+  name,
+  selected,
+  status,
+  booW,
+  booH,
+  cardStatusColor,
+  lastSeenLabel,
+  avatarFlip,
+  nameFlip,
+  statusFlip,
+}: CircleProps) {
+  // FLIP refs go on the INNER divs of each tracked element so the outer
+  // positioning wrapper's `transform: translateX(-50%)` doesn't fight the
+  // FLIP-applied transform.
+  const avatarRef = useFlipMorph<HTMLDivElement>(avatarFlip)
+  const nameRef = useFlipMorph<HTMLDivElement>(nameFlip)
+  const statusRef = useFlipMorph<HTMLDivElement>(statusFlip)
+
+  return (
+    <>
+      <div ref={avatarRef} style={{ width: booW, height: booH, position: 'relative' }}>
+        <AgentBooAvatar agentId={agentId} size={booW} />
+      </div>
+
+      {/* Name — outer wrapper handles centering via flex (no transform that
+          would conflict with FLIP); inner div is the FLIP target. */}
+      <div
+        style={{
+          position: 'absolute',
+          top: booH + 8,
+          left: 0,
+          right: 0,
+          display: 'flex',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          ref={nameRef}
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            color: selected ? '#E94560' : '#E8E8E8',
+            fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
+            whiteSpace: 'nowrap',
+            maxWidth: 96,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            letterSpacing: '0.01em',
+            textAlign: 'center',
+            pointerEvents: 'auto',
+          }}
+        >
+          {name}
+        </div>
+      </div>
+
+      {/* Status pill — same flex-center pattern as name. */}
+      <div
+        style={{
+          position: 'absolute',
+          top: booH + 26,
+          left: 0,
+          right: 0,
+          display: 'flex',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+        }}
+      >
+        <div
+          ref={statusRef}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            pointerEvents: 'auto',
+          }}
+        >
+          {status === 'running' ? (
+            <motion.div
+              style={{ width: 5, height: 5, borderRadius: '50%', background: cardStatusColor }}
+              animate={{ opacity: [1, 0.2, 1] }}
+              transition={{ duration: 1.1, repeat: Infinity }}
+            />
+          ) : (
+            <div
+              style={{ width: 5, height: 5, borderRadius: '50%', background: cardStatusColor }}
+            />
+          )}
+          <span style={{ fontSize: 10, color: 'rgba(232,232,232,0.38)', letterSpacing: '0.05em' }}>
+            {STATUS_LABEL[status] ?? 'idle'}
+          </span>
+        </div>
+      </div>
+
+      {/* Last-seen — not FLIP-tracked, position-bound to circle shape only.
+          Outer wrapper handles centering, no transform conflict to worry about. */}
+      {lastSeenLabel && (
+        <div
+          style={{
+            position: 'absolute',
+            top: booH + 40,
+            left: 0,
+            right: 0,
+            display: 'flex',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 9,
+              color: 'rgba(232,232,232,0.25)',
+              whiteSpace: 'nowrap',
+              letterSpacing: '0.03em',
+            }}
+          >
+            {lastSeenLabel}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -210,6 +210,15 @@ export const BooNode = memo(function BooNode({
 
   const cardStatusColor = STATUS_DOT[status] ?? STATUS_DOT.idle
 
+  // Hover detection for the cascade dimming effect. We can't rely on
+  // ReactFlow's `onNodeMouseEnter` here because the React Flow node element
+  // has `pointer-events: none` (set in `globals.css` for `.react-flow__node-boo`)
+  // — so the node element never receives mouseenter. Hover is captured on the
+  // morph wrapper directly instead.
+  const setHoveredNodeId = useGraphStore((s) => s.setHoveredNodeId)
+  const handleMouseEnter = () => setHoveredNodeId(`boo-${agentId}`)
+  const handleMouseLeave = () => setHoveredNodeId(null)
+
   return (
     <div
       ref={floatRef}
@@ -219,14 +228,18 @@ export const BooNode = memo(function BooNode({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        // The empty area around the morph wrapper shouldn't intercept clicks
-        // meant for siblings or background. Only the rendered Boo shape (the
-        // inner motion.div) re-enables pointer events.
+        // The empty area around the morph wrapper shouldn't intercept clicks,
+        // hover, or drag events. Only the rendered Boo shape (the inner
+        // motion.div) re-enables pointer events. The CSS rule on
+        // `.react-flow__node-boo` in `globals.css` ensures even the React
+        // Flow wrapper element doesn't catch events from the empty area.
         pointerEvents: 'none',
       }}
     >
       <motion.div
         className="group"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         animate={{ boxShadow }}
         transition={
           glow?.pulse ? { duration: 2.2, repeat: Infinity, ease: 'easeInOut' } : { duration: 0.4 }
@@ -350,8 +363,18 @@ export const BooNode = memo(function BooNode({
         {/* See useGraphData.ts:330–336 for the handle-canonical caveat:
             'center' is SOURCE-type, 'center-target' is TARGET-type — never
             swap them when flipping edge source/target during the parent→child
-            edge rewrite. */}
-        <Handle id="center" type="source" position={Position.Top} style={centerHandleStyle} />
+            edge rewrite.
+
+            Source uses `Position.Bottom`: in our layered DOWN org chart,
+            edges depart from the leader DOWNWARD to children below. With
+            `Position.Top` (the previous setup), React Flow's smooth-step
+            routed the edge UP from the source first, made an elbow ABOVE
+            the leader, then descended to the child — putting the
+            horizontal segment way above the leader Boo instead of between
+            leader and child where an org chart expects it. With Bottom +
+            Top the elbow lands at the midpoint between source and target,
+            the natural T-junction shape. */}
+        <Handle id="center" type="source" position={Position.Bottom} style={centerHandleStyle} />
         <Handle
           id="center-target"
           type="target"

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -252,11 +252,10 @@ export const BooNode = memo(function BooNode({
           pointerEvents: 'auto',
           borderRadius: showCard ? 12 : '50%',
           background: showCard ? '#111827' : 'transparent',
-          border: showCard
-            ? selected
-              ? '2px solid rgba(233,69,96,0.7)'
-              : '1px solid rgba(255,255,255,0.08)'
-            : 'none',
+          // Card always uses the same subtle outline regardless of selection
+          // state — the selection-thickening was visually inconsistent with
+          // the now-removed circle ring and didn't add information.
+          border: showCard ? '1px solid rgba(255,255,255,0.08)' : 'none',
           opacity: isHighlighted ? 1 : 0.22,
           transition: SHAPE_TRANSITION,
           // 'visible' (not 'hidden') so children rendering outside the
@@ -290,19 +289,9 @@ export const BooNode = memo(function BooNode({
           />
         )}
 
-        {/* ── Selection ring on circle (card uses border) ─────────────────── */}
-        {!showCard && selected && (
-          <div
-            style={{
-              position: 'absolute',
-              inset: -3,
-              borderRadius: '50%',
-              border: '2px solid rgba(233,69,96,0.7)',
-              pointerEvents: 'none',
-              zIndex: 1,
-            }}
-          />
-        )}
+        {/* Selection ring removed — the previous red ring around a clicked
+            Boo had no functional purpose; the agent-detail navigation
+            happens through the right-click context menu / sidebar. */}
 
         {showCard ? (
           <CardContent
@@ -563,10 +552,11 @@ function CircleContent({
             fontWeight: 600,
             color: selected ? '#E94560' : '#E8E8E8',
             fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
+            // No max-width / truncation: the name sits BELOW the avatar in
+            // circle mode and has the entire 340px envelope width to
+            // expand into. Long names extend symmetrically because the
+            // outer flex wrapper is centered.
             whiteSpace: 'nowrap',
-            maxWidth: 96,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
             letterSpacing: '0.01em',
             textAlign: 'center',
             pointerEvents: 'auto',

--- a/apps/web/src/features/graph/nodes/pickLatestActivity.ts
+++ b/apps/web/src/features/graph/nodes/pickLatestActivity.ts
@@ -1,0 +1,41 @@
+import type { TranscriptEntry } from '@clawboo/protocol'
+import { parseToolMarkdown } from '@clawboo/protocol'
+
+// ─── pickLatestActivity ──────────────────────────────────────────────────────
+//
+// Selects what to show in a Boo's live activity band when the agent is running.
+// Priority: in-flight streaming text > most recent assistant message > most
+// recent tool call (formatted as `[[tool: <label>]]`). Skips thinking/meta/user
+// — we want to show what the agent is *doing*, not its private reasoning or
+// the user's own prompt.
+
+export type PickedActivity =
+  | { kind: 'streaming'; text: string }
+  | { kind: 'assistant'; text: string }
+  | { kind: 'tool'; text: string }
+  | null
+
+export function pickLatestActivity(
+  streamingText: string | null,
+  entries: readonly TranscriptEntry[] | null,
+): PickedActivity {
+  if (streamingText && streamingText.trim()) {
+    return { kind: 'streaming', text: streamingText }
+  }
+  if (!entries || entries.length === 0) return null
+
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]
+    if (!e || !e.text) continue
+    if (e.kind === 'assistant') {
+      return { kind: 'assistant', text: e.text }
+    }
+    if (e.kind === 'tool') {
+      const parsed = parseToolMarkdown(e.text)
+      const label = parsed.label?.trim() || 'tool'
+      return { kind: 'tool', text: `[[tool: ${label}]]` }
+    }
+    // skip 'thinking', 'meta', 'user'
+  }
+  return null
+}

--- a/apps/web/src/features/graph/nodes/useFlipMorph.ts
+++ b/apps/web/src/features/graph/nodes/useFlipMorph.ts
@@ -1,0 +1,116 @@
+import { useLayoutEffect, useRef, type MutableRefObject, type RefCallback } from 'react'
+
+// ─── FLIP-style slide animation for sub-elements during shape morph ──────────
+//
+// "FLIP" = First, Last, Invert, Play. We capture each tracked element's
+// bounding rect at unmount-time of one layout (CardContent / CircleContent),
+// and on the next mount of the OTHER layout we measure the new rect, compute
+// the inverse transform back to the captured position, then animate to
+// identity. Result: the element appears to slide from its previous layout
+// position to its new one across the unmount/remount boundary.
+//
+// Why this and not Framer Motion's `layout` / `layoutId`? Because BooNode is
+// mounted in BOTH `GhostGraphPanel` and `MiniGraph` (via shared `nodeTypes`).
+// FM's layout system tracks `layoutId`s globally — identical ids in two trees
+// during a `<AnimatePresence mode="wait">` route transition jam the exit
+// cycle, leaving the previous view stuck and chat panels unable to mount.
+// FLIP done manually has NO global registry: each `FlipState` is owned by a
+// specific `BooNode` instance via `useRef`. Cross-component coordination is
+// impossible by construction.
+//
+// `state` is owned by the parent BooNode (not by the hook) so it persists
+// across the CardContent ↔ CircleContent unmount/remount that happens on
+// every shape morph. Two timing wrinkles handled below:
+//
+//   1. **StrictMode double-invocation**: in dev, useLayoutEffect fires twice
+//      on every mount (mount → cleanup → mount). The first run applies the
+//      inverse transform; if the second run measured rects again it would
+//      see the post-transform "old" position and trigger a REVERSE FLIP.
+//      The `el.style.transform` guard skips the second run cleanly.
+//
+//   2. **Physics-moved positions stay fresh**: `useFloatingMotion` writes a
+//      transient transform to the parent floatRef wrapper, drifting the
+//      visible avatar by a few pixels on every frame. If we captured the
+//      rect only on initial mount, the stored rect would be stale by the
+//      time the layout actually morphed. Capturing in the cleanup
+//      (immediately before unmount) ensures the rect reflects whatever the
+//      most recent paint looked like, so the FLIP animation starts from
+//      the position the user actually saw.
+
+export interface FlipState {
+  rect: DOMRect | null
+}
+
+export function createFlipState(): FlipState {
+  return { rect: null }
+}
+
+const TRANSITION = 'transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)'
+
+const POSITION_DELTA_THRESHOLD = 1 // pixels
+const SCALE_DELTA_THRESHOLD = 0.02 // 2% size change
+
+export function useFlipMorph<T extends HTMLElement = HTMLElement>(
+  state: MutableRefObject<FlipState>,
+): RefCallback<T> {
+  const elRef = useRef<T | null>(null)
+
+  useLayoutEffect(() => {
+    const el = elRef.current
+    if (!el) return
+
+    // StrictMode guard — see header note.
+    if (el.style.transform && el.style.transform !== 'none') {
+      return
+    }
+
+    const newRect = el.getBoundingClientRect()
+    const oldRect = state.current.rect
+
+    if (oldRect && oldRect.width > 0 && newRect.width > 0) {
+      const dx = oldRect.left - newRect.left
+      const dy = oldRect.top - newRect.top
+      const sx = oldRect.width / newRect.width
+      const sy = oldRect.height / newRect.height
+
+      const moved =
+        Math.abs(dx) > POSITION_DELTA_THRESHOLD || Math.abs(dy) > POSITION_DELTA_THRESHOLD
+      const resized =
+        Math.abs(sx - 1) > SCALE_DELTA_THRESHOLD || Math.abs(sy - 1) > SCALE_DELTA_THRESHOLD
+
+      if (moved || resized) {
+        // Step 1: jump to the OLD position via inverse transform (no transition)
+        el.style.transition = 'none'
+        el.style.transformOrigin = '0 0'
+        el.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`
+        // Step 2: force a reflow so the browser commits the inverse transform
+        void el.offsetWidth
+        // Step 3: animate to identity on the next frame
+        requestAnimationFrame(() => {
+          const animEl = elRef.current
+          if (!animEl) return
+          animEl.style.transition = TRANSITION
+          animEl.style.transform = ''
+        })
+      }
+    }
+
+    state.current.rect = newRect
+
+    // Cleanup runs at unmount. Capture the most recent rect so the NEXT
+    // mount (the OTHER layout) has a fresh starting point — even if physics
+    // / float-motion drifted the position since this mount's initial capture.
+    // Skip if a FLIP transform is still applied (mid-animation): in that
+    // case the previously stored rect is the correct stable layout rect.
+    return () => {
+      const cleanupEl = elRef.current
+      if (!cleanupEl) return
+      if (cleanupEl.style.transform && cleanupEl.style.transform !== 'none') return
+      state.current.rect = cleanupEl.getBoundingClientRect()
+    }
+  }, [])
+
+  return (el: T | null) => {
+    elRef.current = el
+  }
+}

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -339,6 +339,41 @@ export function buildGraphElements(
     }
   }
 
+  // Group primary edges by source so each parent's outgoing edges can render
+  // a SHARED trunk + branches instead of N overlapping smooth-step paths.
+  // Without this, two parallel-looking horizontal lines appear (the
+  // "rope" effect) when many siblings share a parent — each edge draws its
+  // own vertical from the parent + horizontal at the elbow, and tiny
+  // sub-pixel rendering differences between paths show as a doubled line
+  // even when the math says they should overlap exactly. The trunk leader
+  // draws the shared trunk; followers skip the trunk and draw only their
+  // branch (vertical descent to their own child).
+  const primaryBySource = new Map<string, GraphEdge[]>()
+  for (const edge of depEdges) {
+    if (!primaryEdgeIds.has(edge.id)) continue
+    const list = primaryBySource.get(edge.source) ?? []
+    list.push(edge)
+    primaryBySource.set(edge.source, list)
+  }
+  for (const [, siblings] of primaryBySource) {
+    if (siblings.length <= 1) continue // single child — normal smooth-step is fine
+    // Sort by edge id so the leader is deterministic across renders.
+    siblings.sort((a, b) => a.id.localeCompare(b.id))
+    const siblingTargetIds = siblings.map((e) => e.target)
+    siblings[0]!.data = {
+      ...siblings[0]!.data,
+      isTrunkLeader: true,
+      siblingTargetIds,
+    }
+    for (let i = 1; i < siblings.length; i++) {
+      siblings[i]!.data = {
+        ...siblings[i]!.data,
+        isTrunkFollower: true,
+        siblingTargetIds,
+      }
+    }
+  }
+
   // Compute edge counts per boo node for degree-aware sizing.
   // Use ONLY primary dependency edges + skill/resource edges so degree
   // counts reflect what the user actually sees at rest. (Hidden secondary

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -22,11 +22,19 @@ const ELK_OPTIONS = {
   // LAYER_SWEEP is the default barycentric heuristic and is fast on
   // small graphs (handful of Boos per team).
   'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-  // Node placement: NETWORK_SIMPLEX produces balanced columns within each
-  // layer (avoids one teammate hugging the left while another floats on
-  // the right). LP-based, optimal for our team sizes.
-  'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
-  // Spacing tuned so the BOO_ENVELOPE (260px, accounts for orbital
+  // Node placement: BRANDES_KOEPF with BALANCED alignment runs all four
+  // BK alignment passes (LEFT/RIGHT × UP/DOWN) and averages them, which
+  // gives the cleanest symmetric tree placement — parents sit at the
+  // visual midpoint of their children. NETWORK_SIMPLEX (the previous
+  // strategy) snaps nodes to integer columns based on LP flow, which
+  // produces beautifully balanced layouts when the children count is
+  // ODD (parent lands on the natural middle column) but visibly skews the
+  // parent to one side when the children count is EVEN (no middle column
+  // exists, so the parent rounds to the left or right one). BK + BALANCED
+  // averages out that rounding bias.
+  'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
+  'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
+  // Spacing tuned so the BOO_ENVELOPE (340px, accounts for orbital
   // children when expanded) clears between siblings AND between layers
   // with room for the bezier-curve dependency edge + arrowhead.
   'elk.spacing.nodeNode': '100',

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -35,16 +35,14 @@ const ELK_OPTIONS = {
 }
 
 // ─── Boo envelope dimensions ─────────────────────────────────────────────────
-// The Boo node is now a 220×120 card (see `nodes/BooNode.tsx`). The envelope
-// passed to ELK accounts for the card itself + the orbital children fan that
-// appears when a Boo is expanded (peacock-feather expand). Skills sit on an
-// inner ring at ~100–190px from the Boo's center, so we add ~200px of
-// padding around the card so siblings clear the orbital children.
-//
-// Width-side has a slightly tighter envelope than height because expanded
-// fans are quasi-circular but the card itself is wider than tall.
-const BOO_ENVELOPE_WIDTH = 280
-const BOO_ENVELOPE_HEIGHT = 280
+// The Boo renders centered inside this envelope (see BOO_FOOTPRINT in
+// `nodes/BooNode.tsx`) so the visible Boo shape (75–78px circle / 220×120
+// card) is anchored at envelope center — keeping ELK's sibling spacing math
+// honest about where edges actually converge. Sized to clear the card's
+// diagonal half-extent (~125px) plus the orbital children: skills on an
+// inner ring at 150–220px and resources on an outer ring at 230–285px.
+const BOO_ENVELOPE_WIDTH = 340
+const BOO_ENVELOPE_HEIGHT = 340
 
 // ─── Default node dimensions (used before ReactFlow measures them) ────────────
 

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -181,41 +181,129 @@ const SECONDARY_NAV: { id: NavView; label: string; emoji: string }[] = [
 ]
 
 // ─── Group chat row ─────────────────────────────────────────────────────────
+//
+// The button shows a "team photo" of overlapping Boo avatars instead of a
+// single team emoji + generic label. Each avatar is the same as what
+// renders in the Ghost Graph for that agent, so the team's identity reads
+// at a glance from the same visual fingerprints used elsewhere.
+//
+//   - "TEAM CHAT" caption sits ABOVE the photo so the row's purpose
+//     reads first; the photo is the supporting visual.
+//   - Up to MAX_VISIBLE_AVATARS Boos are shown; remaining ones collapse
+//     into a "+N" badge at the end of the stack.
+//   - The leader (when known) is placed FIRST so it sits at the front of
+//     the overlap stack.
+//   - Each avatar has a 2px ring in the surface color so adjacent
+//     overlapping avatars read as separate faces, not a blurred mass.
+//     The ring color is FIXED — it doesn't switch to the team accent on
+//     selection (a previous version did, but the colored rings around
+//     each Boo when active read as visually congested). Selection
+//     feedback comes from the row background lightening on its own.
+
+const GROUP_CHAT_AVATAR_SIZE = 30
+const GROUP_CHAT_STRIDE = 20 // 30 - 20 = 10px overlap between adjacent avatars
+const GROUP_CHAT_MAX_VISIBLE_AVATARS = 6
+
+function orderTeamAgentsForPhoto(team: Team, teamAgents: AgentState[]): AgentState[] {
+  if (!team.leaderAgentId) return teamAgents
+  const leaderIndex = teamAgents.findIndex((a) => a.id === team.leaderAgentId)
+  if (leaderIndex <= 0) return teamAgents
+  // Move leader to position 0; preserve relative order of the rest.
+  const reordered = [...teamAgents]
+  const [leader] = reordered.splice(leaderIndex, 1)
+  if (leader) reordered.unshift(leader)
+  return reordered
+}
 
 function GroupChatRow({
   team,
+  teamAgents,
   isActive,
   onClick,
 }: {
   team: Team
+  teamAgents: AgentState[]
   isActive: boolean
   onClick: () => void
 }) {
+  const ordered = orderTeamAgentsForPhoto(team, teamAgents)
+  const visible = ordered.slice(0, GROUP_CHAT_MAX_VISIBLE_AVATARS)
+  const overflow = Math.max(0, ordered.length - GROUP_CHAT_MAX_VISIBLE_AVATARS)
+  // Ring color is fixed in the surface color so it acts purely as a
+  // separator between overlapping avatars (visually invisible against the
+  // surface). It does NOT switch to the team accent on selection — the
+  // earlier version did and the user found the colored rings congested.
+  const ringColor = '#111827'
+
   return (
     <button
       type="button"
       data-testid="group-chat-row"
       onClick={onClick}
+      title={`${team.name} — Team Chat (${ordered.length} agent${ordered.length === 1 ? '' : 's'})`}
       className={[
-        'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2',
+        'group flex w-full flex-col items-center gap-1.5 rounded-lg px-2.5 py-2.5',
         'transition-colors duration-150',
-        isActive ? 'bg-white/6 shadow-sm' : 'hover:bg-white/4',
+        isActive ? 'bg-white/8 shadow-sm' : 'hover:bg-white/4',
       ].join(' ')}
     >
+      {/* Caption sits ABOVE the photo so the row's purpose reads first. */}
       <span
-        className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-lg text-[15px]"
-        style={{ background: `${team.color}22` }}
+        className="text-[10px] font-semibold uppercase tracking-wider text-secondary/60"
+        style={{ fontFamily: 'var(--font-mono)' }}
       >
-        {team.icon}
+        Team Chat
       </span>
-      <div className="min-w-0 flex-1 text-left">
-        <p
-          className="truncate text-[12px] font-medium leading-tight text-text"
-          style={{ fontFamily: 'var(--font-body)' }}
-        >
-          Group Chat
-        </p>
-        <p className="mt-0.5 text-[10px] text-secondary/40">Group conversation</p>
+
+      {/* Team photo: overlapping Boo avatars centered horizontally. */}
+      <div className="flex items-center justify-center">
+        {visible.map((agent, i) => (
+          <div
+            key={agent.id}
+            title={agent.name}
+            style={{
+              marginLeft: i === 0 ? 0 : -(GROUP_CHAT_AVATAR_SIZE - GROUP_CHAT_STRIDE),
+              width: GROUP_CHAT_AVATAR_SIZE,
+              height: GROUP_CHAT_AVATAR_SIZE,
+              borderRadius: '50%',
+              border: `2px solid ${ringColor}`,
+              overflow: 'hidden',
+              flexShrink: 0,
+              // Earlier (leftmost) avatars sit ON TOP — the leader is at
+              // index 0, so they dominate the front of the team photo.
+              zIndex: visible.length - i,
+              boxShadow: '0 1px 3px rgba(0,0,0,0.45)',
+              background: '#0A0E1A',
+            }}
+          >
+            <AgentBooAvatar agentId={agent.id} size={GROUP_CHAT_AVATAR_SIZE} />
+          </div>
+        ))}
+        {overflow > 0 && (
+          <div
+            title={`${overflow} more ${overflow === 1 ? 'agent' : 'agents'}`}
+            style={{
+              marginLeft: -(GROUP_CHAT_AVATAR_SIZE - GROUP_CHAT_STRIDE),
+              width: GROUP_CHAT_AVATAR_SIZE,
+              height: GROUP_CHAT_AVATAR_SIZE,
+              borderRadius: '50%',
+              border: `2px solid ${ringColor}`,
+              background: '#1f2937',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 10,
+              fontWeight: 700,
+              color: 'rgba(232,232,232,0.75)',
+              flexShrink: 0,
+              zIndex: 0,
+              fontFamily: 'var(--font-mono)',
+              letterSpacing: '0.02em',
+            }}
+          >
+            +{overflow}
+          </div>
+        )}
       </div>
     </button>
   )
@@ -358,6 +446,7 @@ export function AgentListColumn() {
           <>
             <GroupChatRow
               team={selectedTeam}
+              teamAgents={filtered}
               isActive={viewMode.type === 'groupChat' && viewMode.teamId === selectedTeam.id}
               onClick={() => useViewStore.getState().openGroupChat(selectedTeam.id)}
             />

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -182,27 +182,50 @@ const SECONDARY_NAV: { id: NavView; label: string; emoji: string }[] = [
 
 // ─── Group chat row ─────────────────────────────────────────────────────────
 //
-// The button shows a "team photo" of overlapping Boo avatars instead of a
-// single team emoji + generic label. Each avatar is the same as what
-// renders in the Ghost Graph for that agent, so the team's identity reads
-// at a glance from the same visual fingerprints used elsewhere.
+// Single-row horizontal button: avatar stack (the "team photo") on the
+// LEFT, "Group Chat" label + chevron on the RIGHT. Earlier vertical
+// designs (label-above-photo) read as a section heading because of the
+// stacked vertical layout — putting everything on one row of similar
+// height to the agent rows below makes it unambiguously a button while
+// still showing off the team identity through the live Boo avatars.
 //
-//   - "TEAM CHAT" caption sits ABOVE the photo so the row's purpose
-//     reads first; the photo is the supporting visual.
 //   - Up to MAX_VISIBLE_AVATARS Boos are shown; remaining ones collapse
 //     into a "+N" badge at the end of the stack.
 //   - The leader (when known) is placed FIRST so it sits at the front of
 //     the overlap stack.
 //   - Each avatar has a 2px ring in the surface color so adjacent
 //     overlapping avatars read as separate faces, not a blurred mass.
-//     The ring color is FIXED — it doesn't switch to the team accent on
-//     selection (a previous version did, but the colored rings around
-//     each Boo when active read as visually congested). Selection
-//     feedback comes from the row background lightening on its own.
+//     The ring color is FIXED — earlier versions switched it to the team
+//     accent on selection but the colored rings read as congested.
+//   - Right side: "Group Chat" label + a chevron-right icon. The
+//     chevron is the standard "navigate to" affordance so the button
+//     reads as interactive even when nothing is hovered.
+//   - Selection feedback is via the surface background only (lightens
+//     on hover, lightens further when active).
 
-const GROUP_CHAT_AVATAR_SIZE = 30
-const GROUP_CHAT_STRIDE = 20 // 30 - 20 = 10px overlap between adjacent avatars
-const GROUP_CHAT_MAX_VISIBLE_AVATARS = 6
+// Avatars are 28px so 4 of them + the "Group Chat" label + status badge
+// all fit on a single line within the 191px-wide column. (At 30px the
+// stack ate just enough horizontal space that "Group Chat" overflowed
+// its container by 1px and triggered the truncate ellipsis.) The right
+// side mirrors the agent row's layout — name on top, status badge below
+// — so the Group Chat row reads as a structural peer of the agent rows.
+//   - Team has 1–4 agents: show ALL of them (no "+N" badge needed)
+//   - Team has 5+ agents:  show 3 avatars + "+N" badge
+// This caps the avatar stack at 4 items wide regardless of team size.
+const GROUP_CHAT_AVATAR_SIZE = 28
+const GROUP_CHAT_STRIDE = 18 // 28 - 18 = 10px overlap between adjacent avatars
+const GROUP_CHAT_MAX_VISIBLE_NO_OVERFLOW = 4
+const GROUP_CHAT_MAX_VISIBLE_WITH_OVERFLOW = 3
+
+// The avatar-stack column has a FIXED width regardless of how many
+// avatars the team actually contributes — sized to hold the maximum
+// (4 items wide). Without this, smaller teams produced a narrower
+// stack which let the right-side "Group Chat / Idle" text shift left,
+// so the same label rendered at different X positions across teams.
+// A fixed-width left column keeps the label / status badge aligned
+// to the same column edge in every team size.
+const GROUP_CHAT_STACK_WIDTH =
+  GROUP_CHAT_AVATAR_SIZE + (GROUP_CHAT_MAX_VISIBLE_NO_OVERFLOW - 1) * GROUP_CHAT_STRIDE
 
 function orderTeamAgentsForPhoto(team: Team, teamAgents: AgentState[]): AgentState[] {
   if (!team.leaderAgentId) return teamAgents
@@ -213,6 +236,18 @@ function orderTeamAgentsForPhoto(team: Team, teamAgents: AgentState[]): AgentSta
   const [leader] = reordered.splice(leaderIndex, 1)
   if (leader) reordered.unshift(leader)
   return reordered
+}
+
+// Aggregate the team's overall status from its members. Mirrors the
+// status badge shown on individual agent rows so the Group Chat row
+// reads as a peer in the list. Priority: any running > any error >
+// any sleeping > idle.
+function aggregateTeamStatus(teamAgents: AgentState[]): AgentStatus {
+  if (teamAgents.length === 0) return 'idle'
+  if (teamAgents.some((a) => a.status === 'running')) return 'running'
+  if (teamAgents.some((a) => a.status === 'error')) return 'error'
+  if (teamAgents.some((a) => a.status === 'sleeping')) return 'sleeping'
+  return 'idle'
 }
 
 function GroupChatRow({
@@ -227,36 +262,39 @@ function GroupChatRow({
   onClick: () => void
 }) {
   const ordered = orderTeamAgentsForPhoto(team, teamAgents)
-  const visible = ordered.slice(0, GROUP_CHAT_MAX_VISIBLE_AVATARS)
-  const overflow = Math.max(0, ordered.length - GROUP_CHAT_MAX_VISIBLE_AVATARS)
+  // If the team is small enough to show every agent, do so. Otherwise
+  // cap at WITH_OVERFLOW so the "+N" badge fits alongside the label.
+  const willOverflow = ordered.length > GROUP_CHAT_MAX_VISIBLE_NO_OVERFLOW
+  const visibleCount = willOverflow ? GROUP_CHAT_MAX_VISIBLE_WITH_OVERFLOW : ordered.length
+  const visible = ordered.slice(0, visibleCount)
+  const overflow = Math.max(0, ordered.length - visibleCount)
   // Ring color is fixed in the surface color so it acts purely as a
   // separator between overlapping avatars (visually invisible against the
-  // surface). It does NOT switch to the team accent on selection — the
-  // earlier version did and the user found the colored rings congested.
+  // surface). It does NOT switch to the team accent on selection.
   const ringColor = '#111827'
+
+  const aggregateStatus = aggregateTeamStatus(ordered)
 
   return (
     <button
       type="button"
       data-testid="group-chat-row"
       onClick={onClick}
-      title={`${team.name} — Team Chat (${ordered.length} agent${ordered.length === 1 ? '' : 's'})`}
+      title={`${team.name} — Group Chat (${ordered.length} agent${ordered.length === 1 ? '' : 's'})`}
       className={[
-        'group flex w-full flex-col items-center gap-1.5 rounded-lg px-2.5 py-2.5',
+        // py-2 + the right-side label-on-top + status-below stack mirror
+        // the agent rows below exactly — same outer height (~56px) and
+        // same internal vertical rhythm.
+        'group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2',
         'transition-colors duration-150',
         isActive ? 'bg-white/8 shadow-sm' : 'hover:bg-white/4',
       ].join(' ')}
     >
-      {/* Caption sits ABOVE the photo so the row's purpose reads first. */}
-      <span
-        className="text-[10px] font-semibold uppercase tracking-wider text-secondary/60"
-        style={{ fontFamily: 'var(--font-mono)' }}
-      >
-        Team Chat
-      </span>
-
-      {/* Team photo: overlapping Boo avatars centered horizontally. */}
-      <div className="flex items-center justify-center">
+      {/* Team photo — overlapping Boo avatars on the left. The container
+          has a FIXED width (GROUP_CHAT_STACK_WIDTH) regardless of how
+          many avatars are visible, so the right-side label / status
+          column starts at the same X across every team size. */}
+      <div className="flex items-center" style={{ width: GROUP_CHAT_STACK_WIDTH, flexShrink: 0 }}>
         {visible.map((agent, i) => (
           <div
             key={agent.id}
@@ -272,7 +310,7 @@ function GroupChatRow({
               // Earlier (leftmost) avatars sit ON TOP — the leader is at
               // index 0, so they dominate the front of the team photo.
               zIndex: visible.length - i,
-              boxShadow: '0 1px 3px rgba(0,0,0,0.45)',
+              boxShadow: '0 1px 2px rgba(0,0,0,0.4)',
               background: '#0A0E1A',
             }}
           >
@@ -292,7 +330,7 @@ function GroupChatRow({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              fontSize: 10,
+              fontSize: 11,
               fontWeight: 700,
               color: 'rgba(232,232,232,0.75)',
               flexShrink: 0,
@@ -305,6 +343,27 @@ function GroupChatRow({
           </div>
         )}
       </div>
+
+      {/* Right side — "Group Chat" name on top, aggregate status badge
+          below. Vertically stacked the same way agent rows lay out
+          [name / status badge], so the Group Chat row reads as a
+          structural peer of the agents listed beneath it.
+          The label has a small NEGATIVE left margin so its first letter
+          sits slightly outside the badge's left edge — closer to where
+          the agent NAME visually anchors on the rows below. The status
+          badge is left untouched at the column's left edge so the
+          status indicator's absolute position is unchanged. */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p
+          className="truncate text-[12px] font-medium leading-tight text-text"
+          style={{ fontFamily: 'var(--font-body)', marginLeft: -8 }}
+        >
+          Group Chat
+        </p>
+        <div className="flex items-center">
+          <StatusBadge status={aggregateStatus} />
+        </div>
+      </div>
     </button>
   )
 }
@@ -313,7 +372,6 @@ function GroupChatRow({
 
 export function AgentListColumn() {
   const agents = useFleetStore((s) => s.agents)
-  const selectedAgentId = useFleetStore((s) => s.selectedAgentId)
   const selectAgent = useFleetStore((s) => s.selectAgent)
   const hydrateAgents = useFleetStore((s) => s.hydrateAgents)
 
@@ -486,7 +544,14 @@ export function AgentListColumn() {
                 <AgentRow
                   key={agent.id}
                   agent={agent}
-                  selected={agent.id === selectedAgentId}
+                  // Highlight only when actually viewing this agent's
+                  // detail page. Reading from `viewMode` (instead of
+                  // `selectedAgentId`) ensures the row drops its
+                  // highlight as soon as the user navigates to Group
+                  // Chat / a nav view — the previously-selected agent
+                  // shouldn't keep looking active when something else
+                  // is on screen.
+                  selected={viewMode.type === 'agent' && viewMode.agentId === agent.id}
                   onSelect={() => handleSelectAgent(agent.id)}
                   onDelete={() => {
                     if (!client) return


### PR DESCRIPTION
## Summary

- Improves `BooNode` interactions and styling, including cleaner hover/selection behavior and updated visual presentation.
- Enhances graph rendering with refined ELK layout options, improved edge rendering, and trunk-and-branches routing for primary edges.
- Updates `GroupChatRow` with team photo avatars and improved avatar display for a more polished team chat experience.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed yet — app-level graph/layout UI work unless this is the final release-ready package or CLI change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff