### PR TITLE
feat(graph): add Boo node MiniMap rendering and refine group chat layout

### DIFF
--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -20,7 +20,7 @@ import type {
   MiniMapNodeProps,
 } from '@xyflow/react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { GitBranch, Pin } from 'lucide-react'
+import { GitBranch, Map, Pin, X } from 'lucide-react'
 import { useGraphStore } from './store'
 import { useGraphData } from './useGraphData'
 import { useGraphPersistence } from './useGraphPersistence'
@@ -48,6 +48,32 @@ interface ContextMenuState {
   y: number
   agentId: string
   agentName: string
+}
+
+// fitView() honours the bounding box of every node we pass in. By default it
+// fits the full graph — but our peacock-collapse model keeps skill / resource
+// nodes mounted at their orbital positions (150–220 px from each Boo) with
+// `opacity: 0; scale: 0`. fitView still sees them, so it zooms out far enough
+// for the invisible ring, and the actual visible Boos render at ~30 % of
+// their nominal size. We filter to the nodes the user can actually see —
+// every Boo (always rendered) plus any orbital child whose parent is
+// currently expanded — so the camera frames only what's on screen.
+//
+// We can't read `node.data.isVisible` directly because the raw store nodes
+// don't carry it; the flag is added downstream in the `visibleNodes` memo.
+// Instead we re-derive visibility from `expandedBooNodeIds` (the actual
+// source of truth — same path the memo uses).
+function pickFittableNodes(nodes: Node[], expandedBooIds: Set<string>): { id: string }[] {
+  return nodes
+    .filter((n) => {
+      if (n.type === 'boo') return true
+      if (n.type !== 'skill' && n.type !== 'resource') return true
+      const agentIds = (n.data as { agentIds?: string[] } | undefined)?.agentIds
+      const ownerAgentId = agentIds?.[0]
+      if (!ownerAgentId) return false
+      return expandedBooIds.has(`boo-${ownerAgentId}`)
+    })
+    .map((n) => ({ id: n.id }))
 }
 
 // Custom MiniMap node renderer.
@@ -144,6 +170,11 @@ export function GhostGraph() {
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
 
+  // Hide the MiniMap (bottom-right overview) by default to give Boos more
+  // visible canvas. A small floating toggle button takes its place; clicking
+  // it expands the MiniMap back when the user wants to navigate a large graph.
+  const [showMiniMap, setShowMiniMap] = useState(false)
+
   const nodesInitialized = useNodesInitialized()
   const { fitView } = useReactFlow()
 
@@ -208,7 +239,13 @@ export function GhostGraph() {
     }
     if (refitTimerRef.current) clearTimeout(refitTimerRef.current)
     refitTimerRef.current = setTimeout(() => {
-      void fitView({ padding: 0.08, duration: 250, maxZoom: 1.5 })
+      const state = useGraphStore.getState()
+      void fitView({
+        padding: 0.04,
+        duration: 250,
+        maxZoom: 1.5,
+        nodes: pickFittableNodes(state.nodes, state.expandedBooNodeIds),
+      })
     }, 180)
     return () => {
       if (refitTimerRef.current) clearTimeout(refitTimerRef.current)
@@ -264,33 +301,49 @@ export function GhostGraph() {
       (e) => e.type === 'dependency' && (e.data as { isPrimary?: boolean })?.isPrimary !== false,
     )
 
-    void computeElkLayout(booNodes, primaryDepEdges, savedPositions).then((layoutedBooNodes) => {
-      // Skip stale results — a newer ELK computation has started
-      if (generation !== elkGenerationRef.current) return
+    // Pass the canvas aspect so ELK's hierarchy-driven output can be stretched
+    // to claim the empty bands fitView would otherwise leave (see
+    // stretchToAspect in useGraphLayout.ts).
+    const canvasAspect =
+      containerSize.w > 0 && containerSize.h > 0 ? containerSize.w / containerSize.h : undefined
 
-      // Layer 2: Position skills/resources in orbital arcs around their parent boo
-      const orbitalNodes = computeOrbitalPositions(
-        layoutedBooNodes,
-        nonBooNodes,
-        edges, // full edges needed for parent-child mapping
-        savedPositions,
-      )
+    void computeElkLayout(booNodes, primaryDepEdges, savedPositions, canvasAspect).then(
+      (layoutedBooNodes) => {
+        // Skip stale results — a newer ELK computation has started
+        if (generation !== elkGenerationRef.current) return
 
-      setNodes([...layoutedBooNodes, ...orbitalNodes])
-      setHasRunLayout(true)
+        // Layer 2: Position skills/resources in orbital arcs around their parent boo
+        const orbitalNodes = computeOrbitalPositions(
+          layoutedBooNodes,
+          nonBooNodes,
+          edges, // full edges needed for parent-child mapping
+          savedPositions,
+        )
 
-      // Initialize physics particles from layouted positions
-      requestAnimationFrame(() => {
-        const current = useGraphStore.getState()
-        graphPhysics.initialize(current.nodes, current.edges)
-      })
+        setNodes([...layoutedBooNodes, ...orbitalNodes])
+        setHasRunLayout(true)
 
-      requestAnimationFrame(() => {
-        // Tight padding gives Boos visual prominence; maxZoom caps the fit so
-        // tiny graphs (1–2 Boos) don't blow up to fill the canvas.
-        void fitView({ padding: 0.08, duration: 500, maxZoom: 1.5 })
-      })
-    })
+        // Initialize physics particles from layouted positions
+        requestAnimationFrame(() => {
+          const current = useGraphStore.getState()
+          graphPhysics.initialize(current.nodes, current.edges)
+        })
+
+        requestAnimationFrame(() => {
+          // Tight padding gives Boos visual prominence; maxZoom caps the fit so
+          // tiny graphs (1–2 Boos) don't blow up to fill the canvas.
+          // `nodes` filter excludes the invisible-by-default orbital children —
+          // see pickFittableNodes() above for why this matters.
+          const state = useGraphStore.getState()
+          void fitView({
+            padding: 0.04,
+            duration: 500,
+            maxZoom: 1.5,
+            nodes: pickFittableNodes(state.nodes, state.expandedBooNodeIds),
+          })
+        })
+      },
+    )
     // isLoaded gates layout until saved positions are fetched from SQLite.
   }, [nodesInitialized, nodes.length, layoutKey, isLoaded])
 
@@ -626,6 +679,36 @@ export function GhostGraph() {
         {connectMode ? 'Drawing Edges' : 'Connect'}
       </button>
 
+      {/* MiniMap minimize/maximize toggle. Sits at the bottom-right corner —
+          where the MiniMap itself lives — so the relationship between the
+          control and what it controls reads at a glance. When the MiniMap is
+          shown, the toggle slides left of it and switches to an X icon. */}
+      <button
+        onClick={() => setShowMiniMap(!showMiniMap)}
+        title={showMiniMap ? 'Hide minimap' : 'Show minimap'}
+        aria-label={showMiniMap ? 'Hide minimap' : 'Show minimap'}
+        style={{
+          position: 'absolute',
+          bottom: 12,
+          right: showMiniMap ? minimapDims.w + 24 : 12,
+          zIndex: 20,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 28,
+          height: 28,
+          padding: 0,
+          borderRadius: 8,
+          cursor: 'pointer',
+          border: '1px solid rgba(255,255,255,0.1)',
+          background: '#111827',
+          color: showMiniMap ? '#E94560' : 'rgba(232,232,232,0.5)',
+          transition: 'right 0.2s ease, color 0.15s, border-color 0.15s',
+        }}
+      >
+        {showMiniMap ? <X size={14} /> : <Map size={14} />}
+      </button>
+
       <ReactFlow
         nodes={visibleNodes}
         edges={visibleEdges}
@@ -665,31 +748,33 @@ export function GhostGraph() {
             borderRadius: 8,
           }}
         />
-        <MiniMap
-          style={{
-            background: '#111827',
-            border: '1px solid rgba(255,255,255,0.08)',
-            borderRadius: 8,
-            width: minimapDims.w,
-            height: minimapDims.h,
-          }}
-          nodeColor={(node) => {
-            if (node.type === 'boo') return '#E94560'
-            // Skill / resource nodes inherit visibility from their parent
-            // Boo via `data.isVisible` (set by the visibleNodes memo).
-            // When the parent is collapsed, return 'transparent' so the
-            // MiniMap matches what the user sees in the main canvas.
-            // The `?? true` default keeps MiniMap behaviour correct in
-            // contexts that don't set the flag (e.g. MiniGraph) — but
-            // this MiniMap is only on the Ghost Graph anyway.
-            const isVisible = (node.data as { isVisible?: boolean }).isVisible ?? true
-            if (node.type === 'skill') return isVisible ? '#34D399' : 'transparent'
-            if (node.type === 'resource') return isVisible ? '#FBBF24' : 'transparent'
-            return '#FBBF24'
-          }}
-          nodeComponent={GhostGraphMiniMapNode}
-          maskColor="rgba(10,14,26,0.75)"
-        />
+        {showMiniMap && (
+          <MiniMap
+            style={{
+              background: '#111827',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 8,
+              width: minimapDims.w,
+              height: minimapDims.h,
+            }}
+            nodeColor={(node) => {
+              if (node.type === 'boo') return '#E94560'
+              // Skill / resource nodes inherit visibility from their parent
+              // Boo via `data.isVisible` (set by the visibleNodes memo).
+              // When the parent is collapsed, return 'transparent' so the
+              // MiniMap matches what the user sees in the main canvas.
+              // The `?? true` default keeps MiniMap behaviour correct in
+              // contexts that don't set the flag (e.g. MiniGraph) — but
+              // this MiniMap is only on the Ghost Graph anyway.
+              const isVisible = (node.data as { isVisible?: boolean }).isVisible ?? true
+              if (node.type === 'skill') return isVisible ? '#34D399' : 'transparent'
+              if (node.type === 'resource') return isVisible ? '#FBBF24' : 'transparent'
+              return '#FBBF24'
+            }}
+            nodeComponent={GhostGraphMiniMapNode}
+            maskColor="rgba(10,14,26,0.75)"
+          />
+        )}
       </ReactFlow>
 
       {/* Context menu */}

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -17,6 +17,7 @@ import type {
   Node,
   Connection,
   IsValidConnection,
+  MiniMapNodeProps,
 } from '@xyflow/react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { GitBranch, Pin } from 'lucide-react'
@@ -49,6 +50,69 @@ interface ContextMenuState {
   agentName: string
 }
 
+// Custom MiniMap node renderer.
+//
+// React Flow's default MiniMap draws each node at its actual rendered size.
+// Our BooNode is a 340×340 transparent footprint with the visible Boo
+// (~80px circle / 220×120 card) centered inside it — see BOO_FOOTPRINT in
+// nodes/BooNode.tsx. Rendering the full footprint in the MiniMap makes Boos
+// look enormously out of proportion vs. the actual visible shape on the
+// canvas. This component draws Boos as a smaller centered dot so the MiniMap
+// reflects what the user actually sees. Skill / resource nodes already
+// render at sensible visual sizes, so they're drawn at their measured size.
+function GhostGraphMiniMapNode({
+  id,
+  x,
+  y,
+  width,
+  height,
+  color,
+  borderRadius,
+  className,
+  shapeRendering,
+  strokeColor,
+  strokeWidth,
+  selected,
+}: MiniMapNodeProps) {
+  const fill = color ?? '#e2e2e2'
+  if (color === 'transparent') return null
+  const stroke = strokeColor ?? 'transparent'
+  const sw = strokeWidth ?? 0
+  if (id.startsWith('boo-')) {
+    // Visible Boo is roughly 80–120 px on canvas; pick 110 as a single
+    // representative size that reads well in MiniMap regardless of whether
+    // the source Boo is in idle-circle or active-card mode.
+    const visualSize = 110
+    return (
+      <circle
+        cx={x + width / 2}
+        cy={y + height / 2}
+        r={visualSize / 2}
+        fill={fill}
+        stroke={stroke}
+        strokeWidth={sw}
+        shapeRendering={shapeRendering}
+        className={className + (selected ? ' selected' : '')}
+      />
+    )
+  }
+  return (
+    <rect
+      x={x}
+      y={y}
+      width={width}
+      height={height}
+      rx={borderRadius}
+      ry={borderRadius}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={sw}
+      shapeRendering={shapeRendering}
+      className={className + (selected ? ' selected' : '')}
+    />
+  )
+}
+
 // ─── GhostGraph ───────────────────────────────────────────────────────────────
 //
 // Must be rendered inside <ReactFlowProvider> (done by GhostGraphPanel).
@@ -64,6 +128,7 @@ export function GhostGraph() {
     selectedEdgeId,
     setSelectedEdgeId,
     setNodes,
+    hasRunLayout,
     setHasRunLayout,
     updateNodePosition,
     connectMode,
@@ -81,6 +146,12 @@ export function GhostGraph() {
 
   const nodesInitialized = useNodesInitialized()
   const { fitView } = useReactFlow()
+
+  // Track the canvas wrapper size so we can (a) re-fit the graph when the
+  // panel is resized (e.g. user drags the divider in the new vertical group
+  // chat layout) and (b) size the MiniMap proportionally to the canvas.
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const [containerSize, setContainerSize] = useState<{ w: number; h: number }>({ w: 800, h: 600 })
 
   // Track layout state in refs to avoid stale closure issues
   const layoutRanRef = useRef(false)
@@ -100,6 +171,58 @@ export function GhostGraph() {
       graphPhysics.dispose()
     }
   }, [])
+
+  // Observe the canvas wrapper so we can refit + resize the MiniMap when the
+  // surrounding panel changes shape (group chat divider drag, window resize,
+  // navigating into / out of group chat with its short-and-wide row layout).
+  useEffect(() => {
+    const el = wrapperRef.current
+    if (!el) return
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect
+        if (width > 0 && height > 0) {
+          setContainerSize((prev) =>
+            Math.abs(prev.w - width) < 0.5 && Math.abs(prev.h - height) < 0.5
+              ? prev
+              : { w: width, h: height },
+          )
+        }
+      }
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  // Refit the view when the container size changes (debounced). Only fires
+  // after the initial layout has run, otherwise the layout effect already
+  // calls fitView once Boos land. Skipped on the very first dimensions read
+  // (matches the initial 800×600 default → no spurious refit on mount).
+  const refitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const initialFitDoneRef = useRef(false)
+  useEffect(() => {
+    if (!hasRunLayout) return
+    if (!initialFitDoneRef.current) {
+      initialFitDoneRef.current = true
+      return
+    }
+    if (refitTimerRef.current) clearTimeout(refitTimerRef.current)
+    refitTimerRef.current = setTimeout(() => {
+      void fitView({ padding: 0.08, duration: 250, maxZoom: 1.5 })
+    }, 180)
+    return () => {
+      if (refitTimerRef.current) clearTimeout(refitTimerRef.current)
+    }
+  }, [containerSize.w, containerSize.h, hasRunLayout, fitView])
+
+  // MiniMap stays small relative to the canvas — ~16% wide, ~22% tall, with
+  // sensible min/max so it neither becomes invisible on tiny panels nor
+  // dominates the canvas on large ones.
+  const minimapDims = useMemo(() => {
+    const w = Math.round(Math.max(110, Math.min(180, containerSize.w * 0.16)))
+    const h = Math.round(Math.max(72, Math.min(130, containerSize.h * 0.22)))
+    return { w, h }
+  }, [containerSize.w, containerSize.h])
 
   // ── Two-layer auto-layout ────────────────────────────────────────────────────
   // Layer 1: ELK positions boo nodes using dependency edges only (async).
@@ -163,7 +286,9 @@ export function GhostGraph() {
       })
 
       requestAnimationFrame(() => {
-        void fitView({ padding: 0.15, duration: 500 })
+        // Tight padding gives Boos visual prominence; maxZoom caps the fit so
+        // tiny graphs (1–2 Boos) don't blow up to fill the canvas.
+        void fitView({ padding: 0.08, duration: 500, maxZoom: 1.5 })
       })
     })
     // isLoaded gates layout until saved positions are fetched from SQLite.
@@ -372,8 +497,6 @@ export function GhostGraph() {
   // ── Derive selected edge for explain panel ───────────────────────────────────
   const selectedEdge = selectedEdgeId ? (edges.find((e) => e.id === selectedEdgeId) ?? null) : null
 
-  const hasRunLayout = useGraphStore((s) => s.hasRunLayout)
-
   // ── Derive visibility for skill/resource nodes + their edges ──────────────
   // Boos and dependency edges are always visible. Skill / resource nodes are
   // hidden by default and revealed only when the user clicks (and thus
@@ -427,6 +550,7 @@ export function GhostGraph() {
 
   return (
     <div
+      ref={wrapperRef}
       style={{
         width: '100%',
         height: '100%',
@@ -546,6 +670,8 @@ export function GhostGraph() {
             background: '#111827',
             border: '1px solid rgba(255,255,255,0.08)',
             borderRadius: 8,
+            width: minimapDims.w,
+            height: minimapDims.h,
           }}
           nodeColor={(node) => {
             if (node.type === 'boo') return '#E94560'
@@ -561,6 +687,7 @@ export function GhostGraph() {
             if (node.type === 'resource') return isVisible ? '#FBBF24' : 'transparent'
             return '#FBBF24'
           }}
+          nodeComponent={GhostGraphMiniMapNode}
           maskColor="rgba(10,14,26,0.75)"
         />
       </ReactFlow>

--- a/apps/web/src/features/graph/computeOrbitalPositions.ts
+++ b/apps/web/src/features/graph/computeOrbitalPositions.ts
@@ -22,10 +22,10 @@ const JITTER_RANGE = 12
 
 // Offset from each Boo's React Flow `node.position` (top-left of the
 // envelope) to its visual center. The Boo renders centered inside its
-// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the center is
+// envelope (BOO_FOOTPRINT = 280 in `nodes/BooNode.tsx`), so the center is
 // at half the envelope size in each dimension.
-const BOO_HALF_W = 170
-const BOO_HALF_H = 170
+const BOO_HALF_W = 140
+const BOO_HALF_H = 140
 
 // Node dimensions for centering orbital children
 const SKILL_SIZE = 38 // CIRCLE const in SkillNode.tsx

--- a/apps/web/src/features/graph/graphPhysics.ts
+++ b/apps/web/src/features/graph/graphPhysics.ts
@@ -39,11 +39,11 @@ const BOO_MAX_VELOCITY = 3
 
 // Offset from each Boo's React Flow `node.position` (top-left of the
 // envelope) to its visual center. The Boo renders centered inside its
-// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the center is
+// envelope (BOO_FOOTPRINT = 280 in `nodes/BooNode.tsx`), so the center is
 // at half the envelope size — which is what spring math + Boo-Boo
 // collision detection treat as the Boo "anchor" point.
-const BOO_HALF_W = 170
-const BOO_HALF_H = 170
+const BOO_HALF_W = 140
+const BOO_HALF_H = 140
 
 // Node half-sizes for center computation
 const SKILL_HALF = 19 // 38 / 2

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -69,10 +69,12 @@ export const BOO_CARD_HEIGHT = 120
 // (75–78px circle or 220×120 card) sits at the top-left of the envelope and
 // edges visually converge offset from the Boo.
 //
-// Sized so the card's diagonal half-extent (~125px) plus the inner skill ring
-// (150–220px) fit clear inside, with sibling Boos staying spaced when both
-// expand orbital children.
-const BOO_FOOTPRINT = 340
+// Sized to fit the card (220×120, diagonal half ~125 px) plus an inner skill
+// ring at ~150 px from center. Outer skill rings (up to ~220 px) can briefly
+// overlap a sibling's gap region when BOTH neighbours are expanded — that's
+// an acceptable trade-off for the dramatic boost in idle Boo legibility:
+// scale on a 3-Boo group-chat row goes from ~0.49 to ~0.68 (~40 % bigger).
+const BOO_FOOTPRINT = 280
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -34,10 +34,17 @@ const ELK_OPTIONS = {
   // averages out that rounding bias.
   'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
   'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-  // Spacing tuned so the BOO_ENVELOPE (340px, accounts for orbital
+  // Spacing tuned so the BOO_ENVELOPE (280px, accounts for orbital
   // children when expanded) clears between siblings AND between layers
   // with room for the bezier-curve dependency edge + arrowhead.
   'elk.spacing.nodeNode': '100',
+  // Inter-layer spacing scales with the natural width of the widest
+  // layer. For star-shaped teams (one operator + many siblings on layer 2)
+  // ELK produces a wide-and-short layout that leaves lots of vertical
+  // empty space when fit into a wider-than-tall canvas. Spreading layers
+  // farther apart vertically pushes the layout aspect closer to the
+  // canvas aspect, eliminating the top / bottom empty bands without
+  // changing the topology. Set per-layout in computeElkLayout.
   'elk.layered.spacing.nodeNodeBetweenLayers': '140',
   'elk.padding': '[top=40, left=40, bottom=40, right=40]',
 }
@@ -46,11 +53,14 @@ const ELK_OPTIONS = {
 // The Boo renders centered inside this envelope (see BOO_FOOTPRINT in
 // `nodes/BooNode.tsx`) so the visible Boo shape (75–78px circle / 220×120
 // card) is anchored at envelope center — keeping ELK's sibling spacing math
-// honest about where edges actually converge. Sized to clear the card's
-// diagonal half-extent (~125px) plus the orbital children: skills on an
-// inner ring at 150–220px and resources on an outer ring at 230–285px.
-const BOO_ENVELOPE_WIDTH = 340
-const BOO_ENVELOPE_HEIGHT = 340
+// honest about where edges actually converge.
+//
+// Tuned tighter than the orbital outer ring (220 px) so fitView can pack the
+// canvas without leaving large empty bands on either side. Adjacent siblings'
+// OUTER rings can briefly overlap in the gap region when BOTH parents are
+// expanded — that's the trade-off for the boost in idle Boo legibility.
+const BOO_ENVELOPE_WIDTH = 280
+const BOO_ENVELOPE_HEIGHT = 280
 
 // ─── Default node dimensions (used before ReactFlow measures them) ────────────
 
@@ -66,6 +76,75 @@ function defaultHeight(nodeType: string | undefined): number {
   return 60
 }
 
+// ─── Aspect-ratio post-processing ────────────────────────────────────────────
+// ELK lays out a hierarchy by topology, not by canvas geometry. For a
+// star-shaped team (1 operator + many siblings) the output is wide-and-short;
+// for a chain it's narrow-and-tall. Either shape leaves significant empty
+// space when fit into a canvas with a different aspect ratio (notably the
+// group-chat graph row, which is much wider than tall).
+//
+// `stretchToAspect` rescales node positions so the layout's bounding box
+// aspect matches the target. It only ever spreads nodes apart (never
+// crowds them closer than ELK's collision-aware output), so the topology
+// reads the same — we just claim the canvas's empty bands.
+function stretchToAspect(nodes: GraphNode[], targetAspect: number): GraphNode[] {
+  if (nodes.length < 2 || !Number.isFinite(targetAspect) || targetAspect <= 0) {
+    return nodes
+  }
+  // Compute bbox + position range from Boo positions (skill / resource nodes
+  // follow their parent Boo via computeOrbitalPositions — they shouldn't
+  // drive aspect).
+  const boos = nodes.filter((n) => n.type === 'boo')
+  if (boos.length < 2) return nodes
+  let minX = Infinity,
+    maxX = -Infinity,
+    minY = Infinity,
+    maxY = -Infinity
+  for (const n of boos) {
+    if (n.position.x < minX) minX = n.position.x
+    if (n.position.x > maxX) maxX = n.position.x
+    if (n.position.y < minY) minY = n.position.y
+    if (n.position.y > maxY) maxY = n.position.y
+  }
+  // posRange = distance between leftmost and rightmost POSITIONS (top-left
+  // corners). bbox = posRange + node footprint. We have to scale positions
+  // (not bboxes) to hit a target bbox aspect — so the scale derivation
+  // accounts for the fixed node width / height that doesn't stretch.
+  const posRangeX = maxX - minX
+  const posRangeY = maxY - minY
+  const bboxW = posRangeX + BOO_ENVELOPE_WIDTH
+  const bboxH = posRangeY + BOO_ENVELOPE_HEIGHT
+  if (bboxW <= 0 || bboxH <= 0) return nodes
+  const layoutAspect = bboxW / bboxH
+
+  // Stretch only — never compress (compressing would risk overlapping
+  // sibling envelopes within the same layer).
+  let xScale = 1
+  let yScale = 1
+  if (layoutAspect < targetAspect && posRangeX > 0) {
+    // Want bboxW' = bboxH * targetAspect → posRangeX' = bboxW' - envelope
+    const targetPosRange = Math.max(0, bboxH * targetAspect - BOO_ENVELOPE_WIDTH)
+    xScale = targetPosRange / posRangeX
+  } else if (layoutAspect > targetAspect && posRangeY > 0) {
+    const targetPosRange = Math.max(0, bboxW / targetAspect - BOO_ENVELOPE_HEIGHT)
+    yScale = targetPosRange / posRangeY
+  }
+  if (xScale === 1 && yScale === 1) return nodes
+  // Pivot at the position-range center so the stretch is symmetric.
+  const cx = (minX + maxX) / 2
+  const cy = (minY + maxY) / 2
+  return nodes.map((n) => {
+    if (n.type !== 'boo') return n
+    return {
+      ...n,
+      position: {
+        x: cx + (n.position.x - cx) * xScale,
+        y: cy + (n.position.y - cy) * yScale,
+      },
+    }
+  })
+}
+
 // ─── Main layout function ─────────────────────────────────────────────────────
 
 /**
@@ -73,11 +152,17 @@ function defaultHeight(nodeType: string | undefined): number {
  *
  * Nodes that already have a saved position (from a previous user drag or a
  * persisted layout) keep their position; only truly new nodes are placed by ELK.
+ *
+ * `targetAspect`, when provided, runs a post-ELK pass that stretches the
+ * layout's bounding box to match the target aspect ratio (typically the
+ * canvas aspect). This claims empty bands left by ELK's topology-driven
+ * placement when the canvas is much wider or taller than the natural layout.
  */
 export async function computeElkLayout(
   nodes: GraphNode[],
   edges: GraphEdge[],
   savedPositions: LayoutData['positions'],
+  targetAspect?: number,
 ): Promise<GraphNode[]> {
   if (nodes.length === 0) return nodes
 
@@ -113,7 +198,7 @@ export async function computeElkLayout(
     return nodes
   }
 
-  return nodes.map((node) => {
+  const elkResolved = nodes.map((node) => {
     // Prefer user-saved position over ELK result
     if (savedPositions[node.id]) {
       return { ...node, position: savedPositions[node.id]! }
@@ -124,4 +209,6 @@ export async function computeElkLayout(
     }
     return node
   })
+
+  return targetAspect !== undefined ? stretchToAspect(elkResolved, targetAspect) : elkResolved
 }

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -1,4 +1,6 @@
-// GroupChatView — 2-panel resizable layout: GroupChatPanel + GhostGraphPanel.
+// GroupChatView — 2-row resizable layout: GhostGraphPanel on top, GroupChatPanel
+// on bottom. Stacked vertically (full width) so wide team graphs spread out
+// comfortably while the chat area below gets full-width message rendering.
 // Gates the GroupChatPanel behind the team onboarding flow ("Know Your Team"
 // button → agent introductions → user self-introduction → normal chat).
 
@@ -57,13 +59,13 @@ export function GroupChatView({ teamId }: { teamId: string }) {
   // normal chat (or vice versa).
   if (isLoading) {
     return (
-      <Group orientation="horizontal" id="group-chat-h" data-testid="group-chat-view">
-        <Panel defaultSize={50} minSize={25}>
-          <div className="flex h-full items-center justify-center bg-bg" />
-        </Panel>
-        <ResizeHandle direction="horizontal" />
-        <Panel defaultSize={50} minSize={25}>
+      <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+        <Panel defaultSize={45} minSize={20}>
           <GhostGraphPanel />
+        </Panel>
+        <ResizeHandle direction="vertical" />
+        <Panel defaultSize={55} minSize={20}>
+          <div className="flex h-full items-center justify-center bg-bg" />
         </Panel>
       </Group>
     )
@@ -71,8 +73,12 @@ export function GroupChatView({ teamId }: { teamId: string }) {
 
   if (!onboardingComplete) {
     return (
-      <Group orientation="horizontal" id="group-chat-h" data-testid="group-chat-view">
-        <Panel defaultSize={50} minSize={25}>
+      <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+        <Panel defaultSize={45} minSize={20}>
+          <GhostGraphPanel />
+        </Panel>
+        <ResizeHandle direction="vertical" />
+        <Panel defaultSize={55} minSize={20}>
           <TeamOnboardingGate
             teamId={teamId}
             team={team}
@@ -84,22 +90,18 @@ export function GroupChatView({ teamId }: { teamId: string }) {
             onMarkUserIntroduced={markUserIntroduced}
           />
         </Panel>
-        <ResizeHandle direction="horizontal" />
-        <Panel defaultSize={50} minSize={25}>
-          <GhostGraphPanel />
-        </Panel>
       </Group>
     )
   }
 
   return (
-    <Group orientation="horizontal" id="group-chat-h" data-testid="group-chat-view">
-      <Panel defaultSize={50} minSize={25}>
-        <GroupChatPanel teamId={teamId} userIntroText={userIntroText} />
-      </Panel>
-      <ResizeHandle direction="horizontal" />
-      <Panel defaultSize={50} minSize={25}>
+    <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+      <Panel defaultSize={45} minSize={20}>
         <GhostGraphPanel />
+      </Panel>
+      <ResizeHandle direction="vertical" />
+      <Panel defaultSize={55} minSize={20}>
+        <GroupChatPanel teamId={teamId} userIntroText={userIntroText} />
       </Panel>
     </Group>
   )


### PR DESCRIPTION
## Summary

- Refactors `GroupChatView` from a horizontal layout to a vertical layout for a cleaner chat experience.
- Adds custom MiniMap node rendering for Boo nodes to improve graph navigation and visual consistency.
- Refines graph sizing and layout parameters with updated `BooNode` dimensions for better placement and rendering.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed yet — app-level graph/layout UI work unless this is the final release-ready package or CLI change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff