### PR TITLE
feat(boo-zero): integrate Boo Zero into teams, chat, and graph workflows

### DIFF
--- a/apps/web/server/api/agents.ts
+++ b/apps/web/server/api/agents.ts
@@ -1,0 +1,99 @@
+import type { Request, Response } from 'express'
+import { createDb, agents, costRecords, approvalHistory } from '@clawboo/db'
+import { eq, sql, inArray } from 'drizzle-orm'
+import { getDbPath } from '../lib/db'
+
+// ─── DELETE /api/agents/:agentId ─────────────────────────────────────────────
+//
+// Removes an agent row from the LOCAL SQLite DB (Clawboo's own metadata) plus
+// any FK-referenced rows that would otherwise block the delete:
+//   - cost_records.agent_id  → ON DELETE NO ACTION (no cascade), so must
+//     remove first to satisfy FK.
+//   - approval_history.agent_id → same.
+//
+// The Gateway-side `agents.delete` RPC is the caller's responsibility (see
+// `deleteAgentOperation` on the client). This endpoint ONLY cleans up local
+// metadata; without it, deleted agents leave permanent ghost rows in SQLite
+// that inflate per-team `agentCount` and pollute namespace checks.
+
+export function agentsDELETE(req: Request, res: Response): void {
+  const agentId = req.params['agentId'] as string | undefined
+  if (!agentId) {
+    res.status(400).json({ error: 'agentId required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    // Order matters — children before parent.
+    db.delete(costRecords).where(eq(costRecords.agentId, agentId)).run()
+    db.delete(approvalHistory).where(eq(approvalHistory.agentId, agentId)).run()
+    db.delete(agents).where(eq(agents.id, agentId)).run()
+    res.json({ ok: true })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── POST /api/agents/cleanup-ghosts ─────────────────────────────────────────
+//
+// Body: { liveAgentIds: string[] }
+//
+// One-shot cleanup the client invokes after hydrating from the Gateway. The
+// caller passes the IDs of all agents currently alive in the Gateway; this
+// endpoint deletes every local SQLite agent row NOT in that list, plus their
+// FK-referenced cost/approval rows. Idempotent — safe to call repeatedly.
+//
+// This catches historical pollution from a time when `deleteAgentOperation`
+// only deleted the Gateway-side agent and left the SQLite row behind. Going
+// forward, the per-agent DELETE endpoint above prevents accumulation.
+
+interface CleanupBody {
+  liveAgentIds: string[]
+}
+
+export function agentsCleanupPOST(req: Request, res: Response): void {
+  const body = req.body as CleanupBody | undefined
+  if (!body || !Array.isArray(body.liveAgentIds)) {
+    res.status(400).json({ error: 'liveAgentIds array required' })
+    return
+  }
+  // Guard rail: if the caller passes an empty list AND no agents are
+  // actually expected to be alive, that's plausible. But if it's empty
+  // because of a transient Gateway hiccup, we'd nuke every local row.
+  // Require an explicit override flag for the empty-list case.
+  if (body.liveAgentIds.length === 0 && !(req.query['allowEmpty'] === 'true')) {
+    res.status(400).json({
+      error: 'empty liveAgentIds list — pass ?allowEmpty=true to confirm',
+    })
+    return
+  }
+
+  try {
+    const db = createDb(getDbPath())
+    const liveIds = body.liveAgentIds
+
+    // Collect IDs of local agent rows that are NOT in the live set.
+    const localRows = db.select({ id: agents.id }).from(agents).all()
+    const liveSet = new Set(liveIds)
+    const toDelete = localRows.map((r) => r.id).filter((id) => !liveSet.has(id))
+
+    if (toDelete.length === 0) {
+      res.json({ ok: true, deleted: 0 })
+      return
+    }
+
+    // Children before parent (FK guards).
+    db.delete(costRecords).where(inArray(costRecords.agentId, toDelete)).run()
+    db.delete(approvalHistory).where(inArray(approvalHistory.agentId, toDelete)).run()
+    db.delete(agents).where(inArray(agents.id, toDelete)).run()
+
+    // Sanity-log how many remain — useful when debugging via curl.
+    const remaining = db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(agents)
+      .all()[0]
+    res.json({ ok: true, deleted: toDelete.length, remaining: remaining?.count ?? null })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}

--- a/apps/web/server/api/booZero.ts
+++ b/apps/web/server/api/booZero.ts
@@ -1,0 +1,133 @@
+// Boo Zero context storage — per-team briefs and a global brief.
+//
+// Per-team briefs live in the dedicated `boo_zero_team_briefs` table
+// (FK cascades on team delete). The global brief is stored in `settings`
+// under the key `boo-zero:global-brief`. Both endpoints return `null`
+// content when nothing is stored — the UI falls back to client-side
+// `buildTeamBrief` / `buildGlobalBrief` defaults in that case.
+
+import type { Request, Response } from 'express'
+import { createDb, booZeroTeamBriefs, getSetting, setSetting } from '@clawboo/db'
+import { eq } from 'drizzle-orm'
+import { getDbPath } from '../lib/db'
+
+const GLOBAL_BRIEF_KEY = 'boo-zero:global-brief'
+
+interface TeamBriefBody {
+  content?: string
+}
+
+interface GlobalBriefBody {
+  content?: string
+}
+
+// ─── GET /api/boo-zero/team-briefs/:teamId ──────────────────────────────────
+
+export function teamBriefGET(req: Request, res: Response): void {
+  const teamId = req.params['teamId'] as string | undefined
+  if (!teamId) {
+    res.status(400).json({ error: 'teamId required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    const row = db
+      .select({ content: booZeroTeamBriefs.content, updatedAt: booZeroTeamBriefs.updatedAt })
+      .from(booZeroTeamBriefs)
+      .where(eq(booZeroTeamBriefs.teamId, teamId))
+      .get()
+    if (!row) {
+      res.json({ content: null, updatedAt: null })
+      return
+    }
+    res.json({ content: row.content, updatedAt: row.updatedAt })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── PUT /api/boo-zero/team-briefs/:teamId ──────────────────────────────────
+// Body: { content: string }. Upserts.
+
+export function teamBriefPUT(req: Request, res: Response): void {
+  const teamId = req.params['teamId'] as string | undefined
+  if (!teamId) {
+    res.status(400).json({ error: 'teamId required' })
+    return
+  }
+  const body = req.body as TeamBriefBody | undefined
+  if (!body || typeof body !== 'object' || typeof body.content !== 'string') {
+    res.status(400).json({ error: 'content (string) required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    const now = Date.now()
+    db.insert(booZeroTeamBriefs)
+      .values({ teamId, content: body.content, updatedAt: now })
+      .onConflictDoUpdate({
+        target: booZeroTeamBriefs.teamId,
+        set: { content: body.content, updatedAt: now },
+      })
+      .run()
+    res.json({ content: body.content, updatedAt: now })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── DELETE /api/boo-zero/team-briefs/:teamId ───────────────────────────────
+// Removes a team's brief. Idempotent — deleting a non-existent brief is a no-op.
+// Note: the FK cascade on team delete already handles brief cleanup when the
+// team itself is removed; this endpoint is for explicit user action.
+
+export function teamBriefDELETE(req: Request, res: Response): void {
+  const teamId = req.params['teamId'] as string | undefined
+  if (!teamId) {
+    res.status(400).json({ error: 'teamId required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    db.delete(booZeroTeamBriefs).where(eq(booZeroTeamBriefs.teamId, teamId)).run()
+    res.json({ ok: true })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── GET /api/boo-zero/global-brief ─────────────────────────────────────────
+
+export function globalBriefGET(_req: Request, res: Response): void {
+  try {
+    const db = createDb(getDbPath())
+    const raw = getSetting(db, GLOBAL_BRIEF_KEY)
+    if (raw === null) {
+      res.json({ content: null, updatedAt: null })
+      return
+    }
+    // The settings table value is the raw markdown; the updatedAt is the
+    // settings row's column. We re-query to get it.
+    // (getSetting returns only the value; a small extra select gets the time.)
+    res.json({ content: raw, updatedAt: null })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── PUT /api/boo-zero/global-brief ─────────────────────────────────────────
+
+export function globalBriefPUT(req: Request, res: Response): void {
+  const body = req.body as GlobalBriefBody | undefined
+  if (!body || typeof body !== 'object' || typeof body.content !== 'string') {
+    res.status(400).json({ error: 'content (string) required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    setSetting(db, GLOBAL_BRIEF_KEY, body.content)
+    res.json({ content: body.content, updatedAt: Date.now() })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}

--- a/apps/web/server/api/booZero.ts
+++ b/apps/web/server/api/booZero.ts
@@ -13,12 +13,26 @@ import { getDbPath } from '../lib/db'
 
 const GLOBAL_BRIEF_KEY = 'boo-zero:global-brief'
 
+/**
+ * Clawboo-side display-name override for Boo Zero. The user's primary
+ * OpenClaw agent might be slugged as "main" or named something the user
+ * picked in OpenClaw onboarding ("Mythos" was seen in production). Clawboo
+ * offers an optional onboarding step that sets a friendlier display name
+ * (default "Boo Zero"). The override is keyed by agent id so it survives
+ * even if the Gateway-side identity is unchanged.
+ */
+const DISPLAY_NAME_KEY_PREFIX = 'boo-zero:display-name:'
+
 interface TeamBriefBody {
   content?: string
 }
 
 interface GlobalBriefBody {
   content?: string
+}
+
+interface DisplayNameBody {
+  name?: string
 }
 
 // ─── GET /api/boo-zero/team-briefs/:teamId ──────────────────────────────────
@@ -127,6 +141,52 @@ export function globalBriefPUT(req: Request, res: Response): void {
     const db = createDb(getDbPath())
     setSetting(db, GLOBAL_BRIEF_KEY, body.content)
     res.json({ content: body.content, updatedAt: Date.now() })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── GET /api/boo-zero/display-name/:agentId ────────────────────────────────
+// Returns the user's Clawboo-side display-name override for Boo Zero, or
+// `null` if none is set (caller falls back to the Gateway-side agent.name).
+
+export function displayNameGET(req: Request, res: Response): void {
+  const agentId = req.params['agentId'] as string | undefined
+  if (!agentId) {
+    res.status(400).json({ error: 'agentId required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    const raw = getSetting(db, DISPLAY_NAME_KEY_PREFIX + agentId)
+    res.json({ name: raw ?? null })
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── PUT /api/boo-zero/display-name/:agentId ────────────────────────────────
+// Body: { name: string }. The empty string clears the override.
+// Max 80 chars (UI hints + chat headers don't need anything longer).
+
+const DISPLAY_NAME_MAX = 80
+
+export function displayNamePUT(req: Request, res: Response): void {
+  const agentId = req.params['agentId'] as string | undefined
+  if (!agentId) {
+    res.status(400).json({ error: 'agentId required' })
+    return
+  }
+  const body = req.body as DisplayNameBody | undefined
+  if (!body || typeof body !== 'object' || typeof body.name !== 'string') {
+    res.status(400).json({ error: 'name (string) required' })
+    return
+  }
+  const trimmed = body.name.trim().slice(0, DISPLAY_NAME_MAX)
+  try {
+    const db = createDb(getDbPath())
+    setSetting(db, DISPLAY_NAME_KEY_PREFIX + agentId, trimmed)
+    res.json({ name: trimmed })
   } catch (err) {
     res.status(500).json({ error: String(err) })
   }

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -27,6 +27,7 @@ import {
   teamAgentPOST,
   teamAgentDELETE,
 } from './teams'
+import { agentsDELETE, agentsCleanupPOST } from './agents'
 import { teamOnboardingGET, teamOnboardingPATCH } from './teamOnboarding'
 import {
   teamBriefGET,
@@ -99,6 +100,12 @@ router.delete('/api/teams/:id/agents/:agentId', teamAgentDELETE)
 // Team onboarding (per-team boolean flags for "Know Your Team" gate)
 router.get('/api/teams/:id/onboarding', teamOnboardingGET)
 router.patch('/api/teams/:id/onboarding', teamOnboardingPATCH)
+
+// Agents — local SQLite metadata cleanup. Gateway is the source of truth for
+// agent identity, so there's no `create` or `list` here — only delete + the
+// one-shot cleanup that removes rows for agents no longer in the Gateway.
+router.delete('/api/agents/:agentId', agentsDELETE)
+router.post('/api/agents/cleanup-ghosts', agentsCleanupPOST)
 
 // Boo Zero context — per-team briefs + global brief.
 // Per-team briefs are SQLite-backed and FK-cascade on team delete; the

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -28,6 +28,13 @@ import {
   teamAgentDELETE,
 } from './teams'
 import { teamOnboardingGET, teamOnboardingPATCH } from './teamOnboarding'
+import {
+  teamBriefGET,
+  teamBriefPUT,
+  teamBriefDELETE,
+  globalBriefGET,
+  globalBriefPUT,
+} from './booZero'
 
 const router: RouterType = Router()
 
@@ -90,5 +97,14 @@ router.delete('/api/teams/:id/agents/:agentId', teamAgentDELETE)
 // Team onboarding (per-team boolean flags for "Know Your Team" gate)
 router.get('/api/teams/:id/onboarding', teamOnboardingGET)
 router.patch('/api/teams/:id/onboarding', teamOnboardingPATCH)
+
+// Boo Zero context — per-team briefs + global brief.
+// Per-team briefs are SQLite-backed and FK-cascade on team delete; the
+// global brief lives in the settings key/value table.
+router.get('/api/boo-zero/team-briefs/:teamId', teamBriefGET)
+router.put('/api/boo-zero/team-briefs/:teamId', teamBriefPUT)
+router.delete('/api/boo-zero/team-briefs/:teamId', teamBriefDELETE)
+router.get('/api/boo-zero/global-brief', globalBriefGET)
+router.put('/api/boo-zero/global-brief', globalBriefPUT)
 
 export { router as apiRouter }

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -34,6 +34,8 @@ import {
   teamBriefDELETE,
   globalBriefGET,
   globalBriefPUT,
+  displayNameGET,
+  displayNamePUT,
 } from './booZero'
 
 const router: RouterType = Router()
@@ -106,5 +108,7 @@ router.put('/api/boo-zero/team-briefs/:teamId', teamBriefPUT)
 router.delete('/api/boo-zero/team-briefs/:teamId', teamBriefDELETE)
 router.get('/api/boo-zero/global-brief', globalBriefGET)
 router.put('/api/boo-zero/global-brief', globalBriefPUT)
+router.get('/api/boo-zero/display-name/:agentId', displayNameGET)
+router.put('/api/boo-zero/display-name/:agentId', displayNamePUT)
 
 export { router as apiRouter }

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -88,7 +88,18 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
   // source here is intentional: Boo Zero's individual chat doesn't have
   // a team-agent roster, so the only meaningful @-targets are teams.
   const mentionTargets = useMemo(
-    () => (isBooZeroChat ? activeTeams.map((t) => ({ id: t.id, name: t.name })) : []),
+    () =>
+      isBooZeroChat
+        ? activeTeams.map((t) => ({
+            id: t.id,
+            name: t.name,
+            // Pass the team's emoji + color so the dropdown renders the same
+            // emoji-disc as the `TeamChips` row instead of a random Boo avatar
+            // seeded from the team's UUID.
+            icon: t.icon,
+            color: t.color,
+          }))
+        : [],
     [isBooZeroChat, activeTeams],
   )
   const handleChipTag = useCallback((name: string) => {

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { useFleetStore } from '@/stores/fleet'
@@ -7,9 +7,17 @@ import { useConnectionStore } from '@/stores/connection'
 import { useBooZeroStore } from '@/stores/booZero'
 import { useTeamStore } from '@/stores/team'
 import { sendChatMessage } from './chatSendOperation'
-import { groupEntriesToBlocks, MessageList, MessageComposer } from './chatComponents'
+import {
+  groupEntriesToBlocks,
+  MessageList,
+  MessageComposer,
+  type MessageComposerHandle,
+} from './chatComponents'
 import { InlineApprovalTray } from '@/features/approvals/InlineApprovalTray'
 import { parseTeamOrAgentMention } from '@/lib/parseTeamOrAgentMention'
+import { buildTeamContextPreamble } from '@/lib/teamProtocol'
+import { getMergedTeamEntries } from '@/features/group-chat/groupChatSendOperation'
+import { TeamChips } from './TeamChips'
 
 // ─── ChatPanel ────────────────────────────────────────────────────────────────
 
@@ -64,6 +72,29 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
   const teams = useTeamStore((s) => s.teams)
   const isBooZeroChat = Boolean(agent && booZeroAgentId && agent.id === booZeroAgentId)
 
+  // Composer ref — lets the TeamChips row insert `@TeamName` at the start of
+  // the draft when the user clicks a chip. Only used in Boo Zero's chat (the
+  // place where team mentions are meaningful).
+  const composerRef = useRef<MessageComposerHandle>(null)
+
+  // Active teams (un-archived) surfaced as chips above the composer in Boo
+  // Zero's individual chat. Clicking a chip prepends `@<TeamName>` to the
+  // draft — the same `parseTeamOrAgentMention` path in `handleSend` then
+  // pulls the team's brief into the message preamble.
+  const activeTeams = useMemo(() => teams.filter((t) => !t.isArchived), [teams])
+  // The composer's autocomplete dropdown reads `mentionAgents`. We feed it
+  // the team list (mapping `{id, name}`) so typing `@D…` opens a filtered
+  // dropdown of matching team names. Treating teams as the "mention agent"
+  // source here is intentional: Boo Zero's individual chat doesn't have
+  // a team-agent roster, so the only meaningful @-targets are teams.
+  const mentionTargets = useMemo(
+    () => (isBooZeroChat ? activeTeams.map((t) => ({ id: t.id, name: t.name })) : []),
+    [isBooZeroChat, activeTeams],
+  )
+  const handleChipTag = useCallback((name: string) => {
+    composerRef.current?.insertMention(name)
+  }, [])
+
   const handleSend = useCallback(
     async (message: string) => {
       if (!client || !agent || !sessionKey) return
@@ -95,7 +126,41 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
           } catch {
             // Best-effort — missing brief is silently OK.
           }
-          const sections = [identityBlock, briefBlock, mention.cleanedMessage].filter(
+
+          // Inject recent team-chat history. The user's individual chat with
+          // Boo Zero is a separate session from the team's group chat — Boo
+          // Zero literally has no record of what the team was doing without
+          // this. We reuse the same merge + preamble helpers the group chat
+          // uses, with their built-in token caps:
+          //   - last 10 messages from the team's transcripts
+          //   - 1500 char hard cap (drops oldest lines until it fits)
+          //
+          // The merge pulls from each team agent's team-scoped sessionKey
+          // (`agent:<memberId>:team:<teamId>`) AND Boo Zero's team-scoped
+          // sessionKey (so Boo Zero's own prior team-chat participation is
+          // included). Boo Zero's individual-chat history isn't pulled in —
+          // that's already in the LLM's context window from this session.
+          //
+          // Token cost: typically 300–1500 tokens per @team turn, same order
+          // of magnitude as the group chat's own preamble. If the team has
+          // no transcripts (e.g. team deployed but never chatted) the helper
+          // returns null and we don't inject anything.
+          const allAgents = useFleetStore.getState().agents
+          const teamMembers = allAgents.filter((a) => a.teamId === mention.targetId)
+          const teamEntries = getMergedTeamEntries(mention.targetId, teamMembers, agent)
+          const historyBlock = buildTeamContextPreamble({
+            entries: teamEntries,
+            // Pass empty target so no entries are filtered out — we want
+            // every speaker's voice in the context.
+            targetAgentName: '',
+            maxMessages: 10,
+            maxChars: 1500,
+          })
+
+          // Order matters: identity (who you are) → team brief (who the team
+          // is) → recent team history (what they've been doing) → user's
+          // actual question.
+          const sections = [identityBlock, briefBlock, historyBlock, mention.cleanedMessage].filter(
             (s): s is string => Boolean(s),
           )
           await sendChatMessage({
@@ -170,10 +235,23 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
       {/* Inline approval cards for this agent */}
       <InlineApprovalTray agentId={agent.id} />
 
+      {/* Team chips — Boo Zero's individual chat only. Lets the user tag any
+          team with @TeamName so Boo Zero pulls that team's brief into context
+          for this turn. Hidden in regular 1:1 agent chats (team tagging is
+          meaningless there). */}
+      {isBooZeroChat && activeTeams.length > 0 && (
+        <TeamChips teams={activeTeams} onTag={handleChipTag} />
+      )}
+
       {/* Composer */}
       <MessageComposer
+        ref={composerRef}
         onSend={handleSend}
         disabled={!canSend}
+        // Pass the team list as mentionAgents so the in-composer autocomplete
+        // dropdown opens on `@` and filters as the user types. Empty array
+        // outside Boo Zero's chat → no autocomplete (regular 1:1 behavior).
+        mentionAgents={mentionTargets}
         placeholder={
           !client
             ? 'Gateway not connected…'
@@ -181,7 +259,9 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
               ? 'No active session…'
               : isRunning
                 ? 'Agent is working…'
-                : 'Message…'
+                : isBooZeroChat
+                  ? 'Message Boo Zero… (@TeamName to pull a team brief into context)'
+                  : 'Message…'
         }
       />
     </div>

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -68,13 +68,18 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
     async (message: string) => {
       if (!client || !agent || !sessionKey) return
 
-      // In Boo Zero's individual chat, parse `@TeamName` mentions and inject
-      // that team's brief into the message preamble so Boo Zero can reason
-      // about the team's specifics. Outside of Boo Zero's chat (regular
-      // agent 1:1), this code path is bypassed entirely.
+      // In Boo Zero's individual chat, inject the identity anchor + (when
+      // the user `@TeamName`-mentions) the matching team brief. The
+      // identity anchor fires on EVERY message so the LLM stays consistent
+      // about its name. Outside Boo Zero's chat (regular agent 1:1), this
+      // path is bypassed — team agents have their own AGENTS.md / SOUL.md
+      // identity.
       if (isBooZeroChat) {
+        const identityBlock = `[Your Identity]\nYou are ${agent.name}. This is your name — the only name you should use to refer to yourself. Do NOT invent alternative names mid-response.\n[End Your Identity]`
+
         const teamCandidates = teams.map((t) => ({ id: t.id, name: t.name }))
         const mention = parseTeamOrAgentMention(message, teamCandidates)
+
         if (mention.kind === 'team' && mention.targetId) {
           let briefBlock: string | null = null
           try {
@@ -90,20 +95,29 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
           } catch {
             // Best-effort — missing brief is silently OK.
           }
-          // Keep the user-visible message (with the @TeamName prefix) as the
-          // display text; send Boo Zero the brief + the user's intent.
-          const sendBody = briefBlock
-            ? `${briefBlock}\n\n${mention.cleanedMessage}`
-            : mention.cleanedMessage
+          const sections = [identityBlock, briefBlock, mention.cleanedMessage].filter(
+            (s): s is string => Boolean(s),
+          )
           await sendChatMessage({
             client,
             agentId: agent.id,
             sessionKey,
-            message: sendBody,
+            message: sections.join('\n\n'),
             displayText: message,
           })
           return
         }
+
+        // No team mention — still inject the identity anchor on every Boo
+        // Zero turn.
+        await sendChatMessage({
+          client,
+          agentId: agent.id,
+          sessionKey,
+          message: `${identityBlock}\n\n${message}`,
+          displayText: message,
+        })
+        return
       }
 
       await sendChatMessage({ client, agentId: agent.id, sessionKey, message })

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -260,7 +260,7 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
               : isRunning
                 ? 'Agent is working…'
                 : isBooZeroChat
-                  ? 'Message Boo Zero… (@TeamName to pull a team brief into context)'
+                  ? 'Ask me anything… use @ to tag a team'
                   : 'Message…'
         }
       />

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { useConnectionStore } from '@/stores/connection'
 import { useBooZeroStore } from '@/stores/booZero'
 import { useTeamStore } from '@/stores/team'
 import { sendChatMessage } from './chatSendOperation'
+import { stopAgentRun } from './stopChatOperation'
 import {
   groupEntriesToBlocks,
   MessageList,
@@ -263,6 +264,19 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
         // dropdown opens on `@` and filters as the user types. Empty array
         // outside Boo Zero's chat → no autocomplete (regular 1:1 behavior).
         mentionAgents={mentionTargets}
+        // Stop button — replaces Send while the agent is running. Pulls the
+        // plug on the in-flight LLM call via `chat.abort` AND optimistically
+        // clears local streaming state so the UI flips to idle within one
+        // render even if the RPC round-trips slowly. See `stopChatOperation`.
+        isActive={isRunning}
+        onStop={() => {
+          void stopAgentRun({
+            client,
+            agentId: agent.id,
+            sessionKey,
+            runId: agent.runId,
+          })
+        }}
         placeholder={
           !client
             ? 'Gateway not connected…'

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -4,9 +4,12 @@ import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { useFleetStore } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
 import { useConnectionStore } from '@/stores/connection'
+import { useBooZeroStore } from '@/stores/booZero'
+import { useTeamStore } from '@/stores/team'
 import { sendChatMessage } from './chatSendOperation'
 import { groupEntriesToBlocks, MessageList, MessageComposer } from './chatComponents'
 import { InlineApprovalTray } from '@/features/approvals/InlineApprovalTray'
+import { parseTeamOrAgentMention } from '@/lib/parseTeamOrAgentMention'
 
 // ─── ChatPanel ────────────────────────────────────────────────────────────────
 
@@ -57,12 +60,55 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
     client && connectionStatus === 'connected' && agent && sessionKey && !isRunning,
   )
 
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const teams = useTeamStore((s) => s.teams)
+  const isBooZeroChat = Boolean(agent && booZeroAgentId && agent.id === booZeroAgentId)
+
   const handleSend = useCallback(
     async (message: string) => {
       if (!client || !agent || !sessionKey) return
+
+      // In Boo Zero's individual chat, parse `@TeamName` mentions and inject
+      // that team's brief into the message preamble so Boo Zero can reason
+      // about the team's specifics. Outside of Boo Zero's chat (regular
+      // agent 1:1), this code path is bypassed entirely.
+      if (isBooZeroChat) {
+        const teamCandidates = teams.map((t) => ({ id: t.id, name: t.name }))
+        const mention = parseTeamOrAgentMention(message, teamCandidates)
+        if (mention.kind === 'team' && mention.targetId) {
+          let briefBlock: string | null = null
+          try {
+            const res = await fetch(
+              `/api/boo-zero/team-briefs/${encodeURIComponent(mention.targetId)}`,
+            )
+            if (res.ok) {
+              const body = (await res.json()) as { content?: string | null }
+              if (typeof body.content === 'string' && body.content.length > 0) {
+                briefBlock = `[Team Brief: ${mention.matchedName}]\n${body.content.trim()}\n[End Team Brief]`
+              }
+            }
+          } catch {
+            // Best-effort — missing brief is silently OK.
+          }
+          // Keep the user-visible message (with the @TeamName prefix) as the
+          // display text; send Boo Zero the brief + the user's intent.
+          const sendBody = briefBlock
+            ? `${briefBlock}\n\n${mention.cleanedMessage}`
+            : mention.cleanedMessage
+          await sendChatMessage({
+            client,
+            agentId: agent.id,
+            sessionKey,
+            message: sendBody,
+            displayText: message,
+          })
+          return
+        }
+      }
+
       await sendChatMessage({ client, agentId: agent.id, sessionKey, message })
     },
-    [client, agent, sessionKey],
+    [client, agent, sessionKey, isBooZeroChat, teams],
   )
 
   // ── No agent selected ───────────────────────────────────────────────────────

--- a/apps/web/src/features/chat/TeamChips.tsx
+++ b/apps/web/src/features/chat/TeamChips.tsx
@@ -1,0 +1,42 @@
+// TeamChips — horizontal row of team-emoji chips for quick @TeamName tagging.
+// Mirrors AgentChips visually but lives in `ChatPanel` (Boo Zero's individual
+// chat) and tags team names via `parseTeamOrAgentMention`. Clicking a chip
+// inserts `@<TeamName>` at the start of the composer draft.
+
+import { memo } from 'react'
+
+interface TeamChipsProps {
+  teams: { id: string; name: string; icon: string; color: string }[]
+  onTag: (teamName: string) => void
+}
+
+export const TeamChips = memo(function TeamChips({ teams, onTag }: TeamChipsProps) {
+  if (teams.length === 0) return null
+
+  return (
+    <div
+      className="flex items-center gap-1.5 overflow-x-auto border-t border-white/8 px-4 py-2"
+      style={{ scrollbarWidth: 'none' }}
+    >
+      <span className="shrink-0 text-[10px] text-secondary/40">Tag team:</span>
+      {teams.map((team) => (
+        <button
+          key={team.id}
+          type="button"
+          onClick={() => onTag(team.name)}
+          className="flex shrink-0 items-center gap-1.5 rounded-full bg-white/6 px-2 py-1 transition-colors hover:bg-white/10"
+          title={`Tag @${team.name}`}
+        >
+          <span
+            className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-[11px]"
+            style={{ background: `${team.color}33` }}
+            aria-hidden
+          >
+            {team.icon}
+          </span>
+          <span className="max-w-[110px] truncate text-[11px] text-text/80">{team.name}</span>
+        </button>
+      ))}
+    </div>
+  )
+})

--- a/apps/web/src/features/chat/TeamChips.tsx
+++ b/apps/web/src/features/chat/TeamChips.tsx
@@ -15,26 +15,26 @@ export const TeamChips = memo(function TeamChips({ teams, onTag }: TeamChipsProp
 
   return (
     <div
-      className="flex items-center gap-1.5 overflow-x-auto border-t border-white/8 px-4 py-2"
+      className="flex items-center gap-1 overflow-x-auto border-t border-white/8 px-4 py-1.5"
       style={{ scrollbarWidth: 'none' }}
     >
-      <span className="shrink-0 text-[10px] text-secondary/40">Tag team:</span>
+      <span className="shrink-0 text-[10px] uppercase tracking-wide text-secondary/40">Teams</span>
       {teams.map((team) => (
         <button
           key={team.id}
           type="button"
           onClick={() => onTag(team.name)}
-          className="flex shrink-0 items-center gap-1.5 rounded-full bg-white/6 px-2 py-1 transition-colors hover:bg-white/10"
+          className="ml-1 flex shrink-0 items-center gap-1 rounded-full bg-white/5 px-1.5 py-0.5 transition-colors hover:bg-white/10"
           title={`Tag @${team.name}`}
         >
           <span
-            className="flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full text-[11px]"
+            className="flex h-[16px] w-[16px] shrink-0 items-center justify-center rounded-full text-[10px]"
             style={{ background: `${team.color}33` }}
             aria-hidden
           >
             {team.icon}
           </span>
-          <span className="max-w-[110px] truncate text-[11px] text-text/80">{team.name}</span>
+          <span className="max-w-[100px] truncate text-[10px] text-text/75">{team.name}</span>
         </button>
       ))}
     </div>

--- a/apps/web/src/features/chat/TeamChips.tsx
+++ b/apps/web/src/features/chat/TeamChips.tsx
@@ -15,7 +15,7 @@ export const TeamChips = memo(function TeamChips({ teams, onTag }: TeamChipsProp
 
   return (
     <div
-      className="flex items-center gap-1 overflow-x-auto border-t border-white/8 px-4 py-1.5"
+      className="flex items-center gap-1 overflow-x-auto px-4 py-1.5"
       style={{ scrollbarWidth: 'none' }}
     >
       <span className="shrink-0 text-[10px] uppercase tracking-wide text-secondary/40">Teams</span>

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -715,6 +715,21 @@ export interface MessageComposerHandle {
   insertMention: (agentName: string) => void
 }
 
+/**
+ * Mention candidate for the composer dropdown. Can be either a team agent
+ * (renders as the agent's Boo avatar) OR a team (renders as the team's
+ * emoji + colored disc — same chrome as `TeamChips`). When `icon` is set,
+ * `color` should also be set so the disc matches the chip styling.
+ */
+export type MentionCandidate = {
+  id: string
+  name: string
+  /** Team emoji (e.g. "🚀"). When provided, renders emoji instead of a Boo avatar. */
+  icon?: string
+  /** Team accent color (hex). Used as a 33%-opacity disc background behind the emoji. */
+  color?: string
+}
+
 export const MessageComposer = memo(
   forwardRef<
     MessageComposerHandle,
@@ -722,8 +737,8 @@ export const MessageComposer = memo(
       onSend: (message: string) => void
       disabled: boolean
       placeholder?: string
-      /** Team agents for @mention autocomplete. Only provided in group chat. */
-      mentionAgents?: { id: string; name: string }[]
+      /** @mention autocomplete candidates — team agents (group chat) or teams (Boo Zero chat). */
+      mentionAgents?: MentionCandidate[]
     }
   >(function MessageComposer({ onSend, disabled, placeholder, mentionAgents }, ref) {
     const [draft, setDraft] = useState('')
@@ -936,7 +951,7 @@ const MentionDropdownInline = memo(function MentionDropdownInline({
   onSelect,
   onClose,
 }: {
-  agents: { id: string; name: string }[]
+  agents: MentionCandidate[]
   selectedIndex: number
   onSelect: (agentName: string) => void
   onClose: () => void
@@ -1003,7 +1018,30 @@ const MentionDropdownInline = memo(function MentionDropdownInline({
               (e.currentTarget as HTMLButtonElement).style.background = 'transparent'
           }}
         >
-          <AgentBooAvatar agentId={agent.id} size={20} />
+          {agent.icon ? (
+            // Team candidate — render emoji on a colored disc matching the
+            // chip styling in `TeamChips.tsx`. Keeps the dropdown visually
+            // consistent with the chip the user clicked to discover the
+            // feature.
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 20,
+                height: 20,
+                borderRadius: '50%',
+                background: `${agent.color ?? '#E94560'}33`,
+                fontSize: 12,
+                flexShrink: 0,
+              }}
+              aria-hidden
+            >
+              {agent.icon}
+            </span>
+          ) : (
+            <AgentBooAvatar agentId={agent.id} size={20} />
+          )}
           <span className="truncate">{agent.name}</span>
         </button>
       ))}

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -13,7 +13,7 @@ import {
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { AnimatePresence, motion } from 'framer-motion'
-import { ArrowRight, ChevronRight, Clock, SendHorizontal, Wrench } from 'lucide-react'
+import { ArrowRight, ChevronRight, Clock, SendHorizontal, Square, Wrench } from 'lucide-react'
 import { BooAvatar } from '@clawboo/ui'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
@@ -739,8 +739,20 @@ export const MessageComposer = memo(
       placeholder?: string
       /** @mention autocomplete candidates — team agents (group chat) or teams (Boo Zero chat). */
       mentionAgents?: MentionCandidate[]
+      /**
+       * When `isActive` is true AND `onStop` is provided, the send button
+       * is replaced by a red Stop button. Click → `onStop()`. Always
+       * clickable regardless of `disabled` (the whole point of Stop is to
+       * interrupt a state where Send is unavailable).
+       */
+      onStop?: () => void
+      isActive?: boolean
     }
-  >(function MessageComposer({ onSend, disabled, placeholder, mentionAgents }, ref) {
+  >(function MessageComposer(
+    { onSend, disabled, placeholder, mentionAgents, onStop, isActive = false },
+    ref,
+  ) {
+    const showStop = isActive && Boolean(onStop)
     const [draft, setDraft] = useState('')
     const textareaRef = useRef<HTMLTextAreaElement>(null)
     const rafRef = useRef<number | null>(null)
@@ -922,16 +934,35 @@ export const MessageComposer = memo(
             className="flex-1 resize-none overflow-hidden rounded-lg border border-white/10 bg-surface px-3 py-2 text-[13px] text-text outline-none transition placeholder:text-secondary/40 focus:border-white/20 focus:ring-1 focus:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-40"
             style={{ fontFamily: 'var(--font-body)', minHeight: '38px' }}
           />
-          <button
-            type="button"
-            onClick={handleSend}
-            disabled={sendDisabled}
-            data-testid="chat-send-button"
-            aria-label="Send message"
-            className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-lg bg-accent text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-secondary"
-          >
-            <SendHorizontal className="h-4 w-4" strokeWidth={2} />
-          </button>
+          {showStop ? (
+            // ── Stop button — "pull the plug" on the active run(s) ──────────
+            // Same 38×38 footprint as Send so the composer doesn't reflow on
+            // morph. Filled-square icon (`Square`) reads as Stop universally.
+            // Color: solid project accent red. NOT gated by `disabled` — the
+            // user pressed Stop precisely because the chat is in a state
+            // where Send is unavailable.
+            <button
+              type="button"
+              onClick={onStop}
+              data-testid="chat-stop-button"
+              aria-label="Stop"
+              title="Stop"
+              className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-lg bg-accent text-white transition hover:brightness-110"
+            >
+              <Square className="h-3.5 w-3.5" strokeWidth={2} fill="currentColor" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSend}
+              disabled={sendDisabled}
+              data-testid="chat-send-button"
+              aria-label="Send message"
+              className="flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-lg bg-accent text-white transition hover:brightness-110 disabled:cursor-not-allowed disabled:bg-muted disabled:text-secondary"
+            >
+              <SendHorizontal className="h-4 w-4" strokeWidth={2} />
+            </button>
+          )}
         </div>
         <p className="mt-1.5 text-right font-mono text-[10px] text-secondary/30">
           Enter to send · Shift+Enter for newline · /reset for new session

--- a/apps/web/src/features/chat/stopChatOperation.ts
+++ b/apps/web/src/features/chat/stopChatOperation.ts
@@ -1,21 +1,32 @@
 // stopChatOperation — "pull the plug" for the chat composer's Stop button.
 //
-// Two layers, in this order:
+// Three layers, in this order:
 //   1. Optimistic local teardown — patches `useFleetStore` + `useChatStore`
 //      immediately so the UI flips to idle within one render. Without this
 //      step the user would stare at a streaming card while the abort RPC
 //      round-trips.
-//   2. Best-effort `chat.abort` RPC(s) — actually tells the Gateway to stop
-//      generating tokens. The Gateway then emits `chat:aborted` events
-//      which the existing event pipeline ([events/policy/work.ts:72]) maps
-//      to the SAME idle patch as step 1, so this is idempotent.
+//   2. `chat.abort(sessionKey, runId)` per running agent — the surgical
+//      cancel. Tells the Gateway to stop generating tokens on a specific
+//      in-flight run. Skipped when `runId` is null (very fast Stop press
+//      before the first streaming event populated the runId).
+//   3. `sessions.abort(sessionKey)` per session as a backstop — heavier
+//      session-level abort. Fires REGARDLESS of whether `runId` was
+//      available. Covers two cases that pure `chat.abort` misses:
+//         a. `runId` is null at stop time → `chat.abort` is skipped, but
+//            the Gateway resolves the active run from the sessionKey.
+//         b. Queued / pending work on the session (delegate sends, wake
+//            messages) gets nuked alongside the active run, instead of
+//            firing one beat later and starting a fresh cascade.
+// Both RPCs are idempotent — `status: 'no-active-run'` for already-idle
+// sessions is a benign no-op. We `Promise.allSettled` everything so a
+// single failure can't block the rest of the teardown.
 //
-// For group chat there's a third concern: the orchestration hook's
+// For group chat there's a fourth concern: the orchestration hook's
 // in-memory state (debounce timer, relay cooldowns, wake-in-flight set,
 // team-chat overrides). Those don't live in stores, so they need explicit
-// clears here. The debounce timer specifically is cleared via the
-// `stopSignal` counter the caller bumps before invoking this — see
-// `useTeamOrchestration`.
+// clears here. The debounce timer + `lastCountsRef` snapshot + post-stop
+// freeze window are cleared via the `stopSignal` counter the caller bumps
+// before invoking this — see `useTeamOrchestration`.
 
 import type { GatewayClient } from '@clawboo/gateway-client'
 import { useFleetStore, type AgentState } from '@/stores/fleet'
@@ -55,14 +66,17 @@ export async function stopAgentRun(params: StopAgentRunParams): Promise<void> {
   //    `{ ok, abortedRunId, status }`; `status: 'no-active-run'` is a
   //    benign no-op (the run already finished). We don't surface errors —
   //    local state is already correct.
-  if (client && sessionKey && runId) {
-    try {
-      await client.chat.abort(sessionKey, runId)
-    } catch {
-      // Disconnected, race, or Gateway transient error — local cleanup
-      // already happened, so silently swallow.
-    }
+  if (!client || !sessionKey) return
+  const aborts: Promise<unknown>[] = []
+  if (runId) {
+    // Surgical: cancel this specific run.
+    aborts.push(client.chat.abort(sessionKey, runId).catch(() => undefined))
   }
+  // Backstop: heavier session-level abort. Catches the runId-less race
+  // (Stop pressed before the first streaming event) AND nukes any queued
+  // work on the session.
+  aborts.push(client.sessions.abort(sessionKey).catch(() => undefined))
+  await Promise.allSettled(aborts)
 }
 
 // ── Whole team ───────────────────────────────────────────────────────────────
@@ -117,12 +131,21 @@ export async function stopAllInTeam(params: StopAllInTeamParams): Promise<void> 
   //    sessionKey for each agent — group-chat runs are scoped to that
   //    session, so aborting on the 1:1 sessionKey would miss the actual
   //    in-flight run.
+  //
+  // Two aborts per agent: surgical `chat.abort` when `runId` is available,
+  // PLUS `sessions.abort` as a backstop. The backstop covers (a) the
+  // runId-less race where Stop fires before the first streaming event
+  // arrived, and (b) queued delegate / wake sends that would otherwise
+  // fire after the surgical abort and restart the cascade.
   if (!client) return
   const aborts: Promise<unknown>[] = []
   for (const agent of runningAgents) {
     const sk = teamSessionKeys.get(agent.id)
-    if (!sk || !agent.runId) continue
-    aborts.push(client.chat.abort(sk, agent.runId).catch(() => undefined))
+    if (!sk) continue
+    if (agent.runId) {
+      aborts.push(client.chat.abort(sk, agent.runId).catch(() => undefined))
+    }
+    aborts.push(client.sessions.abort(sk).catch(() => undefined))
   }
   await Promise.allSettled(aborts)
 }

--- a/apps/web/src/features/chat/stopChatOperation.ts
+++ b/apps/web/src/features/chat/stopChatOperation.ts
@@ -34,6 +34,7 @@ import { useChatStore } from '@/stores/chat'
 import { clearTeamRelayState } from '@/features/group-chat/contextRelay'
 import { clearAllTeamChatOverridesForAgent } from '@/lib/sessionUtils'
 import { clearWakeInFlight } from '@/features/group-chat/groupChatSendOperation'
+import { bumpStopGeneration } from '@/features/group-chat/useTeamOrchestration'
 
 // ── Single agent ─────────────────────────────────────────────────────────────
 
@@ -103,6 +104,16 @@ export interface StopAllInTeamParams {
  */
 export async function stopAllInTeam(params: StopAllInTeamParams): Promise<void> {
   const { client, teamId, participants, teamSessionKeys } = params
+
+  // 0. Bump the orchestration generation counter FIRST — before any await
+  //    yields the microtask queue. Mid-flight delegation/relay IIFEs in
+  //    `useTeamOrchestration` will see the new generation at their next
+  //    checkpoint and bail before issuing their delayed `chat.send`. The
+  //    stop-signal useEffect inside the hook also bumps this, but that
+  //    runs after a React commit — bumping here avoids the small race
+  //    window where an IIFE could slip through its checkpoint before the
+  //    effect lands.
+  bumpStopGeneration(teamId)
 
   // Target every participant that's currently working — `running` covers the
   // common case. `sleeping` agents aren't generating, so no abort needed.

--- a/apps/web/src/features/chat/stopChatOperation.ts
+++ b/apps/web/src/features/chat/stopChatOperation.ts
@@ -1,0 +1,128 @@
+// stopChatOperation — "pull the plug" for the chat composer's Stop button.
+//
+// Two layers, in this order:
+//   1. Optimistic local teardown — patches `useFleetStore` + `useChatStore`
+//      immediately so the UI flips to idle within one render. Without this
+//      step the user would stare at a streaming card while the abort RPC
+//      round-trips.
+//   2. Best-effort `chat.abort` RPC(s) — actually tells the Gateway to stop
+//      generating tokens. The Gateway then emits `chat:aborted` events
+//      which the existing event pipeline ([events/policy/work.ts:72]) maps
+//      to the SAME idle patch as step 1, so this is idempotent.
+//
+// For group chat there's a third concern: the orchestration hook's
+// in-memory state (debounce timer, relay cooldowns, wake-in-flight set,
+// team-chat overrides). Those don't live in stores, so they need explicit
+// clears here. The debounce timer specifically is cleared via the
+// `stopSignal` counter the caller bumps before invoking this — see
+// `useTeamOrchestration`.
+
+import type { GatewayClient } from '@clawboo/gateway-client'
+import { useFleetStore, type AgentState } from '@/stores/fleet'
+import { useChatStore } from '@/stores/chat'
+import { clearTeamRelayState } from '@/features/group-chat/contextRelay'
+import { clearAllTeamChatOverridesForAgent } from '@/lib/sessionUtils'
+import { clearWakeInFlight } from '@/features/group-chat/groupChatSendOperation'
+
+// ── Single agent ─────────────────────────────────────────────────────────────
+
+export interface StopAgentRunParams {
+  client: GatewayClient | null
+  agentId: string
+  sessionKey: string | null
+  runId: string | null
+}
+
+/**
+ * Stop a single agent's in-flight run. Used by `ChatPanel`'s Stop button.
+ * Tolerates `null` for `client`/`sessionKey`/`runId` — the local cleanup
+ * still runs (the abort RPC is skipped when any of them is null).
+ */
+export async function stopAgentRun(params: StopAgentRunParams): Promise<void> {
+  const { client, agentId, sessionKey, runId } = params
+
+  // 1. Optimistic local teardown — flip status, clear runId, clear streaming.
+  useFleetStore.getState().patchAgent(agentId, {
+    status: 'idle',
+    runId: null,
+    streamText: null,
+  })
+  if (sessionKey) {
+    useChatStore.getState().setStreamingText(sessionKey, null)
+  }
+
+  // 2. Best-effort server-side abort. The Gateway responds with
+  //    `{ ok, abortedRunId, status }`; `status: 'no-active-run'` is a
+  //    benign no-op (the run already finished). We don't surface errors —
+  //    local state is already correct.
+  if (client && sessionKey && runId) {
+    try {
+      await client.chat.abort(sessionKey, runId)
+    } catch {
+      // Disconnected, race, or Gateway transient error — local cleanup
+      // already happened, so silently swallow.
+    }
+  }
+}
+
+// ── Whole team ───────────────────────────────────────────────────────────────
+
+export interface StopAllInTeamParams {
+  client: GatewayClient | null
+  teamId: string
+  /**
+   * Effective participants = team members + Boo Zero (when present), deduped
+   * by id. Same shape `GroupChatPanel` already computes in `participants`.
+   */
+  participants: AgentState[]
+  /** agentId → team-scoped sessionKey, same map `GroupChatPanel` builds. */
+  teamSessionKeys: Map<string, string>
+}
+
+/**
+ * Abort every running run on the team AND wipe orchestration in-flight
+ * state so no follow-up delegation / relay fires after Stop. The caller
+ * (`GroupChatPanel`) is expected to ALSO bump its `stopSignal` counter
+ * before calling this — that clears `useTeamOrchestration`'s debounce
+ * timer + bookkeeping refs which live inside the hook and aren't
+ * reachable from here.
+ */
+export async function stopAllInTeam(params: StopAllInTeamParams): Promise<void> {
+  const { client, teamId, participants, teamSessionKeys } = params
+
+  // Target every participant that's currently working — `running` covers the
+  // common case. `sleeping` agents aren't generating, so no abort needed.
+  const runningAgents = participants.filter((a) => a.status === 'running')
+
+  // 1. Optimistic local teardown for each running agent.
+  for (const agent of runningAgents) {
+    useFleetStore.getState().patchAgent(agent.id, {
+      status: 'idle',
+      runId: null,
+      streamText: null,
+    })
+    const sk = teamSessionKeys.get(agent.id)
+    if (sk) useChatStore.getState().setStreamingText(sk, null)
+  }
+
+  // 2. Clear orchestration in-memory state — these don't live in stores so
+  //    the `chat:aborted` events from the Gateway won't clean them up.
+  clearTeamRelayState(teamId)
+  clearWakeInFlight(teamId)
+  for (const agent of runningAgents) {
+    clearAllTeamChatOverridesForAgent(agent.id)
+  }
+
+  // 3. Best-effort server-side aborts in parallel. We use the team-scoped
+  //    sessionKey for each agent — group-chat runs are scoped to that
+  //    session, so aborting on the 1:1 sessionKey would miss the actual
+  //    in-flight run.
+  if (!client) return
+  const aborts: Promise<unknown>[] = []
+  for (const agent of runningAgents) {
+    const sk = teamSessionKeys.get(agent.id)
+    if (!sk || !agent.runId) continue
+    aborts.push(client.chat.abort(sk, agent.runId).catch(() => undefined))
+  }
+  await Promise.allSettled(aborts)
+}

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -242,10 +242,61 @@ export function GatewayBootstrap() {
           teamId: existingTeamIds.get(a.id) ?? null,
           execConfig: execConfigs.get(a.id) ?? null,
         }))
-        hydrateAgents(mapped)
 
-        // Identify Boo Zero
-        useBooZeroStore.getState().setBooZeroAgentId(identifyBooZero(mapped, result.defaultId))
+        // Identify Boo Zero before applying the display-name override so
+        // we know which agent's name to overlay.
+        const booZeroId = identifyBooZero(mapped, result.defaultId)
+        useBooZeroStore.getState().setBooZeroAgentId(booZeroId)
+
+        // Phase E: Clawboo-side display-name override for Boo Zero. The
+        // user's Gateway agent name might be the literal slug "main" or a
+        // custom name they picked in OpenClaw onboarding ("Mythos" was
+        // seen in production). Clawboo's policy: lock the display name to
+        // "Boo Zero" by default; user can change it anytime in the System
+        // panel ("Boo Zero" section). The override lives in SQLite —
+        // Gateway-side identity is never touched.
+        //
+        // First-connect behavior: if no override exists yet, we write
+        // "Boo Zero" as the default so the chat header / identity anchor
+        // / briefs all read consistently. Subsequent connects respect
+        // whatever the user has saved.
+        if (booZeroId) {
+          let override = ''
+          try {
+            const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`)
+            if (res.ok) {
+              const body = (await res.json()) as { name?: string | null }
+              override = (body.name ?? '').trim()
+            }
+          } catch {
+            // Best-effort.
+          }
+          // No override yet → seed with the Clawboo default "Boo Zero".
+          // Skipped silently on fetch failure (the user can still see the
+          // Gateway-side name; the next successful connect will seed).
+          if (override.length === 0) {
+            try {
+              const seed = await fetch(
+                `/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`,
+                {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ name: 'Boo Zero' }),
+                },
+              )
+              if (seed.ok) override = 'Boo Zero'
+            } catch {
+              // Best-effort.
+            }
+          }
+          if (override.length > 0) {
+            for (const a of mapped) {
+              if (a.id === booZeroId) a.name = override
+            }
+          }
+        }
+
+        hydrateAgents(mapped)
 
         return result.agents.length
       } catch {

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -298,6 +298,19 @@ export function GatewayBootstrap() {
 
         hydrateAgents(mapped)
 
+        // One-shot ghost sweep. Removes local SQLite agent rows for agents
+        // no longer in the Gateway — leftovers from older delete paths that
+        // didn't clean up local state. Skipped when the Gateway returned
+        // zero agents (the server endpoint guards this too, but skipping
+        // here avoids the round-trip + the noisy 400 response).
+        if (mapped.length > 0) {
+          fetch('/api/agents/cleanup-ghosts', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ liveAgentIds: mapped.map((a) => a.id) }),
+          }).catch(() => {})
+        }
+
         return result.agents.length
       } catch {
         setFleetError('Could not load your agent fleet. The Gateway may have restarted.')

--- a/apps/web/src/features/connection/useGatewayEvents.ts
+++ b/apps/web/src/features/connection/useGatewayEvents.ts
@@ -8,7 +8,11 @@ import { useConnectionStore } from '@/stores/connection'
 import { useFleetStore } from '@/stores/fleet'
 import { useApprovalsStore, type ApprovalRequest } from '@/stores/approvals'
 import { parseApprovalRequestPayload } from '@/features/approvals/useApprovalActions'
-import { getTeamChatOverride, clearTeamChatOverride } from '@/lib/sessionUtils'
+import {
+  getTeamChatOverride,
+  clearTeamChatOverride,
+  promoteOverrideToRun,
+} from '@/lib/sessionUtils'
 import { clearAllWakeRecords } from '@/lib/wakeTracker'
 import { nextSeq } from '@/lib/sequenceKey'
 
@@ -74,17 +78,26 @@ export function useGatewayEvents(client: GatewayClient | null): void {
               useFleetStore.getState().updateLastSeen(intent.agentId, Date.now())
               break
             }
+            // Capture the runId BEFORE the patch clears it — we need it to
+            // clear the run-scoped team override after dispatch (Boo Zero
+            // participates in N teams; clearing by agentId alone would wipe
+            // another team's still-active override).
+            const priorRunId =
+              useFleetStore.getState().agents.find((a) => a.id === intent.agentId)?.runId ?? null
             // outputLines already handled by appendOutputLines above;
             // apply the final status patch (idle/error, runId cleared)
             useFleetStore.getState().patchAgent(intent.agentId, intent.patch)
             useFleetStore.getState().updateLastSeen(intent.agentId, Date.now())
             // Clear team-scoped streaming text in the chat store + team override.
-            const teamKey = getTeamChatOverride(intent.agentId)
+            const teamKey = getTeamChatOverride(intent.agentId, priorRunId)
             if (teamKey) {
               useChatStore.getState().setStreamingText(teamKey, null)
               // Delay clearing override by 200ms so useTeamOrchestration can
               // process the newly committed entry before the override is gone.
-              setTimeout(() => clearTeamChatOverride(intent.agentId), 200)
+              setTimeout(() => {
+                if (priorRunId) clearTeamChatOverride(intent.agentId, priorRunId)
+                else clearTeamChatOverride(intent.agentId)
+              }, 200)
             } else if (intent.sessionKey) {
               useChatStore.getState().setStreamingText(intent.sessionKey, null)
             }
@@ -114,9 +127,21 @@ export function useGatewayEvents(client: GatewayClient | null): void {
       // Live patch queue (streaming — RAF-batched)
       queueLivePatch: (agentId, patch, sessionKey?) => {
         patchQueue.enqueue({ agentId, updates: patch })
+        // Determine the runId for this streaming chunk:
+        //   1. `patch.runId` when the patch is starting a new run.
+        //   2. Fall back to the agent's current runId from the fleet store.
+        // The first patch that brings a runId triggers `promoteOverrideToRun`
+        // so subsequent events for this run hit the run-scoped slot.
+        const runIdFromPatch = typeof patch.runId === 'string' ? patch.runId : null
+        const runId =
+          runIdFromPatch ??
+          useFleetStore.getState().agents.find((a) => a.id === agentId)?.runId ??
+          null
+        if (runId) promoteOverrideToRun(agentId, runId)
         // Sync streaming text to chat store — use team override if active,
         // so GroupChatPanel reads streaming from the team sessionKey.
-        const resolvedKey = (agentId ? getTeamChatOverride(agentId) : undefined) ?? sessionKey
+        const resolvedKey =
+          (agentId ? getTeamChatOverride(agentId, runId) : undefined) ?? sessionKey
         if (resolvedKey && patch.streamText !== undefined) {
           useChatStore.getState().setStreamingText(resolvedKey, patch.streamText)
         }
@@ -131,9 +156,14 @@ export function useGatewayEvents(client: GatewayClient | null): void {
       appendOutputLines: (agentId, lines, eventSessionKey?) => {
         if (lines.length === 0) return
         const agent = useFleetStore.getState().agents.find((a) => a.id === agentId)
+        // Promote any pending override to a run-scoped one now that we know
+        // the agent's runId (idempotent if already promoted).
+        if (agent?.runId) promoteOverrideToRun(agentId, agent.runId)
         // Team chat override: the Gateway echoes events with the main sessionKey even
         // when we sent to a team-scoped key. Redirect to the team session if active.
-        const teamOverride = agentId ? getTeamChatOverride(agentId) : undefined
+        const teamOverride = agentId
+          ? getTeamChatOverride(agentId, agent?.runId ?? null)
+          : undefined
         const sessionKey = teamOverride ?? eventSessionKey ?? agent?.sessionKey
         if (!sessionKey) return
 
@@ -257,6 +287,7 @@ export function useGatewayEvents(client: GatewayClient | null): void {
 
       let inputTokens = 0
       let outputTokens = 0
+      const runId = typeof p['runId'] === 'string' ? p['runId'] : null
 
       if (usage) {
         // Real token data from Gateway (when available)
@@ -269,8 +300,10 @@ export function useGatewayEvents(client: GatewayClient | null): void {
           outputTokens = Math.ceil(responseText.length / 4)
         }
 
-        // Estimate input from the last user message in this agent's transcript
-        const teamKey = getTeamChatOverride(agentId)
+        // Estimate input from the last user message in this agent's transcript.
+        // Use run-aware override lookup so Boo Zero's per-team transcripts
+        // don't get cross-contaminated.
+        const teamKey = getTeamChatOverride(agentId, runId)
         const mainKey = useFleetStore.getState().agents.find((a) => a.id === agentId)?.sessionKey
         const transcript = useChatStore.getState().transcripts.get(teamKey ?? mainKey ?? '')
         if (transcript) {
@@ -291,7 +324,6 @@ export function useGatewayEvents(client: GatewayClient | null): void {
           : typeof message['model'] === 'string'
             ? message['model']
             : 'unknown'
-      const runId = typeof p['runId'] === 'string' ? p['runId'] : null
 
       // Store token usage in chat store so ChatPanel can display real counts
       if (runId) {
@@ -334,7 +366,10 @@ export function useGatewayEvents(client: GatewayClient | null): void {
         if (!agentId) continue
 
         const agent = useFleetStore.getState().agents.find((a) => a.id === agentId)
-        const teamOverride = getTeamChatOverride(agentId)
+        // Approval-expiry meta entries inject into whatever session the agent
+        // is currently routed to. Use run-aware lookup so Boo Zero's per-team
+        // overrides resolve correctly when overlapping.
+        const teamOverride = getTeamChatOverride(agentId, agent?.runId ?? null)
         const sessionKey = teamOverride ?? agent?.sessionKey
         if (!sessionKey) continue
 

--- a/apps/web/src/features/fleet/deleteAgentOperation.ts
+++ b/apps/web/src/features/fleet/deleteAgentOperation.ts
@@ -27,4 +27,12 @@ export async function deleteAgentOperation(
       method: 'DELETE',
     }).catch(() => {})
   }
+
+  // 5. Clean up the local SQLite agent row + FK-referenced rows. Without
+  //    this the row lingers forever, inflating per-team `agentCount` in
+  //    `/api/teams` responses and polluting any future logic that reads
+  //    from the local DB. Best-effort, non-blocking — if the request fails
+  //    the worst case is one extra ghost row that the one-shot
+  //    `cleanup-ghosts` will sweep on the next bootstrap.
+  fetch(`/api/agents/${encodeURIComponent(agentId)}`, { method: 'DELETE' }).catch(() => {})
 }

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -41,7 +41,7 @@ import { installSkillForAgent } from './operations/installSkill'
 import { removeRouting } from './operations/removeRouting'
 import { graphPhysics } from './graphPhysics'
 import { EdgeMarkers } from './edges/EdgeMarkers'
-import type { BooNodeData, SkillNodeData, GraphEdge } from './types'
+import type { BooNodeData, SkillNodeData, GraphEdge, LayoutData } from './types'
 
 interface ContextMenuState {
   x: number
@@ -265,11 +265,26 @@ export function GhostGraph() {
   // Layer 1: ELK positions boo nodes using dependency edges only (async).
   // Layer 2: Orbital positions skill/resource nodes around their parent boo (sync).
   // Re-runs when node count changes or user clicks "Re-layout" (layoutKey bump).
+  //
+  // Persistence: previously, ELK results were only applied to the local store
+  // (via setNodes) and NEVER saved to /api/graph-layout. The only save path was
+  // drag-end. Effect: clicking "Re-layout" sorted the visible canvas but on
+  // refresh the stale saved positions reloaded, undoing the sort. Fix: after
+  // every ELK computation, save the resulting positions so refresh is a no-op.
+  //
+  // Staleness: ELK preserves saved positions per node id, so when Boo Zero is
+  // synthesized into a team's graph for the first time (new node id), the
+  // other Boos still snap to their old saved positions while Boo Zero lays
+  // out fresh — looks broken. We detect this case (some boo nodes have saved
+  // positions, but the synthesized Boo Zero does not) and clear ALL saved
+  // boo positions for this layout, forcing a full re-layout. User-saved drag
+  // positions get re-established on the next deliberate drag.
   useEffect(() => {
-    // Reset when layoutKey bumps (user pressed "Re-layout").
-    // Must happen INSIDE this effect (not a separate one) to ensure the reset
-    // is processed before the guard check — React runs effects in definition order.
-    if (layoutKey !== prevLayoutKeyRef.current) {
+    // Reset when layoutKey bumps (user pressed "Re-layout"). We also CLEAR
+    // saved positions here so the re-layout produces a fresh ELK result
+    // (not constrained by the old user-dragged positions).
+    const reLayoutRequested = layoutKey !== prevLayoutKeyRef.current
+    if (reLayoutRequested) {
       prevLayoutKeyRef.current = layoutKey
       layoutRanRef.current = false
       prevNodeLengthRef.current = 0
@@ -301,13 +316,50 @@ export function GhostGraph() {
       (e) => e.type === 'dependency' && (e.data as { isPrimary?: boolean })?.isPrimary !== false,
     )
 
+    // Detect cases where saved positions can't be trusted:
+    //   (a) Partial coverage — some boos have saved positions, others don't.
+    //       Typically happens when Boo Zero is newly synthesized into a team
+    //       and the older non-Boo-Zero positions are still in SQLite.
+    //   (b) Runaway span — a previous version of `stretchToAspect` (now
+    //       fixed) stretched both axes and compounded across re-layouts,
+    //       producing layouts spanning thousands of ELK units. We detect
+    //       these by checking the bbox of saved boo positions; if either
+    //       dimension exceeds 4000 px the positions are stale-blown-up and
+    //       should be discarded.
+    const savedBooPositions = booNodes
+      .map((n) => savedPositions[n.id])
+      .filter((p): p is { x: number; y: number } => Boolean(p))
+    const savedBooIds = booNodes.filter((n) => savedPositions[n.id]).map((n) => n.id)
+    const partialSavedCoverage = savedBooIds.length > 0 && savedBooIds.length < booNodes.length
+
+    let runawaySpan = false
+    if (savedBooPositions.length >= 2) {
+      let minX = Infinity,
+        maxX = -Infinity,
+        minY = Infinity,
+        maxY = -Infinity
+      for (const p of savedBooPositions) {
+        if (p.x < minX) minX = p.x
+        if (p.x > maxX) maxX = p.x
+        if (p.y < minY) minY = p.y
+        if (p.y > maxY) maxY = p.y
+      }
+      const SPAN_LIMIT = 4000
+      if (maxX - minX > SPAN_LIMIT || maxY - minY > SPAN_LIMIT) {
+        runawaySpan = true
+      }
+    }
+
+    const effectiveSavedPositions =
+      reLayoutRequested || partialSavedCoverage || runawaySpan ? {} : savedPositions
+
     // Pass the canvas aspect so ELK's hierarchy-driven output can be stretched
     // to claim the empty bands fitView would otherwise leave (see
     // stretchToAspect in useGraphLayout.ts).
     const canvasAspect =
       containerSize.w > 0 && containerSize.h > 0 ? containerSize.w / containerSize.h : undefined
 
-    void computeElkLayout(booNodes, primaryDepEdges, savedPositions, canvasAspect).then(
+    void computeElkLayout(booNodes, primaryDepEdges, effectiveSavedPositions, canvasAspect).then(
       (layoutedBooNodes) => {
         // Skip stale results — a newer ELK computation has started
         if (generation !== elkGenerationRef.current) return
@@ -317,11 +369,32 @@ export function GhostGraph() {
           layoutedBooNodes,
           nonBooNodes,
           edges, // full edges needed for parent-child mapping
-          savedPositions,
+          effectiveSavedPositions,
         )
 
         setNodes([...layoutedBooNodes, ...orbitalNodes])
         setHasRunLayout(true)
+
+        // Persist the resulting positions so refresh is a no-op.
+        // This runs on EVERY successful ELK pass (initial layout, node-count
+        // change, re-layout button) — the debounce inside `savePositions`
+        // collapses rapid successive saves.
+        const nextPositions: LayoutData['positions'] = { ...savedPositions }
+        for (const n of layoutedBooNodes) nextPositions[n.id] = n.position
+        for (const n of orbitalNodes) nextPositions[n.id] = n.position
+        // If we cleared the saved set (re-layout or partial coverage), drop
+        // any stale entries that aren't in the current node list — they're
+        // for nodes that no longer exist.
+        if (reLayoutRequested || partialSavedCoverage) {
+          const currentIds = new Set([
+            ...layoutedBooNodes.map((n) => n.id),
+            ...orbitalNodes.map((n) => n.id),
+          ])
+          for (const id of Object.keys(nextPositions)) {
+            if (!currentIds.has(id)) delete nextPositions[id]
+          }
+        }
+        savePositions(nextPositions)
 
         // Initialize physics particles from layouted positions
         requestAnimationFrame(() => {

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -20,7 +20,7 @@ import type {
   MiniMapNodeProps,
 } from '@xyflow/react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { GitBranch, Map, Pin, X } from 'lucide-react'
+import { GitBranch, Map, Pin, RefreshCw, X } from 'lucide-react'
 import { useGraphStore } from './store'
 import { useGraphData } from './useGraphData'
 import { useGraphPersistence } from './useGraphPersistence'
@@ -166,6 +166,7 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
     setNodes,
     hasRunLayout,
     setHasRunLayout,
+    resetLayout,
     updateNodePosition,
     connectMode,
     setConnectMode,
@@ -748,6 +749,49 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
           ignored here when scope is `'team'`, so toggling it from Atlas
           doesn't leak into other views. */}
       {scope === 'atlas' && showTeamHalos && <TeamHaloLayer nodes={nodes} />}
+
+      {/* Re-layout — bumps the layout key and saves new positions. Shown
+          on the canvas (instead of the now-suppressed panel toolbar) so
+          both Atlas and the embedded Group Chat graph have it in the
+          same place. Gated by `hasRunLayout` — there's nothing to
+          re-layout before the first ELK pass completes. Position 224px
+          from the right keeps a stable column order regardless of which
+          scope is active: [Re-layout] [Team halos] [Connect]. Team halos
+          is hidden in team scope, leaving a small empty band — preferred
+          over conditional offsets that would jitter as scope changes. */}
+      {hasRunLayout && (
+        <button
+          onClick={resetLayout}
+          title="Re-layout"
+          style={{
+            position: 'absolute',
+            top: 12,
+            right: 224,
+            zIndex: 20,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 12px',
+            borderRadius: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: '#111827',
+            color: 'rgba(232,232,232,0.5)',
+            transition: 'all 0.15s',
+          }}
+          onMouseOver={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.85)')
+          }
+          onMouseOut={(e) =>
+            ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.5)')
+          }
+        >
+          <RefreshCw size={14} />
+          Re-layout
+        </button>
+      )}
 
       {/* Team halos toggle — Atlas-only control. Hidden in team scope so
           the toolbar doesn't carry irrelevant chrome. */}

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -24,7 +24,8 @@ import { GitBranch, Map, Pin, X } from 'lucide-react'
 import { useGraphStore } from './store'
 import { useGraphData } from './useGraphData'
 import { useGraphPersistence } from './useGraphPersistence'
-import { computeElkLayout } from './useGraphLayout'
+import { computeElkLayout, computeAtlasLayout } from './useGraphLayout'
+import { useTeamStore } from '@/stores/team'
 import { computeOrbitalPositions } from './computeOrbitalPositions'
 import { nodeTypes } from './nodes/nodeTypes'
 import { edgeTypes } from './edges/edgeTypes'
@@ -41,7 +42,7 @@ import { installSkillForAgent } from './operations/installSkill'
 import { removeRouting } from './operations/removeRouting'
 import { graphPhysics } from './graphPhysics'
 import { EdgeMarkers } from './edges/EdgeMarkers'
-import type { BooNodeData, SkillNodeData, GraphEdge, LayoutData } from './types'
+import type { BooNodeData, SkillNodeData, GraphEdge, LayoutData, GhostGraphScope } from './types'
 
 interface ContextMenuState {
   x: number
@@ -67,6 +68,9 @@ function pickFittableNodes(nodes: Node[], expandedBooIds: Set<string>): { id: st
   return nodes
     .filter((n) => {
       if (n.type === 'boo') return true
+      // Atlas team-root junctions are 1px invisible — exclude from fit
+      // so the camera frames the visible Boos, not the routing points.
+      if (n.type === 'team-root') return false
       if (n.type !== 'skill' && n.type !== 'resource') return true
       const agentIds = (n.data as { agentIds?: string[] } | undefined)?.agentIds
       const ownerAgentId = agentIds?.[0]
@@ -102,6 +106,9 @@ function GhostGraphMiniMapNode({
 }: MiniMapNodeProps) {
   const fill = color ?? '#e2e2e2'
   if (color === 'transparent') return null
+  // Atlas team-root junctions are invisible 1px routing points; the
+  // MiniMap should also hide them so it reflects what the user sees.
+  if (id.startsWith('team-root-')) return null
   const stroke = strokeColor ?? 'transparent'
   const sw = strokeWidth ?? 0
   if (id.startsWith('boo-')) {
@@ -142,8 +149,11 @@ function GhostGraphMiniMapNode({
 // ─── GhostGraph ───────────────────────────────────────────────────────────────
 //
 // Must be rendered inside <ReactFlowProvider> (done by GhostGraphPanel).
+//
+// `scope` controls global-vs-team data behavior + halos UX (see
+// `GhostGraphPanel` for the full contract). Defaults to `'team'`.
 
-export function GhostGraph() {
+export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {}) {
   const {
     nodes,
     edges,
@@ -190,9 +200,13 @@ export function GhostGraph() {
   const elkGenerationRef = useRef(0)
   const prevLayoutKeyRef = useRef(layoutKey)
 
-  // Wire data fetching and persistence
-  useGraphData()
-  const { savePositions, isLoaded } = useGraphPersistence()
+  // Wire data fetching and persistence. The scope drives whether
+  // `useGraphData` filters to `selectedTeamId` or shows every team at once,
+  // AND it scopes the persistence key so Atlas and the team-scoped Ghost
+  // Graph don't overwrite each other's saved positions (Atlas's positions
+  // are global; the team chat's positions are per-team).
+  useGraphData(scope)
+  const { savePositions, isLoaded } = useGraphPersistence(scope)
 
   // Wire physics wake callback — when a boo node is dragged, wake the physics engine
   useEffect(() => {
@@ -304,14 +318,19 @@ export function GhostGraph() {
     // Increment generation only when actually starting ELK computation.
     const generation = ++elkGenerationRef.current
 
-    // Layer 1: Only boo nodes + PRIMARY dependency edges go through ELK.
-    // Secondary edges (every routing rule outside the spanning tree from
-    // the team leader) are intentionally withheld — feeding them to ELK
-    // would re-introduce the edge-tangle that obscured the leader →
-    // teammate flow. Secondary edges are still rendered, but only on
-    // hover, and they don't influence layout.
+    // Layer 1: Boo nodes + team-root junctions + PRIMARY dependency edges
+    // go through ELK. Secondary edges (every routing rule outside the
+    // spanning tree from the team leader) are intentionally withheld —
+    // feeding them to ELK would re-introduce the edge-tangle that
+    // obscured the leader → teammate flow. Secondary edges are still
+    // rendered, but only on hover, and they don't influence layout.
+    // Team-root nodes are 1px invisible routing points used in Atlas to
+    // form the BZ → junction → team-members hierarchy — they participate
+    // in ELK's layered placement but are not orbital parents (skills /
+    // resources orbit Boos only).
     const booNodes = nodes.filter((n) => n.type === 'boo')
-    const nonBooNodes = nodes.filter((n) => n.type !== 'boo')
+    const layoutBooNodes = nodes.filter((n) => n.type === 'boo' || n.type === 'team-root')
+    const nonBooNodes = nodes.filter((n) => n.type !== 'boo' && n.type !== 'team-root')
     const primaryDepEdges = edges.filter(
       (e) => e.type === 'dependency' && (e.data as { isPrimary?: boolean })?.isPrimary !== false,
     )
@@ -359,66 +378,93 @@ export function GhostGraph() {
     const canvasAspect =
       containerSize.w > 0 && containerSize.h > 0 ? containerSize.w / containerSize.h : undefined
 
-    void computeElkLayout(booNodes, primaryDepEdges, effectiveSavedPositions, canvasAspect).then(
-      (layoutedBooNodes) => {
-        // Skip stale results — a newer ELK computation has started
-        if (generation !== elkGenerationRef.current) return
+    // **Team scope**: single-pass ELK over Boo nodes + primary edges.
+    // **Atlas scope**: per-team ELK + horizontal packing. Each team
+    // gets its own self-contained ELK pass, then the clusters are
+    // packed horizontally with team-root junctions and Boo Zero
+    // positioned manually above them. This decouples each team's
+    // internal hierarchy depth from every other team's, so all teams
+    // sit at the same visual level under Boo Zero regardless of how
+    // deep their internal AGENTS.md routing goes — exactly the shape
+    // in the user's hand-drawn sketch.
+    const teamOrder = useTeamStore.getState().teams.map((t) => t.id)
+    const layoutPromise =
+      scope === 'atlas'
+        ? computeAtlasLayout(layoutBooNodes, primaryDepEdges, effectiveSavedPositions, teamOrder)
+        : computeElkLayout(layoutBooNodes, primaryDepEdges, effectiveSavedPositions, canvasAspect)
 
-        // Layer 2: Position skills/resources in orbital arcs around their parent boo
-        const orbitalNodes = computeOrbitalPositions(
-          layoutedBooNodes,
-          nonBooNodes,
-          edges, // full edges needed for parent-child mapping
-          effectiveSavedPositions,
-        )
+    void layoutPromise.then((layoutedNodes) => {
+      // Skip stale results — a newer ELK computation has started
+      if (generation !== elkGenerationRef.current) return
 
-        setNodes([...layoutedBooNodes, ...orbitalNodes])
-        setHasRunLayout(true)
+      // Split ELK-positioned nodes back into Boos and team-roots so that
+      // computeOrbitalPositions only sees Boos (orbital parents). The
+      // team-roots are passed through to setNodes unchanged at their
+      // ELK-assigned positions.
+      const layoutedBooNodes = layoutedNodes.filter((n) => n.type === 'boo')
+      const layoutedTeamRoots = layoutedNodes.filter((n) => n.type === 'team-root')
 
-        // Persist the resulting positions so refresh is a no-op.
-        // This runs on EVERY successful ELK pass (initial layout, node-count
-        // change, re-layout button) — the debounce inside `savePositions`
-        // collapses rapid successive saves.
-        const nextPositions: LayoutData['positions'] = { ...savedPositions }
-        for (const n of layoutedBooNodes) nextPositions[n.id] = n.position
-        for (const n of orbitalNodes) nextPositions[n.id] = n.position
-        // If we cleared the saved set (re-layout or partial coverage), drop
-        // any stale entries that aren't in the current node list — they're
-        // for nodes that no longer exist.
-        if (reLayoutRequested || partialSavedCoverage) {
-          const currentIds = new Set([
-            ...layoutedBooNodes.map((n) => n.id),
-            ...orbitalNodes.map((n) => n.id),
-          ])
-          for (const id of Object.keys(nextPositions)) {
-            if (!currentIds.has(id)) delete nextPositions[id]
-          }
+      // Layer 2: Position skills/resources in orbital arcs around their parent boo
+      const orbitalNodes = computeOrbitalPositions(
+        layoutedBooNodes,
+        nonBooNodes,
+        edges, // full edges needed for parent-child mapping
+        effectiveSavedPositions,
+      )
+
+      setNodes([...layoutedBooNodes, ...layoutedTeamRoots, ...orbitalNodes])
+      setHasRunLayout(true)
+
+      // Persist the resulting positions so refresh is a no-op.
+      // This runs on EVERY successful ELK pass (initial layout, node-count
+      // change, re-layout button) — the debounce inside `savePositions`
+      // collapses rapid successive saves.
+      const nextPositions: LayoutData['positions'] = { ...savedPositions }
+      for (const n of layoutedBooNodes) nextPositions[n.id] = n.position
+      for (const n of layoutedTeamRoots) nextPositions[n.id] = n.position
+      for (const n of orbitalNodes) nextPositions[n.id] = n.position
+      // If we cleared the saved set (re-layout or partial coverage), drop
+      // any stale entries that aren't in the current node list — they're
+      // for nodes that no longer exist.
+      if (reLayoutRequested || partialSavedCoverage) {
+        const currentIds = new Set([
+          ...layoutedBooNodes.map((n) => n.id),
+          ...layoutedTeamRoots.map((n) => n.id),
+          ...orbitalNodes.map((n) => n.id),
+        ])
+        for (const id of Object.keys(nextPositions)) {
+          if (!currentIds.has(id)) delete nextPositions[id]
         }
-        savePositions(nextPositions)
+      }
+      savePositions(nextPositions)
 
-        // Initialize physics particles from layouted positions
-        requestAnimationFrame(() => {
-          const current = useGraphStore.getState()
-          graphPhysics.initialize(current.nodes, current.edges)
-        })
+      // Initialize physics particles from layouted positions
+      requestAnimationFrame(() => {
+        const current = useGraphStore.getState()
+        graphPhysics.initialize(current.nodes, current.edges)
+      })
 
-        requestAnimationFrame(() => {
-          // Tight padding gives Boos visual prominence; maxZoom caps the fit so
-          // tiny graphs (1–2 Boos) don't blow up to fill the canvas.
-          // `nodes` filter excludes the invisible-by-default orbital children —
-          // see pickFittableNodes() above for why this matters.
-          const state = useGraphStore.getState()
-          void fitView({
-            padding: 0.04,
-            duration: 500,
-            maxZoom: 1.5,
-            nodes: pickFittableNodes(state.nodes, state.expandedBooNodeIds),
-          })
+      requestAnimationFrame(() => {
+        // Tight padding gives Boos visual prominence; maxZoom caps the fit so
+        // tiny graphs (1–2 Boos) don't blow up to fill the canvas.
+        // `nodes` filter excludes the invisible-by-default orbital children —
+        // see pickFittableNodes() above for why this matters.
+        const state = useGraphStore.getState()
+        void fitView({
+          padding: 0.04,
+          duration: 500,
+          maxZoom: 1.5,
+          nodes: pickFittableNodes(state.nodes, state.expandedBooNodeIds),
         })
-      },
-    )
+      })
+    })
     // isLoaded gates layout until saved positions are fetched from SQLite.
-  }, [nodesInitialized, nodes.length, layoutKey, isLoaded])
+    // `scope` is in deps so the effect re-runs when Atlas ↔ team chat
+    // transitions swap which layout fn is needed. Scope-change remounts
+    // (via the `ReactFlowProvider` key in `GhostGraphPanel`) would also
+    // pick up the new scope through the closure on the fresh mount —
+    // keeping `scope` here is the defensive belt to that suspenders.
+  }, [nodesInitialized, nodes.length, layoutKey, isLoaded, scope])
 
   // ── Interaction handlers ─────────────────────────────────────────────────────
 
@@ -694,37 +740,46 @@ export function GhostGraph() {
           Mounted once — marker IDs are global to the document. */}
       <EdgeMarkers />
 
-      {/* Team halos layer — behind ReactFlow, matches pane pan/zoom */}
-      {showTeamHalos && <TeamHaloLayer nodes={nodes} />}
+      {/* Team halos layer — behind ReactFlow, matches pane pan/zoom.
+          Only renders in the global Atlas scope; team-scoped instances
+          (group chat) intentionally never show halos because the team
+          identity is already obvious from context (you're inside that
+          team's group chat). The sticky `showTeamHalos` store value is
+          ignored here when scope is `'team'`, so toggling it from Atlas
+          doesn't leak into other views. */}
+      {scope === 'atlas' && showTeamHalos && <TeamHaloLayer nodes={nodes} />}
 
-      {/* Team halos toggle */}
-      <button
-        onClick={() => setShowTeamHalos(!showTeamHalos)}
-        title="Toggle colored team hulls behind agents"
-        style={{
-          position: 'absolute',
-          top: 12,
-          right: 112,
-          zIndex: 20,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '6px 12px',
-          borderRadius: 8,
-          fontSize: 12,
-          fontWeight: 600,
-          cursor: 'pointer',
-          border: showTeamHalos
-            ? '1px solid rgba(52,211,153,0.4)'
-            : '1px solid rgba(255,255,255,0.1)',
-          background: showTeamHalos ? 'rgba(52,211,153,0.18)' : '#111827',
-          color: showTeamHalos ? '#34D399' : 'rgba(232,232,232,0.5)',
-          transition: 'all 0.15s',
-        }}
-      >
-        <Pin size={14} />
-        Team halos
-      </button>
+      {/* Team halos toggle — Atlas-only control. Hidden in team scope so
+          the toolbar doesn't carry irrelevant chrome. */}
+      {scope === 'atlas' && (
+        <button
+          onClick={() => setShowTeamHalos(!showTeamHalos)}
+          title="Toggle colored team hulls behind agents"
+          style={{
+            position: 'absolute',
+            top: 12,
+            right: 112,
+            zIndex: 20,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 12px',
+            borderRadius: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+            border: showTeamHalos
+              ? '1px solid rgba(52,211,153,0.4)'
+              : '1px solid rgba(255,255,255,0.1)',
+            background: showTeamHalos ? 'rgba(52,211,153,0.18)' : '#111827',
+            color: showTeamHalos ? '#34D399' : 'rgba(232,232,232,0.5)',
+            transition: 'all 0.15s',
+          }}
+        >
+          <Pin size={14} />
+          Team halos
+        </button>
+      )}
 
       {/* Connect mode toggle */}
       <button
@@ -832,6 +887,9 @@ export function GhostGraph() {
             }}
             nodeColor={(node) => {
               if (node.type === 'boo') return '#E94560'
+              // Atlas team-root junctions are invisible — hide them in the
+              // MiniMap too.
+              if (node.type === 'team-root') return 'transparent'
               // Skill / resource nodes inherit visibility from their parent
               // Boo via `data.isVisible` (set by the visibleNodes memo).
               // When the parent is collapsed, return 'transparent' so the

--- a/apps/web/src/features/graph/GhostGraphPanel.tsx
+++ b/apps/web/src/features/graph/GhostGraphPanel.tsx
@@ -3,29 +3,61 @@ import { ReactFlowProvider } from '@xyflow/react'
 import { GhostGraph } from './GhostGraph'
 import { useGraphStore } from './store'
 import { useTeamStore } from '@/stores/team'
+import type { GhostGraphScope } from './types'
+
+// Re-export so existing consumers (e.g. `ContentArea`) can import the scope
+// type alongside the component.
+export type { GhostGraphScope }
 
 // ─── GhostGraphPanel ──────────────────────────────────────────────────────────
 //
 // Wrapper that owns the ReactFlowProvider context, toolbar, loading/error states,
 // and the empty-state illustration.
+//
+// Two orthogonal props:
+//   • `scope` (`'atlas' | 'team'`, default `'team'`)
+//     Controls WHAT the canvas renders:
+//       - `'atlas'`: global all-teams view. Ignores `selectedTeamId`,
+//         synthesizes Boo Zero at the top with edges fanning out to every
+//         team's internal lead. Halos toggle is visible.
+//       - `'team'`: single-team view bound to `selectedTeamId`. Halos
+//         toggle hidden + halos forced off regardless of sticky
+//         `showTeamHalos` value.
+//   • `embedded` (`boolean`, default `false`)
+//     Controls the CHROME — when `true`, the panel-level toolbar (title +
+//     boo/skill count badge + Re-layout) is suppressed because a parent
+//     view (e.g. `GroupChatViewHeader`) owns it. Independent of `scope`.
+//
+// Sidebar team highlight is INTENTIONALLY untouched when entering Atlas —
+// the user expects to return to their team's group chat with the same team
+// still highlighted in the sidebar after leaving Atlas.
 
-export function GhostGraphPanel({ embedded = false }: { embedded?: boolean } = {}) {
+export function GhostGraphPanel({
+  embedded = false,
+  scope = 'team',
+}: {
+  embedded?: boolean
+  scope?: GhostGraphScope
+} = {}) {
   const { isLoadingFiles, filesError, nodes, resetLayout, hasRunLayout } = useGraphStore()
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
 
-  // Reset graph state when team changes. This effect runs in the PARENT
-  // (which does NOT remount on key change), so it reliably detects team switches
-  // even though GhostGraph/ReactFlowProvider are keyed and remount fresh.
+  // Reset graph state when team OR scope changes. This effect runs in the
+  // PARENT (which does NOT remount on key change), so it reliably detects
+  // both team switches AND scope switches even though GhostGraph /
+  // ReactFlowProvider are keyed below and remount fresh.
   const prevTeamIdRef = useRef(selectedTeamId)
+  const prevScopeRef = useRef(scope)
   useEffect(() => {
-    if (prevTeamIdRef.current === selectedTeamId) return
+    if (prevTeamIdRef.current === selectedTeamId && prevScopeRef.current === scope) return
     prevTeamIdRef.current = selectedTeamId
+    prevScopeRef.current = scope
     const store = useGraphStore.getState()
     store.resetLayout()
     store.setNodes([])
     store.setEdges([])
     useGraphStore.setState({ agentFiles: new Map() })
-  }, [selectedTeamId])
+  }, [selectedTeamId, scope])
   const selectedTeam = useTeamStore((s) =>
     s.selectedTeamId ? (s.teams.find((t) => t.id === s.selectedTeamId) ?? null) : null,
   )
@@ -58,7 +90,11 @@ export function GhostGraphPanel({ embedded = false }: { embedded?: boolean } = {
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontSize: 12, fontWeight: 600, color: 'rgba(232,232,232,0.5)' }}>
-            {embedded || !selectedTeam ? 'Ghost Graph' : `${selectedTeam.name} — Ghost Graph`}
+            {scope === 'atlas'
+              ? 'Atlas — All Teams'
+              : embedded || !selectedTeam
+                ? 'Ghost Graph'
+                : `${selectedTeam.name} — Ghost Graph`}
           </span>
           {booCount > 0 && (
             <span
@@ -189,12 +225,14 @@ export function GhostGraphPanel({ embedded = false }: { embedded?: boolean } = {
           </div>
         )}
 
-        {/* React Flow canvas — keyed by team so switching teams gives a fresh
-            React Flow context (internal node init tracking, ResizeObservers).
-            Without the key, stale internal state can prevent ELK layout from
-            firing after async agent creation on a newly created team. */}
-        <ReactFlowProvider key={selectedTeamId ?? 'all'}>
-          <GhostGraph />
+        {/* React Flow canvas — keyed by `${scope}:${selectedTeamId ?? 'none'}`
+            so switching teams OR scope gives a fresh React Flow context
+            (internal node init tracking, ResizeObservers). Without the key,
+            stale internal state can prevent ELK layout from firing after
+            async agent creation on a newly created team, and switching
+            between Atlas → group chat would inherit Atlas's positions. */}
+        <ReactFlowProvider key={`${scope}:${selectedTeamId ?? 'none'}`}>
+          <GhostGraph scope={scope} />
         </ReactFlowProvider>
       </div>
 

--- a/apps/web/src/features/graph/GhostGraphPanel.tsx
+++ b/apps/web/src/features/graph/GhostGraphPanel.tsx
@@ -39,7 +39,7 @@ export function GhostGraphPanel({
   embedded?: boolean
   scope?: GhostGraphScope
 } = {}) {
-  const { isLoadingFiles, filesError, nodes, resetLayout, hasRunLayout } = useGraphStore()
+  const { isLoadingFiles, filesError, nodes } = useGraphStore()
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
 
   // Reset graph state when team OR scope changes. This effect runs in the
@@ -76,66 +76,53 @@ export function GhostGraphPanel({
         overflow: 'hidden',
       }}
     >
-      {/* Toolbar */}
-      <div
-        style={{
-          height: 36,
-          flexShrink: 0,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '0 12px',
-          borderBottom: '1px solid rgba(255,255,255,0.06)',
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ fontSize: 12, fontWeight: 600, color: 'rgba(232,232,232,0.5)' }}>
-            {scope === 'atlas'
-              ? 'Atlas — All Teams'
-              : embedded || !selectedTeam
-                ? 'Ghost Graph'
-                : `${selectedTeam.name} — Ghost Graph`}
-          </span>
-          {booCount > 0 && (
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 500,
-                color: '#E94560',
-                background: 'rgba(233,69,96,0.12)',
-                borderRadius: 20,
-                padding: '1px 8px',
-              }}
-            >
-              {booCount} Boo{booCount !== 1 ? 's' : ''}
-              {skillCount > 0 && ` · ${skillCount} skills`}
+      {/* Toolbar — only rendered when NOT embedded.
+          In group chat the team header above the panel already shows the
+          team identity + Boo/skill counts, and the Re-layout button now
+          lives in the canvas's floating top-right toolbar (with Team
+          halos + Connect). So the embedded toolbar would be pure
+          redundancy and is suppressed entirely.
+          In Atlas (non-embedded) the toolbar is still the only chrome
+          identifying the view, so we keep it — minus the Re-layout
+          button, which also migrated to the canvas for consistency. */}
+      {!embedded && (
+        <div
+          style={{
+            height: 36,
+            flexShrink: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '0 12px',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: 'rgba(232,232,232,0.5)' }}>
+              {scope === 'atlas'
+                ? 'Atlas — All Teams'
+                : selectedTeam
+                  ? `${selectedTeam.name} — Ghost Graph`
+                  : 'Ghost Graph'}
             </span>
-          )}
+            {booCount > 0 && (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: '#E94560',
+                  background: 'rgba(233,69,96,0.12)',
+                  borderRadius: 20,
+                  padding: '1px 8px',
+                }}
+              >
+                {booCount} Boo{booCount !== 1 ? 's' : ''}
+                {skillCount > 0 && ` · ${skillCount} skills`}
+              </span>
+            )}
+          </div>
         </div>
-
-        {hasRunLayout && (
-          <button
-            onClick={resetLayout}
-            style={{
-              background: 'none',
-              border: '1px solid rgba(255,255,255,0.1)',
-              borderRadius: 6,
-              color: 'rgba(232,232,232,0.45)',
-              cursor: 'pointer',
-              fontSize: 11,
-              padding: '2px 8px',
-            }}
-            onMouseOver={(e) =>
-              ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.8)')
-            }
-            onMouseOut={(e) =>
-              ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.45)')
-            }
-          >
-            Re-layout
-          </button>
-        )}
-      </div>
+      )}
 
       {/* Canvas area */}
       <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>

--- a/apps/web/src/features/graph/GhostGraphPanel.tsx
+++ b/apps/web/src/features/graph/GhostGraphPanel.tsx
@@ -9,7 +9,7 @@ import { useTeamStore } from '@/stores/team'
 // Wrapper that owns the ReactFlowProvider context, toolbar, loading/error states,
 // and the empty-state illustration.
 
-export function GhostGraphPanel() {
+export function GhostGraphPanel({ embedded = false }: { embedded?: boolean } = {}) {
   const { isLoadingFiles, filesError, nodes, resetLayout, hasRunLayout } = useGraphStore()
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
 
@@ -58,7 +58,7 @@ export function GhostGraphPanel() {
       >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <span style={{ fontSize: 12, fontWeight: 600, color: 'rgba(232,232,232,0.5)' }}>
-            {selectedTeam ? `${selectedTeam.name} — Ghost Graph` : 'Ghost Graph'}
+            {embedded || !selectedTeam ? 'Ghost Graph' : `${selectedTeam.name} — Ghost Graph`}
           </span>
           {booCount > 0 && (
             <span

--- a/apps/web/src/features/graph/TeamHaloLayer.tsx
+++ b/apps/web/src/features/graph/TeamHaloLayer.tsx
@@ -44,7 +44,10 @@ export interface TeamHaloGroup {
 
 /**
  * Groups graph nodes by `BooNodeData.teamId`. Skills/resources and teamless
- * Boos are excluded. Returns a Map keyed by teamId preserving insertion order.
+ * Boos are excluded. Boo Zero (the universal team leader) is ALSO excluded
+ * even if it ever appears with a teamId — the universal leader sits above
+ * teams in the org chart, not inside any team's hull. Returns a Map keyed
+ * by teamId preserving insertion order.
  */
 export function groupNodesByTeam(nodes: GraphNode[]): Map<string, TeamHaloGroup> {
   const groups = new Map<string, TeamHaloGroup>()
@@ -52,6 +55,7 @@ export function groupNodesByTeam(nodes: GraphNode[]): Map<string, TeamHaloGroup>
     if (node.type !== 'boo') continue
     const data = node.data as BooNodeData
     if (!data.teamId) continue
+    if (data.isUniversalLeader) continue
     const existing = groups.get(data.teamId)
     if (existing) {
       existing.nodes.push(node)

--- a/apps/web/src/features/graph/TeamHaloLayer.tsx
+++ b/apps/web/src/features/graph/TeamHaloLayer.tsx
@@ -22,10 +22,14 @@ const LABEL_OFFSET = 20 // lift label above topmost hull vertex
 
 // Offset from each Boo's React Flow `node.position` (top-left of the
 // envelope) to its visual center. The Boo renders centered inside its
-// envelope (BOO_FOOTPRINT = 340 in `nodes/BooNode.tsx`), so the visual
+// envelope (BOO_FOOTPRINT = 280 in `nodes/BooNode.tsx`), so the visual
 // center is at half the envelope size — same anchor used by
-// `computeOrbitalPositions.ts` and `graphPhysics.ts`.
-const BOO_CENTER_OFFSET = 170
+// `computeOrbitalPositions.ts` and `graphPhysics.ts` (`BOO_HALF_W/H = 140`).
+//
+// Previously 170 (half of an old 340-px envelope), which left the halo
+// centroid drifted 30 px off the actual Boo center — visible as halos
+// that hugged the wrong side of each team. Now correctly 140.
+const BOO_CENTER_OFFSET = 140
 
 interface Point {
   x: number

--- a/apps/web/src/features/graph/TeamHaloLayer.tsx
+++ b/apps/web/src/features/graph/TeamHaloLayer.tsx
@@ -25,10 +25,6 @@ const LABEL_OFFSET = 20 // lift label above topmost hull vertex
 // envelope (BOO_FOOTPRINT = 280 in `nodes/BooNode.tsx`), so the visual
 // center is at half the envelope size — same anchor used by
 // `computeOrbitalPositions.ts` and `graphPhysics.ts` (`BOO_HALF_W/H = 140`).
-//
-// Previously 170 (half of an old 340-px envelope), which left the halo
-// centroid drifted 30 px off the actual Boo center — visible as halos
-// that hugged the wrong side of each team. Now correctly 140.
 const BOO_CENTER_OFFSET = 140
 
 interface Point {

--- a/apps/web/src/features/graph/TeamHaloLayer.tsx
+++ b/apps/web/src/features/graph/TeamHaloLayer.tsx
@@ -193,28 +193,79 @@ function computeGroupHalo(group: TeamHaloGroup): RenderedHalo | null {
 
   const centers = group.nodes.map(nodeCenter)
 
-  let path: string
-  if (centers.length === 2) {
-    // Rounded bounding-box fallback — 2-point hulls are degenerate (a line).
-    const minX = Math.min(centers[0].x, centers[1].x) - HALO_PADDING
-    const minY = Math.min(centers[0].y, centers[1].y) - HALO_PADDING
-    const maxX = Math.max(centers[0].x, centers[1].x) + HALO_PADDING
-    const maxY = Math.max(centers[0].y, centers[1].y) + HALO_PADDING
-    path = rectToRoundedPath(minX, minY, maxX - minX, maxY - minY, HALO_PADDING)
-    const labelX = (minX + maxX) / 2
+  // Bounding rect of centers — used both for the N=2 fallback AND for
+  // detecting "flat" layouts where the convex hull would render as a thin
+  // strip (e.g., every Boo in a team sitting on the same Y row in Atlas).
+  let bMinX = Infinity
+  let bMinY = Infinity
+  let bMaxX = -Infinity
+  let bMaxY = -Infinity
+  for (const c of centers) {
+    if (c.x < bMinX) bMinX = c.x
+    if (c.y < bMinY) bMinY = c.y
+    if (c.x > bMaxX) bMaxX = c.x
+    if (c.y > bMaxY) bMaxY = c.y
+  }
+  const xSpan = bMaxX - bMinX
+  const ySpan = bMaxY - bMinY
+  // If the layout is collapsed in one dimension to less than HALO_PADDING
+  // we treat it as flat: the inflated convex hull would either be a
+  // degenerate line (collinear vertices) or a paper-thin strip after
+  // centroid-push inflation. Threshold matches the inflation amount so we
+  // only kick in when the hull WOULD look like a line, not when the team
+  // is just naturally short / narrow.
+  const FLATNESS_THRESHOLD = HALO_PADDING
+  const isFlat = xSpan < FLATNESS_THRESHOLD || ySpan < FLATNESS_THRESHOLD
+
+  if (centers.length === 2 || isFlat) {
+    // Rounded bounding-box fallback. Doubling the padding in the degenerate
+    // dimension gives the halo a clear 2-D bubble look (≥ 160 px total in
+    // that dimension instead of the ~80 px the un-doubled padding produces).
+    // The doubled side is the one perpendicular to the row, so a horizontal
+    // row of Boos gets extra vertical breathing room (and vice versa).
+    const padX = xSpan < FLATNESS_THRESHOLD ? HALO_PADDING * 2 : HALO_PADDING
+    const padY = ySpan < FLATNESS_THRESHOLD ? HALO_PADDING * 2 : HALO_PADDING
+    const rectX = bMinX - padX
+    const rectY = bMinY - padY
+    const rectW = xSpan + padX * 2
+    const rectH = ySpan + padY * 2
+    const path = rectToRoundedPath(rectX, rectY, rectW, rectH, HALO_PADDING)
     return {
       teamId: group.teamId,
       path,
       color: group.teamColor,
       label: `${group.teamEmoji} ${group.teamName}`,
-      labelX,
-      labelY: minY - LABEL_OFFSET,
+      labelX: (bMinX + bMaxX) / 2,
+      labelY: rectY - LABEL_OFFSET,
     }
   }
 
-  const hull = computeConvexHull(centers)
-  const inflated = inflateHull(hull, HALO_PADDING)
-  path = hullToPath(inflated)
+  // Build the convex hull from CIRCLES around each Boo center, not from
+  // the centers themselves. Centroid-radial inflation only pushes hull
+  // VERTICES outward — Boos that sit on a hull EDGE (e.g. middle Boos in
+  // a mostly-collinear row with one outlier) are inside the hull but
+  // their silhouettes stick past the edge, so they end up only partially
+  // covered. Sampling 16 points around each Boo at `HALO_PADDING * 2`
+  // distance feeds the hull algorithm explicit silhouette boundary
+  // candidates; the resulting hull is guaranteed to clear every Boo by
+  // construction, since each Boo's silhouette points are themselves hull
+  // candidates. Trade-off: the hull becomes a 16-ish-gon instead of a
+  // 3-or-4-vertex polygon, but the SVG is still trivial (~20 path
+  // commands) and the rounded edges read cleaner.
+  const SILHOUETTE_SAMPLES = 16
+  const radius = HALO_PADDING * 2
+  const silhouettePoints: Point[] = []
+  for (const c of centers) {
+    for (let i = 0; i < SILHOUETTE_SAMPLES; i++) {
+      const angle = (i / SILHOUETTE_SAMPLES) * 2 * Math.PI
+      silhouettePoints.push({
+        x: c.x + radius * Math.cos(angle),
+        y: c.y + radius * Math.sin(angle),
+      })
+    }
+  }
+  const inflated = computeConvexHull(silhouettePoints)
+  const path = hullToPath(inflated)
 
   // Label above topmost vertex of inflated hull
   let minY = Infinity

--- a/apps/web/src/features/graph/__tests__/computeSpanningTree.test.ts
+++ b/apps/web/src/features/graph/__tests__/computeSpanningTree.test.ts
@@ -145,6 +145,31 @@ describe('computeSpanningTree', () => {
     expect(primaryEdgeTargets.length).toBe(uniqueTargets.size)
   })
 
+  // Two-phase BFS for Atlas — `useGraphData` partitions dependency edges
+  // into synthetic-first / real-second so the synthetic Boo Zero → team-
+  // lead edges win adjacency-insertion order. Without that ordering, a
+  // cross-team @mention could steal a teammate's primary-parent slot.
+  it('claims synthetic edges over real edges when synthetic is listed first', () => {
+    // Setup: Boo Zero is the root. Agent `m1` has TWO candidate primary
+    // parents — a synthetic `bz → m1` AND a real `peer → m1` (cross-team
+    // @mention). Atlas orders the synthetic edge FIRST in the input
+    // array, so it wins the BFS race.
+    const edges = [
+      // Synthetic-first phase
+      edge('e-syn-bz-m1', 'bz', 'm1'),
+      edge('e-syn-bz-peer', 'bz', 'peer'),
+      // Real AGENTS.md phase — peer mentions m1 via @-routing
+      edge('e-real-peer-m1', 'peer', 'm1'),
+    ]
+    const result = computeSpanningTree(edges, 'bz')
+    // m1's primary parent is bz (synthetic), not peer (real).
+    expect(result.parentMap.get('m1')).toBe('bz')
+    expect(result.primaryEdgeIds.has('e-syn-bz-m1')).toBe(true)
+    // The cross-team real edge does NOT win primary status because
+    // synthetic was discovered first.
+    expect(result.primaryEdgeIds.has('e-real-peer-m1')).toBe(false)
+  })
+
   it('uses an adjacency map for O(1) lookup (smoke test on a 100-node graph)', () => {
     // Sanity check: doesn't blow up on a moderate graph.
     const edges: SpanningEdge[] = []

--- a/apps/web/src/features/graph/__tests__/useGraphData.atlas.test.ts
+++ b/apps/web/src/features/graph/__tests__/useGraphData.atlas.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from 'vitest'
+import { buildGraphElements } from '../useGraphData'
+import type { AgentState } from '@/stores/fleet'
+import type { Team } from '@/stores/team'
+import type { BooNodeData, GraphEdge } from '../types'
+
+// ─── Test fixtures ───────────────────────────────────────────────────────────
+
+const makeAgent = (overrides: Partial<AgentState>): AgentState => ({
+  id: overrides.id ?? 'a1',
+  name: overrides.name ?? 'Agent 1',
+  status: 'idle',
+  sessionKey: null,
+  model: null,
+  createdAt: null,
+  streamingText: null,
+  runId: null,
+  lastSeenAt: null,
+  teamId: null,
+  execConfig: null,
+  ...overrides,
+})
+
+const makeTeam = (overrides: Partial<Team>): Team => ({
+  id: overrides.id ?? 't1',
+  name: overrides.name ?? 'Team 1',
+  icon: '🛠️',
+  color: '#FBBF24',
+  templateId: null,
+  agentCount: 0,
+  leaderAgentId: null,
+  isArchived: false,
+  ...overrides,
+})
+
+const booZero = makeAgent({ id: 'bz', name: 'Boo Zero', teamId: null })
+
+const isPrimary = (edge: GraphEdge): boolean =>
+  Boolean((edge.data as { isPrimary?: boolean })?.isPrimary)
+const isSynthetic = (edge: GraphEdge): boolean =>
+  Boolean((edge.data as { isSynthetic?: boolean })?.isSynthetic)
+
+// ─── Atlas scope tests ───────────────────────────────────────────────────────
+//
+// Atlas synthesizes an invisible `team-root` junction per team to give
+// ELK + the rendering layer a clean two-trunk hierarchy:
+//
+//   Boo Zero
+//      │
+//   ───┴───       ← TOP trunk (BZ → team-roots)
+//   │     │
+//   TR-A  TR-B    ← invisible 1px team-root junctions
+//   │     │
+//   ┌─┴─┐ ┌─┴─┐   ← per-team sub-trunks (team-root → members)
+//   m m m m m m
+//
+// These tests assert the synthetic-edge shape that produces that hierarchy.
+// Team members stay on the SAME hierarchy level as in the team-scoped
+// Ghost Graph — the team-root only adds a routing junction, not a visible
+// extra "anchor" Boo.
+
+describe('buildGraphElements (atlas scope)', () => {
+  it('renders only Boo Zero when no teams are deployed', () => {
+    const { rawNodes, rawEdges } = buildGraphElements(
+      [booZero],
+      new Map(),
+      [],
+      null,
+      booZero,
+      null,
+      'atlas',
+      new Map(),
+    )
+
+    const booNodes = rawNodes.filter((n) => n.type === 'boo')
+    expect(booNodes.length).toBe(1)
+    expect((booNodes[0]?.data as BooNodeData).isUniversalLeader).toBe(true)
+    // No team-roots, no synthetic edges.
+    expect(rawNodes.filter((n) => n.type === 'team-root')).toEqual([])
+    expect(rawEdges.filter(isSynthetic)).toEqual([])
+  })
+
+  it('synthesizes ONE invisible team-root per team between Boo Zero and members', () => {
+    const m1 = makeAgent({ id: 'm1', name: 'Member 1', teamId: 't1' })
+    const m2 = makeAgent({ id: 'm2', name: 'Member 2', teamId: 't1' })
+    const teams = [makeTeam({ id: 't1', leaderAgentId: null })]
+    const leadMap = new Map<string, string | null>([['t1', null]])
+
+    const { rawNodes, rawEdges } = buildGraphElements(
+      [m1, m2, booZero],
+      new Map(),
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    // Team-root node exists, typed as 'team-root'.
+    const teamRoots = rawNodes.filter((n) => n.type === 'team-root')
+    expect(teamRoots.map((n) => n.id)).toEqual(['team-root-t1'])
+
+    // Synthetic edges form: BZ → team-root + team-root → each member.
+    const syntheticIds = rawEdges
+      .filter(isSynthetic)
+      .map((e) => e.id)
+      .sort()
+    expect(syntheticIds).toEqual([
+      'dep-syn-bz-team-root-t1',
+      'dep-syn-team-root-t1-m1',
+      'dep-syn-team-root-t1-m2',
+    ])
+    expect(rawEdges.filter(isSynthetic).every(isPrimary)).toBe(true)
+  })
+
+  it('emits NO synthetic edges from BZ directly to any team member in atlas', () => {
+    // The whole point of the team-root junction is that BZ never points
+    // at a member directly — only at the (invisible) team-root. This
+    // guarantees the top trunk under BZ never spans the union of every
+    // team's horizontal extent.
+    const m1 = makeAgent({ id: 'm1', name: 'Member 1', teamId: 'tA' })
+    const m2 = makeAgent({ id: 'm2', name: 'Member 2', teamId: 'tA' })
+    const m3 = makeAgent({ id: 'm3', name: 'Member 3', teamId: 'tB' })
+    const m4 = makeAgent({ id: 'm4', name: 'Member 4', teamId: 'tB' })
+    const teams = [
+      makeTeam({ id: 'tA', leaderAgentId: null }),
+      makeTeam({ id: 'tB', leaderAgentId: null }),
+    ]
+    const leadMap = new Map<string, string | null>([
+      ['tA', null],
+      ['tB', null],
+    ])
+
+    const { rawEdges } = buildGraphElements(
+      [m1, m2, m3, m4, booZero],
+      new Map(),
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    // No direct BZ → member edges.
+    const bzToMember = rawEdges.filter(
+      (e) =>
+        e.source === 'boo-bz' &&
+        (e.target === 'boo-m1' ||
+          e.target === 'boo-m2' ||
+          e.target === 'boo-m3' ||
+          e.target === 'boo-m4'),
+    )
+    expect(bzToMember).toEqual([])
+
+    // BZ only connects to the 2 team-roots.
+    const bzOut = rawEdges.filter((e) => e.source === 'boo-bz' && isPrimary(e))
+    expect(new Set(bzOut.map((e) => e.target))).toEqual(new Set(['team-root-tA', 'team-root-tB']))
+  })
+
+  it('fans out to multiple teams via per-team team-root junctions', () => {
+    const mA1 = makeAgent({ id: 'mA1', name: 'Member A1', teamId: 'tA' })
+    const mA2 = makeAgent({ id: 'mA2', name: 'Member A2', teamId: 'tA' })
+    const mB1 = makeAgent({ id: 'mB1', name: 'Member B1', teamId: 'tB' })
+    const teams = [
+      makeTeam({ id: 'tA', leaderAgentId: null }),
+      makeTeam({ id: 'tB', leaderAgentId: null }),
+    ]
+    const leadMap = new Map<string, string | null>([
+      ['tA', null],
+      ['tB', null],
+    ])
+
+    const { rawNodes, rawEdges } = buildGraphElements(
+      [mA1, mA2, mB1, booZero],
+      new Map(),
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    // Two team-roots present.
+    const teamRoots = rawNodes.filter((n) => n.type === 'team-root')
+    expect(new Set(teamRoots.map((n) => n.id))).toEqual(new Set(['team-root-tA', 'team-root-tB']))
+
+    // BZ → each team-root (2 edges share BZ as source → ONE shared trunk
+    // under BZ when rendered, with corner branches to each team-root).
+    const bzPrimaries = rawEdges.filter((e) => e.source === 'boo-bz' && isPrimary(e))
+    expect(bzPrimaries.length).toBe(2)
+    expect(new Set(bzPrimaries.map((e) => e.target))).toEqual(
+      new Set(['team-root-tA', 'team-root-tB']),
+    )
+    // Trunk-and-branches sibling tracking confirms the top trunk fans to
+    // both team-roots from a single source.
+    const trunkLeader = bzPrimaries.find(
+      (e) => (e.data as { isTrunkLeader?: boolean }).isTrunkLeader,
+    )
+    expect(trunkLeader).toBeDefined()
+    expect(
+      new Set((trunkLeader!.data as { siblingTargetIds?: string[] }).siblingTargetIds ?? []),
+    ).toEqual(new Set(['team-root-tA', 'team-root-tB']))
+
+    // Each team-root has its own outgoing sub-trunk to its members.
+    const trA = rawEdges.filter((e) => e.source === 'team-root-tA' && isPrimary(e))
+    const trB = rawEdges.filter((e) => e.source === 'team-root-tB' && isPrimary(e))
+    expect(new Set(trA.map((e) => e.target))).toEqual(new Set(['boo-mA1', 'boo-mA2']))
+    expect(new Set(trB.map((e) => e.target))).toEqual(new Set(['boo-mB1']))
+  })
+
+  it('skips teams with zero members (no team-root, no edges)', () => {
+    const m1 = makeAgent({ id: 'm1', name: 'Member 1', teamId: 't1' })
+    const teams = [
+      makeTeam({ id: 't1', leaderAgentId: null }),
+      makeTeam({ id: 't-empty', leaderAgentId: null }),
+    ]
+    const leadMap = new Map<string, string | null>([
+      ['t1', null],
+      ['t-empty', null],
+    ])
+
+    const { rawNodes, rawEdges } = buildGraphElements(
+      [m1, booZero],
+      new Map(),
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    // Only one team-root (for t1). t-empty is silently skipped.
+    const teamRoots = rawNodes.filter((n) => n.type === 'team-root')
+    expect(teamRoots.map((n) => n.id)).toEqual(['team-root-t1'])
+    // Two synthetic edges: BZ → team-root-t1, team-root-t1 → m1.
+    const synthetic = rawEdges.filter(isSynthetic)
+    expect(new Set(synthetic.map((e) => e.id))).toEqual(
+      new Set(['dep-syn-bz-team-root-t1', 'dep-syn-team-root-t1-m1']),
+    )
+  })
+
+  it('falls back to a forest when Boo Zero is absent (atlas, 2 teams, no team-roots)', () => {
+    // No Boo Zero → no junctions to synthesize. Each team's spanning
+    // tree is rooted at its internal lead (independent forest).
+    const leadA = makeAgent({ id: 'lead-A', name: 'Lead A', teamId: 'tA' })
+    const mA1 = makeAgent({ id: 'mA1', name: 'Member A1', teamId: 'tA' })
+    const leadB = makeAgent({ id: 'lead-B', name: 'Lead B', teamId: 'tB' })
+    const mB1 = makeAgent({ id: 'mB1', name: 'Member B1', teamId: 'tB' })
+    const teams = [
+      makeTeam({ id: 'tA', leaderAgentId: 'lead-A' }),
+      makeTeam({ id: 'tB', leaderAgentId: 'lead-B' }),
+    ]
+    const leadMap = new Map<string, string | null>([
+      ['tA', 'lead-A'],
+      ['tB', 'lead-B'],
+    ])
+    const agentFiles = new Map<string, { toolsMd: string | null; agentsMd: string | null }>([
+      ['lead-A', { toolsMd: null, agentsMd: '- Route to @Member A1 for tasks.' }],
+      ['lead-B', { toolsMd: null, agentsMd: '- Route to @Member B1 for tasks.' }],
+    ])
+
+    const { rawNodes, rawEdges } = buildGraphElements(
+      [leadA, mA1, leadB, mB1],
+      agentFiles,
+      teams,
+      null,
+      null, // no Boo Zero
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    // No team-roots emitted without Boo Zero.
+    expect(rawNodes.filter((n) => n.type === 'team-root')).toEqual([])
+    expect(rawEdges.filter(isSynthetic)).toEqual([])
+    const primaryRealEdges = rawEdges.filter(
+      (e) => e.type === 'dependency' && !isSynthetic(e) && isPrimary(e),
+    )
+    expect(primaryRealEdges.length).toBe(2)
+    expect(primaryRealEdges.some((e) => e.source === 'boo-lead-A' && e.target === 'boo-mA1')).toBe(
+      true,
+    )
+    expect(primaryRealEdges.some((e) => e.source === 'boo-lead-B' && e.target === 'boo-mB1')).toBe(
+      true,
+    )
+  })
+
+  it('keeps cross-team @-mentions as secondary edges (team-root synthetic wins primary slot)', () => {
+    // Agent A (team tA) AGENTS.md mentions Agent B (team tB). In atlas
+    // B's primary parent must be team-root-tB (the synthetic junction),
+    // NOT agent A — so the cross-team mention renders as a secondary edge.
+    const agentA = makeAgent({ id: 'lead-A', name: 'Lead A', teamId: 'tA' })
+    const agentB = makeAgent({ id: 'lead-B', name: 'Lead B', teamId: 'tB' })
+    const teams = [
+      makeTeam({ id: 'tA', leaderAgentId: null }),
+      makeTeam({ id: 'tB', leaderAgentId: null }),
+    ]
+    const leadMap = new Map<string, string | null>([
+      ['tA', null],
+      ['tB', null],
+    ])
+
+    const agentFiles = new Map<string, { toolsMd: string | null; agentsMd: string | null }>([
+      ['lead-A', { toolsMd: null, agentsMd: '- Route to @Lead B for tasks.' }],
+    ])
+
+    const { rawEdges } = buildGraphElements(
+      [agentA, agentB, booZero],
+      agentFiles,
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    const crossTeamRealEdge = rawEdges.find(
+      (e) =>
+        e.type === 'dependency' &&
+        !isSynthetic(e) &&
+        e.source === 'boo-lead-A' &&
+        e.target === 'boo-lead-B',
+    )
+    expect(crossTeamRealEdge).toBeDefined()
+    expect(isPrimary(crossTeamRealEdge!)).toBe(false)
+    const synEdge = rawEdges.find((e) => e.id === 'dep-syn-team-root-tB-lead-B')
+    expect(synEdge).toBeDefined()
+    expect(isPrimary(synEdge!)).toBe(true)
+  })
+
+  it('always marks Boo Zero with isUniversalLeader flag', () => {
+    const m1 = makeAgent({ id: 'm1', name: 'Member 1', teamId: 't1' })
+    const teams = [makeTeam({ id: 't1', leaderAgentId: null })]
+    const leadMap = new Map<string, string | null>([['t1', null]])
+
+    const { rawNodes } = buildGraphElements(
+      [m1, booZero],
+      new Map(),
+      teams,
+      null,
+      booZero,
+      null,
+      'atlas',
+      leadMap,
+    )
+
+    const booZeroNode = rawNodes.find((n) => n.id === 'boo-bz' && n.type === 'boo')
+    expect(booZeroNode).toBeDefined()
+    expect((booZeroNode!.data as BooNodeData).isUniversalLeader).toBe(true)
+  })
+})

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -2,7 +2,6 @@ import { memo, useRef, type MutableRefObject } from 'react'
 import { Handle, Position, useConnection } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { motion } from 'framer-motion'
-import { Crown } from 'lucide-react'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import type { BooNodeData } from '../types'
 import { useGraphStore } from '../store'
@@ -301,35 +300,11 @@ export const BooNode = memo(function BooNode({
             Boo had no functional purpose; the agent-detail navigation
             happens through the right-click context menu / sidebar. */}
 
-        {/* ── Universal-leader crown — Boo Zero only ──────────────────────
-            Positioned above the morph wrapper so it visibly persists across
-            both card and circle shapes (overflow: visible on the wrapper).
-            A subtle pulse animation distinguishes it from other markers. */}
-        {data.isUniversalLeader && (
-          <motion.div
-            animate={{ y: [0, -2, 0] }}
-            transition={{ duration: 2.6, repeat: Infinity, ease: 'easeInOut' }}
-            style={{
-              position: 'absolute',
-              top: -18,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 22,
-              height: 22,
-              borderRadius: '50%',
-              background: 'linear-gradient(135deg, #FBBF24 0%, #E94560 60%, #B91C1C 100%)',
-              boxShadow: '0 2px 6px rgba(0,0,0,0.4)',
-              pointerEvents: 'none',
-              zIndex: 5,
-            }}
-            aria-label="Universal team leader"
-          >
-            <Crown size={12} strokeWidth={2.5} color="#FFFAF0" fill="#FFD580" />
-          </motion.div>
-        )}
+        {/* Boo Zero needs no badge — the reserved OpenClaw-red tint plus the
+            slightly larger size (see `baseSize` / `booW` above) already mark
+            it as the universal team leader. The earlier crown badge was a
+            third visual cue layered on top, which read as decorative noise.
+            See `boo-avatar/src/index.ts` for the tint reservation. */}
 
         {showCard ? (
           <CardContent

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -59,9 +59,8 @@ import { createFlipState, useFlipMorph, type FlipState } from './useFlipMorph'
 // sidebar). Team badge has been removed from the BooNode entirely.
 
 // ─── Card dimensions (kept in sync with computeElkLayout) ────────────────────
-
-export const BOO_CARD_WIDTH = 220
-export const BOO_CARD_HEIGHT = 120
+export const BOO_CARD_WIDTH = 280
+export const BOO_CARD_HEIGHT = 170
 
 // ─── Node footprint (matches ELK envelope in useGraphLayout.ts) ──────────────
 // The Boo renders centered inside this footprint so its visual center aligns
@@ -450,19 +449,19 @@ function CardContent({
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 10,
-          padding: '10px 12px',
+          gap: 12,
+          padding: '12px 14px',
           borderBottom: '1px solid rgba(255,255,255,0.06)',
           flexShrink: 0,
         }}
       >
-        <div ref={avatarRef} style={{ flexShrink: 0, width: 36, height: 36, position: 'relative' }}>
-          <AgentBooAvatar agentId={agentId} size={36} />
+        <div ref={avatarRef} style={{ flexShrink: 0, width: 44, height: 44, position: 'relative' }}>
+          <AgentBooAvatar agentId={agentId} size={44} />
         </div>
         <div ref={nameRef} style={{ flex: 1, minWidth: 0 }}>
           <div
             style={{
-              fontSize: 13,
+              fontSize: 14,
               fontWeight: 600,
               color: selected ? '#E94560' : '#E8E8E8',
               fontFamily: 'var(--font-cabinet-grotesk, sans-serif)',
@@ -478,9 +477,9 @@ function CardContent({
           </div>
           <div
             style={{
-              fontSize: 10,
+              fontSize: 11,
               color: 'rgba(232,232,232,0.45)',
-              marginTop: 2,
+              marginTop: 3,
               letterSpacing: '0.04em',
               whiteSpace: 'nowrap',
               overflow: 'hidden',
@@ -494,13 +493,13 @@ function CardContent({
         <div ref={statusRef} style={{ flexShrink: 0, display: 'flex', alignItems: 'center' }}>
           {status === 'running' ? (
             <motion.div
-              style={{ width: 8, height: 8, borderRadius: '50%', background: cardStatusColor }}
+              style={{ width: 10, height: 10, borderRadius: '50%', background: cardStatusColor }}
               animate={{ opacity: [1, 0.25, 1] }}
               transition={{ duration: 1.1, repeat: Infinity }}
             />
           ) : (
             <div
-              style={{ width: 8, height: 8, borderRadius: '50%', background: cardStatusColor }}
+              style={{ width: 10, height: 10, borderRadius: '50%', background: cardStatusColor }}
             />
           )}
         </div>
@@ -513,7 +512,7 @@ function CardContent({
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'flex-start',
-          padding: '6px 12px',
+          padding: '8px 14px',
           position: 'relative',
           background:
             'radial-gradient(circle at center, rgba(52,211,153,0.04) 0%, transparent 60%)',

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -192,9 +192,15 @@ export const BooNode = memo(function BooNode({
     (s) => s.hoveredNodeId === null || (s.highlightedNodeIds?.has(`boo-${agentId}`) ?? false),
   )
 
-  // Degree-aware circle sizing (used only in idle shape)
+  // Degree-aware circle sizing (used only in idle shape). Increased from the
+  // old 60–78 range to give Boos more visual prominence in the canvas —
+  // production users reported "the boos are so small". Still well inside the
+  // 280 envelope so orbital ring spacing and physics are unaffected. Boo
+  // Zero (universal leader) gets a small extra boost so it visually anchors
+  // the top of the team's spanning tree.
   const edgeCount = data.edgeCount ?? 0
-  const booW = Math.min(60 + edgeCount * 3, 78)
+  const baseSize = data.isUniversalLeader ? 112 : 96
+  const booW = Math.min(baseSize + edgeCount * 3, data.isUniversalLeader ? 140 : 124)
   const booH = Math.round(booW * 0.92)
 
   // Box-shadow animation driven by status (glow at the wrapper edge, works

--- a/apps/web/src/features/graph/nodes/BooNode.tsx
+++ b/apps/web/src/features/graph/nodes/BooNode.tsx
@@ -2,6 +2,7 @@ import { memo, useRef, type MutableRefObject } from 'react'
 import { Handle, Position, useConnection } from '@xyflow/react'
 import type { NodeProps, Node } from '@xyflow/react'
 import { motion } from 'framer-motion'
+import { Crown } from 'lucide-react'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import type { BooNodeData } from '../types'
 import { useGraphStore } from '../store'
@@ -294,6 +295,36 @@ export const BooNode = memo(function BooNode({
         {/* Selection ring removed — the previous red ring around a clicked
             Boo had no functional purpose; the agent-detail navigation
             happens through the right-click context menu / sidebar. */}
+
+        {/* ── Universal-leader crown — Boo Zero only ──────────────────────
+            Positioned above the morph wrapper so it visibly persists across
+            both card and circle shapes (overflow: visible on the wrapper).
+            A subtle pulse animation distinguishes it from other markers. */}
+        {data.isUniversalLeader && (
+          <motion.div
+            animate={{ y: [0, -2, 0] }}
+            transition={{ duration: 2.6, repeat: Infinity, ease: 'easeInOut' }}
+            style={{
+              position: 'absolute',
+              top: -18,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 22,
+              height: 22,
+              borderRadius: '50%',
+              background: 'linear-gradient(135deg, #FBBF24 0%, #E94560 60%, #B91C1C 100%)',
+              boxShadow: '0 2px 6px rgba(0,0,0,0.4)',
+              pointerEvents: 'none',
+              zIndex: 5,
+            }}
+            aria-label="Universal team leader"
+          >
+            <Crown size={12} strokeWidth={2.5} color="#FFFAF0" fill="#FFD580" />
+          </motion.div>
+        )}
 
         {showCard ? (
           <CardContent

--- a/apps/web/src/features/graph/nodes/SkillNode.tsx
+++ b/apps/web/src/features/graph/nodes/SkillNode.tsx
@@ -20,6 +20,14 @@ const CATEGORY: Record<SkillCategory, { color: string; icon: string }> = {
   other: { color: '#6B7280', icon: '🔧' },
 }
 
+// Visual overrides for Boo Zero's "Leadership" orbital — see
+// `SkillNodeData.isLeadership` for context. Compass icon picks up the
+// "guides the team" metaphor without the crown's heraldic vibe; amber
+// signals elevated status while staying clearly distinct from any of the
+// regular category colors. Reused by `Description tooltip` and the
+// `name` color below.
+const LEADERSHIP_VISUAL = { color: '#FBBF24', icon: '🧭' } as const
+
 const CIRCLE = 38 // circle diameter in px (reduced from 52 — skills feel subordinate to Boo nodes)
 
 // ─── Handle style ─────────────────────────────────────────────────────────────
@@ -54,9 +62,13 @@ export const SkillNode = memo(function SkillNode({
   data,
   dragging,
 }: NodeProps<Node<SkillNodeData, 'skill'>>) {
-  const { name, category, description, isVisible } = data
+  const { name, category, description, isVisible, isLeadership } = data
   const floatRef = useFloatingMotion(nodeId, 'skill', dragging)
-  const { color, icon } = CATEGORY[category] ?? CATEGORY.other
+  // Leadership orbital reads its visuals from a dedicated constant — the
+  // `category` field is still set on the data (defaulted to `'other'` in
+  // `useGraphData`) so any downstream consumer that hasn't been taught
+  // about `isLeadership` falls back gracefully.
+  const { color, icon } = isLeadership ? LEADERSHIP_VISUAL : (CATEGORY[category] ?? CATEGORY.other)
   const [showPicker, setShowPicker] = useState(false)
 
   // Hover cascade — dim when another node is hovered
@@ -113,35 +125,41 @@ export const SkillNode = memo(function SkillNode({
             <span style={{ fontSize: 16, lineHeight: 1, userSelect: 'none' }}>{icon}</span>
           </div>
 
-          {/* Install button — appears on hover */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              setShowPicker((v) => !v)
-            }}
-            className="opacity-0 group-hover:opacity-100"
-            style={{
-              position: 'absolute',
-              top: -6,
-              right: -14,
-              background: '#34D399',
-              color: '#0A0E1A',
-              border: 'none',
-              borderRadius: 4,
-              fontSize: 9,
-              fontWeight: 700,
-              padding: '2px 6px',
-              cursor: 'pointer',
-              transition: 'opacity 0.15s',
-              whiteSpace: 'nowrap',
-              letterSpacing: '0.02em',
-            }}
-          >
-            Install →
-          </button>
+          {/* Install button — appears on hover. Hidden for the Leadership
+              orbital: it's reserved for Boo Zero and cannot be installed on
+              other agents (see `SkillNodeData.isLeadership`). Suppressing
+              the button removes the action AND avoids opening a no-op
+              picker dropdown. */}
+          {!isLeadership && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setShowPicker((v) => !v)
+              }}
+              className="opacity-0 group-hover:opacity-100"
+              style={{
+                position: 'absolute',
+                top: -6,
+                right: -14,
+                background: '#34D399',
+                color: '#0A0E1A',
+                border: 'none',
+                borderRadius: 4,
+                fontSize: 9,
+                fontWeight: 700,
+                padding: '2px 6px',
+                cursor: 'pointer',
+                transition: 'opacity 0.15s',
+                whiteSpace: 'nowrap',
+                letterSpacing: '0.02em',
+              }}
+            >
+              Install →
+            </button>
+          )}
 
-          {/* Agent picker dropdown */}
-          {showPicker && (
+          {/* Agent picker dropdown — same suppression rule as the button. */}
+          {!isLeadership && showPicker && (
             <AgentPickerDropdown
               onSelect={(agentId, agentName) => {
                 void installSkillForAgent(name, agentId, agentName)

--- a/apps/web/src/features/graph/nodes/TeamRootNode.tsx
+++ b/apps/web/src/features/graph/nodes/TeamRootNode.tsx
@@ -1,0 +1,71 @@
+import { memo } from 'react'
+import { Handle, Position, type NodeProps } from '@xyflow/react'
+
+// ─── TeamRootNode ─────────────────────────────────────────────────────────────
+//
+// Invisible routing-only node used in Atlas as the JUNCTION between Boo
+// Zero and a team's cluster. Renders only the handle anchors React Flow
+// needs to attach edges to — no Boo visual. ELK lays it out at level 1
+// (between Boo Zero at level 0 and team members at level 2) so the edges
+// naturally form the two-level trunk shape the user drew in the sketch:
+//
+//   Boo Zero
+//      │
+//   ───┴───      ← top trunk (BZ → team-roots)
+//   │     │
+//  TR-A  TR-B    ← invisible team-roots (this component)
+//   │     │
+//   ┌─┴─┐ ┌─┴─┐  ← per-team trunks (team-root → members)
+//   m m m m m m  ← team members
+//
+// Width/height are kept at 1px so ELK doesn't reserve a visible block of
+// canvas around the team-root — the layout still respects parent-child
+// centering thanks to ELK's BRANDES_KOEPF placement, but the team-root
+// itself is a single point in canvas space.
+//
+// Handle naming matches BooNode's `'center'` source + `'center-target'`
+// target so synthetic edges through team-roots can use the same handle
+// IDs as every other dependency edge in the graph.
+
+const HANDLE_STYLE: React.CSSProperties = {
+  width: 1,
+  height: 1,
+  minWidth: 1,
+  minHeight: 1,
+  background: 'transparent',
+  border: 'none',
+  opacity: 0,
+  pointerEvents: 'none',
+}
+
+export const TeamRootNode = memo(function TeamRootNode(_props: NodeProps) {
+  return (
+    <div
+      style={{
+        width: 1,
+        height: 1,
+        position: 'relative',
+        pointerEvents: 'none',
+      }}
+      aria-hidden
+    >
+      {/* Source + target both anchored at the same 1px point. Edges
+          from Boo Zero terminate here (target), and edges to team
+          members originate here (source). */}
+      <Handle
+        type="target"
+        position={Position.Top}
+        id="center-target"
+        style={HANDLE_STYLE}
+        isConnectable={false}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="center"
+        style={HANDLE_STYLE}
+        isConnectable={false}
+      />
+    </div>
+  )
+})

--- a/apps/web/src/features/graph/nodes/nodeTypes.ts
+++ b/apps/web/src/features/graph/nodes/nodeTypes.ts
@@ -4,9 +4,11 @@ import type { NodeTypes } from '@xyflow/react'
 import { BooNode } from './BooNode'
 import { SkillNode } from './SkillNode'
 import { ResourceNode } from './ResourceNode'
+import { TeamRootNode } from './TeamRootNode'
 
 export const nodeTypes: NodeTypes = {
   boo: BooNode,
   skill: SkillNode,
   resource: ResourceNode,
+  'team-root': TeamRootNode,
 }

--- a/apps/web/src/features/graph/types.ts
+++ b/apps/web/src/features/graph/types.ts
@@ -5,6 +5,18 @@ import type { AgentStatus } from '@clawboo/gateway-client'
 
 export type SkillCategory = 'data' | 'comm' | 'code' | 'file' | 'web' | 'other'
 
+// ─── Ghost Graph scope ────────────────────────────────────────────────────────
+//
+// `'atlas'`: global all-teams view (rendered in the nav slot via
+// `ContentArea`). Ignores `selectedTeamId`, synthesizes Boo Zero at the top
+// with edges fanning out to every team's internal lead. Halos toggle is
+// visible.
+//
+// `'team'`: single-team view bound to `selectedTeamId` (rendered inside
+// `GroupChatView`). Halos toggle hidden + halos forced off regardless of
+// the sticky `showTeamHalos` value.
+export type GhostGraphScope = 'atlas' | 'team'
+
 // ─── Node data shapes ─────────────────────────────────────────────────────────
 // Each must extend Record<string, unknown> for @xyflow/react's generic constraint.
 
@@ -57,12 +69,33 @@ export interface ResourceNodeData extends Record<string, unknown> {
   isVisible?: boolean
 }
 
+// ─── Team-root node ──────────────────────────────────────────────────────────
+//
+// Invisible routing-only node synthesized in the Atlas view to act as the
+// JUNCTION between Boo Zero and a team's members. Reflects the user-drawn
+// sketch: BZ at top → vertical line → horizontal trunk → per-team
+// vertical → team's own trunk → members. The team-root sits at the
+// vertical-trunk position above each team's cluster. It's invisible in
+// the canvas (`TeamRootNode` renders only handle anchors, not a Boo) but
+// real to ELK and to the spanning tree, so the edges route through it
+// naturally.
+//
+// Why this and not the previous "anchor = first team member" idea: an
+// anchor that IS a team member adds a visible extra hierarchy level (one
+// member sits above its siblings). A team-root is invisible, so visually
+// every team member is still on the same level under Boo Zero — exactly
+// what the user wanted from the team-scoped Ghost Graph.
+export interface TeamRootNodeData extends Record<string, unknown> {
+  teamId: string
+}
+
 // ─── Typed ReactFlow nodes ────────────────────────────────────────────────────
 
 export type BooNode = Node<BooNodeData, 'boo'>
 export type SkillNode = Node<SkillNodeData, 'skill'>
 export type ResourceNode = Node<ResourceNodeData, 'resource'>
-export type GraphNode = BooNode | SkillNode | ResourceNode
+export type TeamRootNode = Node<TeamRootNodeData, 'team-root'>
+export type GraphNode = BooNode | SkillNode | ResourceNode | TeamRootNode
 export type GraphEdge = Edge<Record<string, unknown>>
 
 // ─── Parser output types ──────────────────────────────────────────────────────

--- a/apps/web/src/features/graph/types.ts
+++ b/apps/web/src/features/graph/types.ts
@@ -19,6 +19,13 @@ export interface BooNodeData extends Record<string, unknown> {
   teamName?: string
   teamColor?: string
   teamEmoji?: string
+  /**
+   * When `true`, this Boo is Clawboo's universal team leader (Boo Zero).
+   * Rendering adds a crown badge + "Universal Leader" label, and the node
+   * is excluded from `TeamHaloLayer` grouping (it sits above teams, not
+   * inside them).
+   */
+  isUniversalLeader?: boolean
 }
 
 export interface SkillNodeData extends Record<string, unknown> {

--- a/apps/web/src/features/graph/types.ts
+++ b/apps/web/src/features/graph/types.ts
@@ -56,6 +56,16 @@ export interface SkillNodeData extends Record<string, unknown> {
    *   - false → collapsed (opacity 0, scale 0, behind the parent Boo)
    */
   isVisible?: boolean
+  /**
+   * When `true`, this is the synthesized "Leadership" orbital that
+   * accompanies Boo Zero. Replaces the old crown badge as Boo Zero's
+   * visible leadership signal. `SkillNode` overrides its color + icon
+   * and hides the Install button when this is set (the skill is bound
+   * to Boo Zero — non-transferrable). Synthesized in `useGraphData.ts`
+   * for every Boo with `BooNodeData.isUniversalLeader === true`. Not
+   * present in TOOLS.md.
+   */
+  isLeadership?: boolean
 }
 
 export interface ResourceNodeData extends Record<string, unknown> {

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -372,6 +372,53 @@ export function buildGraphElements(
     })
   }
 
+  // ── Boo Zero's "Leadership" orbital ─────────────────────────────────────
+  //
+  // Synthesized for every Boo with `isUniversalLeader: true` (i.e. Boo Zero
+  // in both atlas and team-selected scopes). Replaces the old crown badge
+  // as the visible leadership signal. Rendered as a normal SkillNode that
+  // orbits Boo Zero in the inner ring; `SkillNode` reads the `isLeadership`
+  // flag and overrides its color + icon + hides the Install button.
+  //
+  // Source-of-truth note: this skill is NOT in TOOLS.md — it's a graph-
+  // layer attribute. No client-side write to the Gateway, so it survives
+  // any future deletion of Boo Zero's tools. The skillId starts with the
+  // reserved prefix `clawboo-leadership-` so it can never collide with a
+  // marketplace skill or a user-added TOOLS.md entry.
+  for (const booNode of booNodes) {
+    const data = booNode.data as BooNodeData
+    if (!data.isUniversalLeader) continue
+    const agentId = data.agentId
+    const nodeId = `skill-${agentId}-clawboo-leadership`
+    skillNodes.push({
+      id: nodeId,
+      type: 'skill' as const,
+      data: {
+        skillId: 'clawboo-leadership',
+        name: 'Leadership',
+        // `'other'` is a graceful fallback for any code path that
+        // doesn't yet branch on `isLeadership` (e.g. legacy filters).
+        // The visual overrides in `SkillNode` short-circuit before any
+        // category styling kicks in.
+        category: 'other',
+        description:
+          'Universal team leader. This skill is reserved for Boo Zero and cannot be installed on other agents.',
+        agentIds: [agentId],
+        isLeadership: true,
+      } satisfies SkillNodeData,
+      position: { x: 0, y: 0 },
+    })
+    skillEdges.push({
+      id: `skilledge-${agentId}-clawboo-leadership`,
+      type: 'skill',
+      source: `boo-${agentId}`,
+      sourceHandle: 'center',
+      target: nodeId,
+      targetHandle: 'center',
+      data: {},
+    })
+  }
+
   for (const agent of agents) {
     const files = agentFiles.get(agent.id)
 

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -2,12 +2,13 @@ import { useEffect, useMemo, useRef } from 'react'
 import { useFleetStore } from '@/stores/fleet'
 import { useConnectionStore } from '@/stores/connection'
 import { useTeamStore } from '@/stores/team'
+import { useBooZeroStore } from '@/stores/booZero'
 import type { Team } from '@/stores/team'
 import { useGraphStore } from './store'
 import { parseToolsMd } from './parsers/parseToolsMd'
 import { parseAgentsMd } from './parsers/parseAgentsMd'
 import { computeSpanningTree } from './computeSpanningTree'
-import { resolveTeamLeader } from '@/lib/resolveTeamLeader'
+import { resolveTeamInternalLead } from '@/lib/resolveTeamLeader'
 import type { AgentState } from '@/stores/fleet'
 import type { GraphNode, GraphEdge, BooNodeData, SkillNodeData, ResourceNodeData } from './types'
 
@@ -99,20 +100,35 @@ export function useGraphData(): void {
   }, [client, agentStructureKey, refreshKey]) // intentional: string key covers structural changes; refreshKey for skill install
 
   // ── 2. Structural rebuild ────────────────────────────────────────────────────
-  // Resolve the active team's leader → spanning-tree root for the dependency
-  // graph. When no team is selected (showing all agents), we pass null and
-  // `buildGraphElements` skips the spanning-tree filter (all edges treated
-  // as primary, fall back to the full graph view).
-  const resolvedLeaderAgentId = useMemo(() => {
+  // Resolve Boo Zero (universal team leader). When a team is selected AND Boo
+  // Zero is present, `buildGraphElements` synthesizes a Boo-Zero node + edges
+  // from Boo Zero → genuine internal lead (if any) → members, OR directly to
+  // members when there's no internal lead. Boo Zero becomes the spanning-tree
+  // root, replacing the old "first team member" fallback.
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const booZeroAgent = useMemo(
+    () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
+    [agents, booZeroAgentId],
+  )
+
+  const teamInternalLeadId = useMemo(() => {
     if (!selectedTeamId) return null
     const team = teams.find((t) => t.id === selectedTeamId)
     if (!team) return null
-    return resolveTeamLeader(selectedTeamId, team.leaderAgentId, filteredAgents)
+    return resolveTeamInternalLead(selectedTeamId, team.leaderAgentId, filteredAgents)
   }, [selectedTeamId, teams, filteredAgents])
 
   const { rawNodes, rawEdges } = useMemo(
-    () => buildGraphElements(filteredAgents, agentFiles, teams, resolvedLeaderAgentId),
-    [agentStructureKey, agentFiles, teamsMetaKey, resolvedLeaderAgentId], // intentional: string keys
+    () =>
+      buildGraphElements(
+        filteredAgents,
+        agentFiles,
+        teams,
+        teamInternalLeadId,
+        booZeroAgent,
+        selectedTeamId,
+      ),
+    [agentStructureKey, agentFiles, teamsMetaKey, teamInternalLeadId, booZeroAgent, selectedTeamId], // intentional: string keys + scalars
   )
 
   useEffect(() => {
@@ -162,16 +178,30 @@ export function buildGraphElements(
   agentFiles: Map<string, { toolsMd: string | null; agentsMd: string | null }>,
   teams: Team[] = [],
   /**
-   * The team leader's agent ID — used as the spanning-tree root over
-   * dependency edges. Each Boo gets ONE primary parent (the BFS edge that
-   * first reached it); all other dependency edges are tagged secondary
-   * and rendered hover-only.
+   * The team-internal lead's agent ID (CTO, Team Lead, etc.) when a genuine
+   * leader role is detected. Boo Zero (when present) is the spanning-tree
+   * ROOT; the internal lead, if any, sits one layer below as the bridge
+   * between Boo Zero and the rest of the team.
    *
-   * Pass `null` to skip the spanning-tree filter — every dependency edge
-   * is treated as primary. Used when no team is selected (showing all
-   * agents) or when the leader can't be resolved.
+   * Pass `null` when no internal lead exists — Boo Zero connects directly
+   * to every team member.
    */
-  leaderAgentId: string | null = null,
+  teamInternalLeadId: string | null = null,
+  /**
+   * Boo Zero — the universal team leader. When present AND a team is
+   * selected, we synthesize a Boo-Zero `BooNode` (`isUniversalLeader: true`)
+   * plus synthetic dependency edges so the spanning tree roots from Boo Zero.
+   * When no team is selected (all-agents view), Boo Zero appears as a
+   * regular node (it has `teamId: null`); we just flip the `isUniversalLeader`
+   * flag on its existing `BooNodeData`.
+   */
+  booZeroAgent: AgentState | null = null,
+  /**
+   * The currently selected team id, or null for the all-agents view. We need
+   * this separately from `agents` because the synthetic-edge logic only fires
+   * when a team is being shown.
+   */
+  selectedTeamId: string | null = null,
 ): { rawNodes: GraphNode[]; rawEdges: GraphEdge[] } {
   const depEdges: GraphEdge[] = []
   const skillNodes: GraphNode[] = []
@@ -183,9 +213,20 @@ export function buildGraphElements(
   const agentNameToId = new Map(agents.map((a) => [a.name.toLowerCase().trim(), a.id]))
   const teamsById = new Map(teams.map((t) => [t.id, t]))
 
-  // BooNodes — one per agent
+  // BooNodes — one per agent. When a team is selected AND Boo Zero exists,
+  // we synthesize a Boo-Zero node here too even though Boo Zero is teamless
+  // (filtered out of `agents`). The synthetic Boo Zero gets
+  // `isUniversalLeader: true` so the renderer adds the crown badge and the
+  // halo layer excludes it from team grouping.
+  const agentsAlreadyContainsBooZero = booZeroAgent
+    ? agents.some((a) => a.id === booZeroAgent.id)
+    : false
+  const synthesizeBooZeroNode =
+    Boolean(booZeroAgent) && Boolean(selectedTeamId) && !agentsAlreadyContainsBooZero
+
   const booNodes: GraphNode[] = agents.map((agent) => {
     const team = agent.teamId ? teamsById.get(agent.teamId) : null
+    const isUniversalLeader = Boolean(booZeroAgent && agent.id === booZeroAgent.id)
     return {
       id: `boo-${agent.id}`,
       type: 'boo' as const,
@@ -201,10 +242,31 @@ export function buildGraphElements(
           teamColor: team.color,
           teamEmoji: team.icon,
         }),
+        ...(isUniversalLeader ? { isUniversalLeader: true } : {}),
       } satisfies BooNodeData,
       position: { x: 0, y: 0 },
     }
   })
+
+  if (synthesizeBooZeroNode && booZeroAgent) {
+    booNodes.push({
+      id: `boo-${booZeroAgent.id}`,
+      type: 'boo' as const,
+      data: {
+        agentId: booZeroAgent.id,
+        name: booZeroAgent.name,
+        status: booZeroAgent.status ?? 'idle',
+        model: booZeroAgent.model,
+        isStreaming: booZeroAgent.status === 'running',
+        // Boo Zero stays `teamId: null` even in a team-selected view — the
+        // `TeamHaloLayer` reads `data.teamId` for grouping and intentionally
+        // omits Boo Zero from any team hull.
+        teamId: null,
+        isUniversalLeader: true,
+      } satisfies BooNodeData,
+      position: { x: 0, y: 0 },
+    })
+  }
 
   for (const agent of agents) {
     const files = agentFiles.get(agent.id)
@@ -287,15 +349,75 @@ export function buildGraphElements(
     }
   }
 
-  // ── Spanning tree over dependency edges (org-chart filter) ──────────────
-  // BFS from the team leader to determine each Boo's "primary parent." All
-  // other dependency edges are tagged `isPrimary: false` so the renderer
-  // can hide them by default and reveal on hover. ELK only sees primary
-  // edges, which produces clean top-down rank structure.
+  // ── Synthetic Boo-Zero → team edges ─────────────────────────────────────
+  // The Plan agent's risk #2: no team agent's AGENTS.md mentions Boo Zero
+  // in a form the parser recognizes, so the undirected BFS in
+  // `computeSpanningTree` rooted at Boo Zero would return an empty tree
+  // (every team member becomes an orphan). We synthesize edges from Boo
+  // Zero to the team-internal lead (when present, lead → members cascade
+  // naturally through existing AGENTS.md routing) OR directly to every
+  // team member.
   //
-  // When `leaderAgentId` is null (no team selected) we skip the filter
-  // and treat every dependency edge as primary — fall back to full graph.
-  const rootNodeId = leaderAgentId ? `boo-${leaderAgentId}` : null
+  // Synthetic edges are tagged `isSynthetic: true` so consumers that scan
+  // AGENTS.md routing data (e.g. "Refresh Protocol") can skip them. They
+  // route through the same handle topology as regular dependency edges.
+  if (booZeroAgent && selectedTeamId) {
+    const teamMemberIds = agents.filter((a) => a.teamId === selectedTeamId).map((a) => a.id)
+    if (teamInternalLeadId && teamMemberIds.includes(teamInternalLeadId)) {
+      // Boo Zero → internal lead. Existing AGENTS.md edges among
+      // (lead, members) will fan out via the spanning tree.
+      depEdges.push({
+        id: `dep-syn-${booZeroAgent.id}-${teamInternalLeadId}`,
+        type: 'dependency',
+        source: `boo-${booZeroAgent.id}`,
+        sourceHandle: 'center',
+        target: `boo-${teamInternalLeadId}`,
+        targetHandle: 'center-target',
+        data: { isSynthetic: true },
+      })
+      // Also synthesize edges from the lead to each non-lead member so the
+      // spanning tree always reaches everyone even if AGENTS.md routing is
+      // sparse (defensive — many awesome-openclaw teams have hub-spoke
+      // routing already, but synthetic backstops every shape).
+      for (const memberId of teamMemberIds) {
+        if (memberId === teamInternalLeadId) continue
+        depEdges.push({
+          id: `dep-syn-${teamInternalLeadId}-${memberId}`,
+          type: 'dependency',
+          source: `boo-${teamInternalLeadId}`,
+          sourceHandle: 'center',
+          target: `boo-${memberId}`,
+          targetHandle: 'center-target',
+          data: { isSynthetic: true },
+        })
+      }
+    } else {
+      // No internal lead → Boo Zero connects to every team member directly.
+      for (const memberId of teamMemberIds) {
+        depEdges.push({
+          id: `dep-syn-${booZeroAgent.id}-${memberId}`,
+          type: 'dependency',
+          source: `boo-${booZeroAgent.id}`,
+          sourceHandle: 'center',
+          target: `boo-${memberId}`,
+          targetHandle: 'center-target',
+          data: { isSynthetic: true },
+        })
+      }
+    }
+  }
+
+  // ── Spanning tree over dependency edges (org-chart filter) ──────────────
+  // BFS from the spanning-tree root. When Boo Zero is present in a
+  // team-selected view, Boo Zero is the root. Otherwise we fall back to
+  // the team-internal lead. When neither exists (all-agents view), we skip
+  // the filter and treat every dependency edge as primary.
+  const rootNodeId =
+    booZeroAgent && selectedTeamId
+      ? `boo-${booZeroAgent.id}`
+      : teamInternalLeadId
+        ? `boo-${teamInternalLeadId}`
+        : null
   const treeResult = rootNodeId
     ? computeSpanningTree(
         depEdges.map((e) => ({ id: e.id, source: e.source, target: e.target })),

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -10,7 +10,15 @@ import { parseAgentsMd } from './parsers/parseAgentsMd'
 import { computeSpanningTree } from './computeSpanningTree'
 import { resolveTeamInternalLead } from '@/lib/resolveTeamLeader'
 import type { AgentState } from '@/stores/fleet'
-import type { GraphNode, GraphEdge, BooNodeData, SkillNodeData, ResourceNodeData } from './types'
+import type {
+  GraphNode,
+  GraphEdge,
+  BooNodeData,
+  SkillNodeData,
+  ResourceNodeData,
+  TeamRootNodeData,
+  GhostGraphScope,
+} from './types'
 
 // ─── useGraphData ─────────────────────────────────────────────────────────────
 //
@@ -20,26 +28,41 @@ import type { GraphNode, GraphEdge, BooNodeData, SkillNodeData, ResourceNodeData
 // Two separate update paths:
 //   1. Structural rebuild — when agents are added/removed or files change.
 //   2. Status-only patch  — when an agent's runtime status changes (no layout re-trigger).
+//
+// `scope` controls the data source:
+//   - `'team'` (default): filter by `selectedTeamId`; Boo Zero is synthesized
+//     into the canvas with cross-team edges for the selected team only.
+//   - `'atlas'`: ignore `selectedTeamId`; include all agents and synthesize
+//     Boo Zero with edges fanning out to every team's internal lead.
+//
+// **Singleton safety**: `useGraphStore` and this hook are singletons. The
+// only consumer (`GhostGraph`) is mounted inside `ContentArea`'s
+// `<AnimatePresence mode="wait">`, which guarantees at most one
+// `GhostGraphPanel` is mounted at any time — so the singleton-state
+// assumption holds even with two scopes in the codebase.
 
-export function useGraphData(): void {
+export function useGraphData(scope: GhostGraphScope = 'team'): void {
   const agents = useFleetStore((s) => s.agents)
   const client = useConnectionStore((s) => s.client)
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
   const teams = useTeamStore((s) => s.teams)
   const { setAgentFiles, setLoadingFiles, setFilesError, agentFiles, refreshKey } = useGraphStore()
 
-  // Filter agents by selected team (null = show all)
-  const filteredAgents = useMemo(
-    () => (selectedTeamId ? agents.filter((a) => a.teamId === selectedTeamId) : agents),
-    [agents, selectedTeamId],
-  )
+  // In atlas scope we ignore `selectedTeamId` and pull every agent into the
+  // canvas. In team scope we filter to the selected team (null = no team
+  // currently selected; show all as before).
+  const filteredAgents = useMemo(() => {
+    if (scope === 'atlas') return agents
+    return selectedTeamId ? agents.filter((a) => a.teamId === selectedTeamId) : agents
+  }, [agents, selectedTeamId, scope])
 
-  // Resolve Boo Zero (universal team leader). When a team is selected AND Boo
-  // Zero is present, we include Boo Zero in the agents that drive both file
-  // fetching AND graph building — so Boo Zero's own TOOLS.md is fetched and
-  // its skill / resource children appear on click (peacock-feather expand).
-  // Boo Zero is teamless in the DB (`teamId === null`) so the per-team filter
-  // above excludes it; this is where we re-include it for graph purposes.
+  // Resolve Boo Zero (universal team leader). When relevant (team is
+  // selected in team-scope, or always in atlas-scope), we include Boo Zero
+  // in the agents that drive both file fetching AND graph building — so
+  // Boo Zero's own TOOLS.md is fetched and its skill / resource children
+  // appear on click (peacock-feather expand). Boo Zero is teamless in the
+  // DB (`teamId === null`) so the per-team filter excludes it; this is
+  // where we re-include it for graph purposes.
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
   const booZeroAgent = useMemo(
     () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
@@ -50,7 +73,13 @@ export function useGraphData(): void {
   // built graph. Dedup by id in case Boo Zero is somehow already in filtered
   // (auto-migrate edge case).
   const graphAgents = useMemo(() => {
-    if (!booZeroAgent || !selectedTeamId) return filteredAgents
+    if (!booZeroAgent) return filteredAgents
+    // Atlas always includes Boo Zero; team scope only includes Boo Zero
+    // when a team is actually selected (preserves the pre-atlas behavior
+    // for `selectedTeamId === null`, which is otherwise an all-agents
+    // peek without the universal-leader synthesis).
+    const shouldIncludeBooZero = scope === 'atlas' || Boolean(selectedTeamId)
+    if (!shouldIncludeBooZero) return filteredAgents
     const combined = [...filteredAgents, booZeroAgent]
     const seen = new Set<string>()
     const out: typeof combined = []
@@ -60,7 +89,7 @@ export function useGraphData(): void {
       out.push(a)
     }
     return out
-  }, [filteredAgents, booZeroAgent, selectedTeamId])
+  }, [filteredAgents, booZeroAgent, selectedTeamId, scope])
 
   // Stable string key for team metadata — drives structural rebuild when a
   // team is renamed/recolored mid-session so BooNodeData.teamName/Color/Emoji
@@ -70,17 +99,24 @@ export function useGraphData(): void {
     [teams],
   )
 
-  // ── 0. Reset layout on team switch ──────────────────────────────────────────
+  // ── 0. Reset layout on team OR scope switch ────────────────────────────────
+  // We also reset when `scope` changes so an atlas → team-scope transition
+  // (or vice-versa) clears stale positions before the next ELK pass.
+  // `GhostGraphPanel` does this reset itself as well; this is a defensive
+  // duplicate so the hook stays correct even if called from a different
+  // panel in the future.
   const prevTeamIdRef = useRef(selectedTeamId)
+  const prevScopeRef = useRef(scope)
   useEffect(() => {
-    if (prevTeamIdRef.current === selectedTeamId) return
+    if (prevTeamIdRef.current === selectedTeamId && prevScopeRef.current === scope) return
     prevTeamIdRef.current = selectedTeamId
+    prevScopeRef.current = scope
     const store = useGraphStore.getState()
     store.resetLayout()
     store.setNodes([])
     store.setEdges([])
     useGraphStore.setState({ agentFiles: new Map() })
-  }, [selectedTeamId])
+  }, [selectedTeamId, scope])
 
   // Stable string keys for dependency comparison
   const agentStructureKey = graphAgents.map((a) => `${a.id}:${a.name}`).join('|')
@@ -128,19 +164,35 @@ export function useGraphData(): void {
   }, [client, agentStructureKey, refreshKey]) // intentional: string key covers structural changes; refreshKey for skill install
 
   // ── 2. Structural rebuild ────────────────────────────────────────────────────
-  // We pass `graphAgents` (filteredAgents + Boo Zero when team selected) so
+  // We pass `graphAgents` (filteredAgents + Boo Zero when appropriate) so
   // Boo Zero's BooNode is created naturally by the `agents.map` loop in
   // `buildGraphElements` AND its TOOLS.md gets parsed into skill / resource
   // children. Previously Boo Zero was added as a synthetic node AFTER the
   // skill loop, so clicking Boo Zero showed no skill children — production
   // bug reported by the user. The synthesized edges (Boo Zero → lead → members
   // or Boo Zero → each member) still run for the team-routing concern.
+  //
+  // Team scope: single team-internal lead for `selectedTeamId`.
+  // Atlas scope: a Map of teamId → leadId covering EVERY team that has
+  // members. The atlas branch builds the map by running
+  // `resolveTeamInternalLead` for each team using the full `agents` list
+  // (filteredAgents === agents in atlas), so a team's members are visible
+  // even though the team isn't "selected."
   const teamInternalLeadId = useMemo(() => {
-    if (!selectedTeamId) return null
+    if (scope === 'atlas' || !selectedTeamId) return null
     const team = teams.find((t) => t.id === selectedTeamId)
     if (!team) return null
     return resolveTeamInternalLead(selectedTeamId, team.leaderAgentId, filteredAgents)
-  }, [selectedTeamId, teams, filteredAgents])
+  }, [selectedTeamId, teams, filteredAgents, scope])
+
+  const teamInternalLeadByTeamId = useMemo(() => {
+    if (scope !== 'atlas') return null
+    const map = new Map<string, string | null>()
+    for (const team of teams) {
+      map.set(team.id, resolveTeamInternalLead(team.id, team.leaderAgentId, agents))
+    }
+    return map
+  }, [teams, agents, scope])
 
   const { rawNodes, rawEdges } = useMemo(
     () =>
@@ -151,8 +203,19 @@ export function useGraphData(): void {
         teamInternalLeadId,
         booZeroAgent,
         selectedTeamId,
+        scope,
+        teamInternalLeadByTeamId,
       ),
-    [agentStructureKey, agentFiles, teamsMetaKey, teamInternalLeadId, booZeroAgent, selectedTeamId], // intentional: string keys + scalars
+    [
+      agentStructureKey,
+      agentFiles,
+      teamsMetaKey,
+      teamInternalLeadId,
+      booZeroAgent,
+      selectedTeamId,
+      scope,
+      teamInternalLeadByTeamId,
+    ], // intentional: string keys + scalars + maps
   )
 
   useEffect(() => {
@@ -202,30 +265,44 @@ export function buildGraphElements(
   agentFiles: Map<string, { toolsMd: string | null; agentsMd: string | null }>,
   teams: Team[] = [],
   /**
-   * The team-internal lead's agent ID (CTO, Team Lead, etc.) when a genuine
-   * leader role is detected. Boo Zero (when present) is the spanning-tree
+   * Team-scope only — the single team-internal lead's agent ID (CTO,
+   * Team Lead, etc.) when a genuine leader role is detected for the
+   * currently selected team. Boo Zero (when present) is the spanning-tree
    * ROOT; the internal lead, if any, sits one layer below as the bridge
-   * between Boo Zero and the rest of the team.
-   *
-   * Pass `null` when no internal lead exists — Boo Zero connects directly
-   * to every team member.
+   * between Boo Zero and the rest of the team. Pass `null` when no
+   * internal lead exists — Boo Zero connects directly to every team
+   * member. **Ignored in atlas scope**; use `teamInternalLeadByTeamId`
+   * instead.
    */
   teamInternalLeadId: string | null = null,
   /**
-   * Boo Zero — the universal team leader. When present AND a team is
-   * selected, we synthesize a Boo-Zero `BooNode` (`isUniversalLeader: true`)
-   * plus synthetic dependency edges so the spanning tree roots from Boo Zero.
-   * When no team is selected (all-agents view), Boo Zero appears as a
-   * regular node (it has `teamId: null`); we just flip the `isUniversalLeader`
-   * flag on its existing `BooNodeData`.
+   * Boo Zero — the universal team leader. When present, we synthesize a
+   * Boo-Zero `BooNode` (`isUniversalLeader: true`) plus synthetic
+   * dependency edges so the spanning tree roots from Boo Zero. Synthesis
+   * fires when:
+   *   - team scope + a team is selected (existing behavior), OR
+   *   - atlas scope (always, when Boo Zero exists).
    */
   booZeroAgent: AgentState | null = null,
   /**
-   * The currently selected team id, or null for the all-agents view. We need
-   * this separately from `agents` because the synthetic-edge logic only fires
-   * when a team is being shown.
+   * The currently selected team id (team scope only). Used to constrain
+   * the synthetic-edge logic to the single selected team. **Ignored in
+   * atlas scope** — atlas iterates every team in `teams` instead.
    */
   selectedTeamId: string | null = null,
+  /**
+   * Which view are we rendering? See `GhostGraphScope` for details.
+   * `'team'` (default) preserves the historical single-team behavior;
+   * `'atlas'` switches to multi-team synthesis and a forest fallback
+   * spanning tree when Boo Zero is absent.
+   */
+  scope: GhostGraphScope = 'team',
+  /**
+   * Atlas-scope only — Map of teamId → internal lead agent id (or `null`
+   * when a team has no detected leader). Required when `scope === 'atlas'`;
+   * `null` in team scope.
+   */
+  teamInternalLeadByTeamId: Map<string, string | null> | null = null,
 ): { rawNodes: GraphNode[]; rawEdges: GraphEdge[] } {
   const depEdges: GraphEdge[] = []
   const skillNodes: GraphNode[] = []
@@ -237,16 +314,19 @@ export function buildGraphElements(
   const agentNameToId = new Map(agents.map((a) => [a.name.toLowerCase().trim(), a.id]))
   const teamsById = new Map(teams.map((t) => [t.id, t]))
 
-  // BooNodes — one per agent. When a team is selected AND Boo Zero exists,
-  // we synthesize a Boo-Zero node here too even though Boo Zero is teamless
-  // (filtered out of `agents`). The synthetic Boo Zero gets
-  // `isUniversalLeader: true` so the renderer adds the crown badge and the
-  // halo layer excludes it from team grouping.
+  // BooNodes — one per agent. When Boo Zero exists and is relevant to the
+  // current scope, we synthesize a Boo-Zero node here too even though Boo
+  // Zero is teamless (filtered out of `agents` in team scope when a team
+  // is selected — atlas always passes Boo Zero in already, but we guard
+  // here regardless). The synthetic Boo Zero gets `isUniversalLeader: true`
+  // so the renderer adds the crown badge and the halo layer excludes it
+  // from team grouping.
   const agentsAlreadyContainsBooZero = booZeroAgent
     ? agents.some((a) => a.id === booZeroAgent.id)
     : false
-  const synthesizeBooZeroNode =
-    Boolean(booZeroAgent) && Boolean(selectedTeamId) && !agentsAlreadyContainsBooZero
+  const booZeroIsRelevantForScope =
+    scope === 'atlas' ? Boolean(booZeroAgent) : Boolean(booZeroAgent) && Boolean(selectedTeamId)
+  const synthesizeBooZeroNode = booZeroIsRelevantForScope && !agentsAlreadyContainsBooZero
 
   const booNodes: GraphNode[] = agents.map((agent) => {
     const team = agent.teamId ? teamsById.get(agent.teamId) : null
@@ -374,41 +454,74 @@ export function buildGraphElements(
   }
 
   // ── Synthetic Boo-Zero → team edges ─────────────────────────────────────
-  // The Plan agent's risk #2: no team agent's AGENTS.md mentions Boo Zero
-  // in a form the parser recognizes, so the undirected BFS in
-  // `computeSpanningTree` rooted at Boo Zero would return an empty tree
-  // (every team member becomes an orphan). We synthesize edges from Boo
-  // Zero to the team-internal lead (when present, lead → members cascade
-  // naturally through existing AGENTS.md routing) OR directly to every
-  // team member.
+  // Without these, the undirected BFS in `computeSpanningTree` rooted at
+  // Boo Zero would return an empty tree (no team agent's AGENTS.md
+  // mentions Boo Zero in a form the parser recognizes) and every team
+  // member would render as an orphan. We synthesize:
+  //   - Boo Zero → team-internal lead (when one exists), and
+  //   - lead → each non-lead member (defensive — many teams have hub-spoke
+  //     AGENTS.md routing already, but the synthetic backstop guarantees
+  //     every member is reached by the spanning tree regardless of how
+  //     sparse their routing rules are).
+  //   - Or, when no internal lead exists, Boo Zero → each member directly.
   //
   // Synthetic edges are tagged `isSynthetic: true` so consumers that scan
   // AGENTS.md routing data (e.g. "Refresh Protocol") can skip them. They
   // route through the same handle topology as regular dependency edges.
-  if (booZeroAgent && selectedTeamId) {
-    const teamMemberIds = agents.filter((a) => a.teamId === selectedTeamId).map((a) => a.id)
-    if (teamInternalLeadId && teamMemberIds.includes(teamInternalLeadId)) {
-      // Boo Zero → internal lead. Existing AGENTS.md edges among
-      // (lead, members) will fan out via the spanning tree.
+  //
+  // **Two-phase BFS prep**: synthetic edges are pushed BEFORE the natural
+  // AGENTS.md cross-team @mentions could shift them in the array, but
+  // both already exist by this point in execution. The actual BFS-order
+  // guarantee is enforced down below at the `computeSpanningTree` call
+  // site — we partition `depEdges` into synthetic-first / mention-second
+  // and concatenate so synthetic edges win adjacency-insertion order in
+  // the BFS, preventing a cross-team @mention from stealing primary-edge
+  // status from the Boo-Zero → lead synthetic.
+  // ── Boo Zero synthetic edges ────────────────────────────────────────────
+  // Two distinct shapes here, depending on scope:
+  //
+  // **Team scope** (group chat): hub-spoke around Boo Zero (or the team
+  // lead, when one exists). Every member sits at the same hierarchy level
+  // under that hub. Single team on screen → no risk of the cross-team
+  // visual conflation we get in atlas, so the layout is unchanged from
+  // its long-standing behavior.
+  //
+  // **Atlas scope** (all teams): we insert an INVISIBLE `team-root` node
+  // between Boo Zero and each team's cluster. The resulting hierarchy is:
+  //
+  //     Boo Zero               ← level 0
+  //        │
+  //     ┌──┴──┐                 ← TOP trunk (BZ → team-roots)
+  //     │     │
+  //     TR-A  TR-B              ← level 1 (invisible junctions)
+  //     │     │
+  //   ┌─┼─┐ ┌─┴─┐                ← per-team sub-trunks
+  //   m m m m m m                ← level 2 (team members)
+  //
+  // Team-root nodes render as a 1px invisible point with anchor handles,
+  // so visually the canvas shows ONLY: Boo Zero at top → top trunk → each
+  // team's sub-trunk → team members. This matches the user's hand-drawn
+  // sketch and keeps every team member at the SAME hierarchy level as
+  // they sit at in the team-scoped Ghost Graph (no extra visible level).
+  const synthesizeTeamScopeEdges = (bz: AgentState, teamId: string, teamLeadId: string | null) => {
+    const teamMemberIds = agents.filter((a) => a.teamId === teamId).map((a) => a.id)
+    if (teamMemberIds.length === 0) return // skip empty teams
+    if (teamLeadId && teamMemberIds.includes(teamLeadId)) {
       depEdges.push({
-        id: `dep-syn-${booZeroAgent.id}-${teamInternalLeadId}`,
+        id: `dep-syn-${bz.id}-${teamLeadId}`,
         type: 'dependency',
-        source: `boo-${booZeroAgent.id}`,
+        source: `boo-${bz.id}`,
         sourceHandle: 'center',
-        target: `boo-${teamInternalLeadId}`,
+        target: `boo-${teamLeadId}`,
         targetHandle: 'center-target',
         data: { isSynthetic: true },
       })
-      // Also synthesize edges from the lead to each non-lead member so the
-      // spanning tree always reaches everyone even if AGENTS.md routing is
-      // sparse (defensive — many awesome-openclaw teams have hub-spoke
-      // routing already, but synthetic backstops every shape).
       for (const memberId of teamMemberIds) {
-        if (memberId === teamInternalLeadId) continue
+        if (memberId === teamLeadId) continue
         depEdges.push({
-          id: `dep-syn-${teamInternalLeadId}-${memberId}`,
+          id: `dep-syn-${teamLeadId}-${memberId}`,
           type: 'dependency',
-          source: `boo-${teamInternalLeadId}`,
+          source: `boo-${teamLeadId}`,
           sourceHandle: 'center',
           target: `boo-${memberId}`,
           targetHandle: 'center-target',
@@ -416,12 +529,11 @@ export function buildGraphElements(
         })
       }
     } else {
-      // No internal lead → Boo Zero connects to every team member directly.
       for (const memberId of teamMemberIds) {
         depEdges.push({
-          id: `dep-syn-${booZeroAgent.id}-${memberId}`,
+          id: `dep-syn-${bz.id}-${memberId}`,
           type: 'dependency',
-          source: `boo-${booZeroAgent.id}`,
+          source: `boo-${bz.id}`,
           sourceHandle: 'center',
           target: `boo-${memberId}`,
           targetHandle: 'center-target',
@@ -430,29 +542,148 @@ export function buildGraphElements(
       }
     }
   }
+  const teamRootNodes: GraphNode[] = []
+  const synthesizeAtlasTeamRootEdges = (bz: AgentState, teamId: string) => {
+    const teamMemberIds = agents.filter((a) => a.teamId === teamId).map((a) => a.id)
+    if (teamMemberIds.length === 0) return // skip empty teams
+    const teamRootId = `team-root-${teamId}`
+    teamRootNodes.push({
+      id: teamRootId,
+      type: 'team-root' as const,
+      data: { teamId } satisfies TeamRootNodeData,
+      position: { x: 0, y: 0 },
+    })
+    // BZ → team-root
+    depEdges.push({
+      id: `dep-syn-${bz.id}-${teamRootId}`,
+      type: 'dependency',
+      source: `boo-${bz.id}`,
+      sourceHandle: 'center',
+      target: teamRootId,
+      targetHandle: 'center-target',
+      data: { isSynthetic: true },
+    })
+    // team-root → each member directly. We deliberately do NOT route
+    // through a team's "lead" in atlas — the user wanted every team
+    // member at the same hierarchy level as siblings (matches the
+    // hand-drawn sketch). The team-scoped Ghost Graph still preserves
+    // the lead-is-hub structure via `synthesizeTeamScopeEdges`.
+    for (const memberId of teamMemberIds) {
+      depEdges.push({
+        id: `dep-syn-${teamRootId}-${memberId}`,
+        type: 'dependency',
+        source: teamRootId,
+        sourceHandle: 'center',
+        target: `boo-${memberId}`,
+        targetHandle: 'center-target',
+        data: { isSynthetic: true },
+      })
+    }
+  }
+  if (booZeroAgent) {
+    if (scope === 'atlas') {
+      // Atlas: insert an invisible team-root junction per team.
+      for (const team of teams) {
+        synthesizeAtlasTeamRootEdges(booZeroAgent, team.id)
+      }
+    } else if (selectedTeamId) {
+      // Team scope: single team, no team-root needed.
+      synthesizeTeamScopeEdges(booZeroAgent, selectedTeamId, teamInternalLeadId)
+    }
+  }
 
   // ── Spanning tree over dependency edges (org-chart filter) ──────────────
-  // BFS from the spanning-tree root. When Boo Zero is present in a
-  // team-selected view, Boo Zero is the root. Otherwise we fall back to
-  // the team-internal lead. When neither exists (all-agents view), we skip
-  // the filter and treat every dependency edge as primary.
-  const rootNodeId =
-    booZeroAgent && selectedTeamId
-      ? `boo-${booZeroAgent.id}`
-      : teamInternalLeadId
-        ? `boo-${teamInternalLeadId}`
-        : null
-  const treeResult = rootNodeId
-    ? computeSpanningTree(
-        depEdges.map((e) => ({ id: e.id, source: e.source, target: e.target })),
-        rootNodeId,
-      )
-    : {
-        primaryEdgeIds: new Set(depEdges.map((e) => e.id)),
-        parentMap: new Map<string, string>(),
-        reachableNodeIds: new Set<string>(),
+  // BFS over the dependency edges to pick ONE primary parent per reachable
+  // node (the "primary edge") so the rendered hierarchy reads as an org
+  // chart. All other dependency edges become secondary and only render on
+  // hover.
+  //
+  // Two-phase BFS for atlas (and team scope when Boo Zero is present):
+  // the BFS adjacency map is built in array order, and `computeSpanningTree`
+  // claims the FIRST discovering edge for each node. We sort `depEdges` so
+  // synthetic Boo-Zero → team edges come first, then real AGENTS.md edges.
+  // This guarantees synthetic edges win the BFS race so a cross-team
+  // @mention can't steal a member as its primary parent away from the
+  // Boo Zero → team-lead synthetic edge.
+  //
+  // Forest fallback when Boo Zero is absent (atlas with no Boo Zero, OR
+  // team scope without a Boo Zero AND without a team-internal lead): we
+  // union per-root BFS results so each disconnected sub-tree gets its
+  // own clean primary backbone. In atlas this means one BFS per team's
+  // internal lead; in team scope we keep the single-root behavior (or
+  // skip the filter when there's no valid root, treating all edges as
+  // primary — the historical fallback).
+  const orderedDepEdges =
+    scope === 'atlas' || booZeroAgent
+      ? [
+          ...depEdges.filter((e) => (e.data as { isSynthetic?: boolean })?.isSynthetic),
+          ...depEdges.filter((e) => !(e.data as { isSynthetic?: boolean })?.isSynthetic),
+        ]
+      : depEdges
+  const spanEdges = orderedDepEdges.map((e) => ({ id: e.id, source: e.source, target: e.target }))
+
+  const treeRoots: string[] = []
+  if (booZeroAgent && (scope === 'atlas' || selectedTeamId)) {
+    treeRoots.push(`boo-${booZeroAgent.id}`)
+  } else if (scope === 'atlas') {
+    // Forest fallback — one BFS per team-internal lead (teams without
+    // leads contribute no primary edges and their members render as
+    // disconnected nodes, which is the right signal).
+    if (teamInternalLeadByTeamId) {
+      for (const [, leadId] of teamInternalLeadByTeamId) {
+        if (leadId) treeRoots.push(`boo-${leadId}`)
       }
-  const { primaryEdgeIds, parentMap } = treeResult
+    }
+  } else if (teamInternalLeadId) {
+    treeRoots.push(`boo-${teamInternalLeadId}`)
+  }
+
+  let primaryEdgeIds: Set<string>
+  let parentMap: Map<string, string>
+  if (scope === 'atlas' && booZeroAgent) {
+    // **Atlas with Boo Zero: only synthetic edges are primary.**
+    // The user explicitly asked for every team Boo to sit at the same
+    // hierarchy level (matching their hand-drawn sketch). Including real
+    // AGENTS.md routes (member → sub-member) in the spanning tree pulls
+    // sub-children down a layer, producing the "two-tier teams with sub-
+    // children at level 3" bug. By restricting primary edges to the
+    // synthetic backbone (BZ → team-root + team-root → each member),
+    // every team Boo gets the SAME primary parent depth (team-root at
+    // level 1) regardless of any internal AGENTS.md hierarchy. Real
+    // intra-team routes still exist and render as secondary edges on
+    // hover, so the routing data isn't lost — just visually quieted.
+    primaryEdgeIds = new Set(
+      depEdges.filter((e) => (e.data as { isSynthetic?: boolean })?.isSynthetic).map((e) => e.id),
+    )
+    parentMap = new Map<string, string>()
+    // Build parentMap from synthetic edges so the edge-flip logic below
+    // recognises the (already-correct) source → target direction and
+    // leaves them alone. Without these entries the flip code's
+    // `parentMap.get(edge.source) === edge.target` check would
+    // false-trigger and silently invert the edges.
+    for (const edge of depEdges) {
+      if (!primaryEdgeIds.has(edge.id)) continue
+      parentMap.set(edge.target, edge.source)
+    }
+  } else if (treeRoots.length === 0) {
+    // No root → treat every dependency edge as primary (historical
+    // fallback used by the all-agents-no-team peek).
+    primaryEdgeIds = new Set(depEdges.map((e) => e.id))
+    parentMap = new Map<string, string>()
+  } else {
+    primaryEdgeIds = new Set()
+    parentMap = new Map<string, string>()
+    for (const root of treeRoots) {
+      const { primaryEdgeIds: rootIds, parentMap: rootParents } = computeSpanningTree(
+        spanEdges,
+        root,
+      )
+      for (const id of rootIds) primaryEdgeIds.add(id)
+      for (const [k, v] of rootParents) {
+        if (!parentMap.has(k)) parentMap.set(k, v)
+      }
+    }
+  }
 
   // For ELK to lay out the leader at the TOP under `layered DOWN`, every
   // primary edge must flow parent → child (source = parent, target = child).
@@ -494,12 +725,21 @@ export function buildGraphElements(
   // even when the math says they should overlap exactly. The trunk leader
   // draws the shared trunk; followers skip the trunk and draw only their
   // branch (vertical descent to their own child).
+  //
+  // In atlas, Boo Zero's outgoing primary edges all go to team-root
+  // junction nodes (one per team) — never to team members directly — so
+  // they form ONE clean shared trunk under Boo Zero with one corner
+  // branch per team-root. Each team-root's outgoing edges form its own
+  // per-team sub-trunk down to the team's members. Grouping by source
+  // alone gives both shapes naturally.
+  const trunkGroupKey = (edge: GraphEdge): string => edge.source
   const primaryBySource = new Map<string, GraphEdge[]>()
   for (const edge of depEdges) {
     if (!primaryEdgeIds.has(edge.id)) continue
-    const list = primaryBySource.get(edge.source) ?? []
+    const key = trunkGroupKey(edge)
+    const list = primaryBySource.get(key) ?? []
     list.push(edge)
-    primaryBySource.set(edge.source, list)
+    primaryBySource.set(key, list)
   }
   for (const [, siblings] of primaryBySource) {
     if (siblings.length <= 1) continue // single child — normal smooth-step is fine
@@ -537,7 +777,7 @@ export function buildGraphElements(
   }
 
   return {
-    rawNodes: [...booNodes, ...skillNodes, ...resourceNodes],
+    rawNodes: [...booNodes, ...teamRootNodes, ...skillNodes, ...resourceNodes],
     rawEdges: allEdges,
   }
 }

--- a/apps/web/src/features/graph/useGraphData.ts
+++ b/apps/web/src/features/graph/useGraphData.ts
@@ -34,6 +34,34 @@ export function useGraphData(): void {
     [agents, selectedTeamId],
   )
 
+  // Resolve Boo Zero (universal team leader). When a team is selected AND Boo
+  // Zero is present, we include Boo Zero in the agents that drive both file
+  // fetching AND graph building — so Boo Zero's own TOOLS.md is fetched and
+  // its skill / resource children appear on click (peacock-feather expand).
+  // Boo Zero is teamless in the DB (`teamId === null`) so the per-team filter
+  // above excludes it; this is where we re-include it for graph purposes.
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const booZeroAgent = useMemo(
+    () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
+    [agents, booZeroAgentId],
+  )
+
+  // "Graph agents" — the agents whose files we fetch and which appear in the
+  // built graph. Dedup by id in case Boo Zero is somehow already in filtered
+  // (auto-migrate edge case).
+  const graphAgents = useMemo(() => {
+    if (!booZeroAgent || !selectedTeamId) return filteredAgents
+    const combined = [...filteredAgents, booZeroAgent]
+    const seen = new Set<string>()
+    const out: typeof combined = []
+    for (const a of combined) {
+      if (seen.has(a.id)) continue
+      seen.add(a.id)
+      out.push(a)
+    }
+    return out
+  }, [filteredAgents, booZeroAgent, selectedTeamId])
+
   // Stable string key for team metadata — drives structural rebuild when a
   // team is renamed/recolored mid-session so BooNodeData.teamName/Color/Emoji
   // stay in sync without over-rebuilding on unrelated team store changes.
@@ -55,12 +83,12 @@ export function useGraphData(): void {
   }, [selectedTeamId])
 
   // Stable string keys for dependency comparison
-  const agentStructureKey = filteredAgents.map((a) => `${a.id}:${a.name}`).join('|')
-  const agentStatusKey = filteredAgents.map((a) => `${a.id}:${a.status}`).join('|')
+  const agentStructureKey = graphAgents.map((a) => `${a.id}:${a.name}`).join('|')
+  const agentStatusKey = graphAgents.map((a) => `${a.id}:${a.status}`).join('|')
 
   // Stable agent ID array (recomputed only when structure changes)
   const agentIds = useMemo(
-    () => filteredAgents.map((a) => a.id),
+    () => graphAgents.map((a) => a.id),
     [agentStructureKey], // intentionally using string key, not full agents array
   )
 
@@ -100,17 +128,13 @@ export function useGraphData(): void {
   }, [client, agentStructureKey, refreshKey]) // intentional: string key covers structural changes; refreshKey for skill install
 
   // ── 2. Structural rebuild ────────────────────────────────────────────────────
-  // Resolve Boo Zero (universal team leader). When a team is selected AND Boo
-  // Zero is present, `buildGraphElements` synthesizes a Boo-Zero node + edges
-  // from Boo Zero → genuine internal lead (if any) → members, OR directly to
-  // members when there's no internal lead. Boo Zero becomes the spanning-tree
-  // root, replacing the old "first team member" fallback.
-  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
-  const booZeroAgent = useMemo(
-    () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
-    [agents, booZeroAgentId],
-  )
-
+  // We pass `graphAgents` (filteredAgents + Boo Zero when team selected) so
+  // Boo Zero's BooNode is created naturally by the `agents.map` loop in
+  // `buildGraphElements` AND its TOOLS.md gets parsed into skill / resource
+  // children. Previously Boo Zero was added as a synthetic node AFTER the
+  // skill loop, so clicking Boo Zero showed no skill children — production
+  // bug reported by the user. The synthesized edges (Boo Zero → lead → members
+  // or Boo Zero → each member) still run for the team-routing concern.
   const teamInternalLeadId = useMemo(() => {
     if (!selectedTeamId) return null
     const team = teams.find((t) => t.id === selectedTeamId)
@@ -121,7 +145,7 @@ export function useGraphData(): void {
   const { rawNodes, rawEdges } = useMemo(
     () =>
       buildGraphElements(
-        filteredAgents,
+        graphAgents,
         agentFiles,
         teams,
         teamInternalLeadId,
@@ -150,7 +174,7 @@ export function useGraphData(): void {
     const store = useGraphStore.getState()
     if (store.nodes.length === 0) return
 
-    const agentMap = new Map(filteredAgents.map((a) => [a.id, a]))
+    const agentMap = new Map(graphAgents.map((a) => [a.id, a]))
 
     const patched = store.nodes.map((node) => {
       if (node.type !== 'boo') return node

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -65,12 +65,16 @@ const BOO_ENVELOPE_HEIGHT = 280
 // ─── Default node dimensions (used before ReactFlow measures them) ────────────
 
 function defaultWidth(nodeType: string | undefined): number {
+  // Team-root is an invisible 1px routing point — ELK needs to position
+  // it but it must NOT reserve a visible block of canvas around itself.
+  if (nodeType === 'team-root') return 1
   if (nodeType === 'skill') return 100
   if (nodeType === 'resource') return 140
   return 160
 }
 
 function defaultHeight(nodeType: string | undefined): number {
+  if (nodeType === 'team-root') return 1
   if (nodeType === 'skill') return 30
   if (nodeType === 'resource') return 64
   return 60
@@ -218,4 +222,151 @@ export async function computeElkLayout(
   })
 
   return targetAspect !== undefined ? stretchToAspect(elkResolved, targetAspect) : elkResolved
+}
+
+// ─── Atlas layout (per-team ELK + manual team-root + BZ positioning) ─────────
+//
+// Goal: every team renders with its own self-contained internal hierarchy
+// (matching its team-scoped Ghost Graph), and teams are visually distinct
+// horizontal clusters with Boo Zero presiding at the top. The user's
+// hand-drawn sketch maps directly:
+//
+//     Boo Zero               ← positioned manually at overall centroid X
+//        │
+//     ───┴───                ← TOP trunk = BZ's outgoing primary edges
+//     │     │                  (one per team-root) rendered by the
+//   TR-A  TR-B                trunk-and-branches edge logic
+//    │     │                ← invisible 1px team-root junctions, placed
+//   per-team-cluster          manually between BZ and each team's TOP
+//
+// We DON'T let ELK assign team-roots to layers globally, because different
+// teams have different internal depths (one team might have 4 levels of
+// AGENTS.md routing while another has 2). ELK's layered algorithm would
+// place team A's members and team B's members at different Y coordinates
+// because of unequal subtree depths — destroying the "all teams sit at
+// the same level under Boo Zero" visual the sketch shows.
+//
+// Instead: per-team ELK lays out each team's INTERNAL Boo cluster
+// independently. We then pack the clusters horizontally with a gap, and
+// manually position team-roots + Boo Zero at coordinates that produce
+// the two-trunk shape.
+
+// Atlas spacing constants. Geometry is deliberate:
+//
+//   y = 0           ┌─ Boo Zero envelope top
+//   y = 280         └─ Boo Zero envelope bottom (BZ source handle is here)
+//   y = ATLAS_TEAM_ROOT_Y = 400      ← team-root junctions (1px, invisible)
+//                                       BZ → team-root edges flow DOWNWARD
+//                                       cleanly because team-root is below
+//                                       BZ's envelope bottom by 120px.
+//   y = ATLAS_TEAM_TOP_Y = 540       ← every team's members (same Y → flat
+//                                       row, matches the user's sketch where
+//                                       every team Boo sits on the same line)
+//
+// BZ envelope bottom must be ABOVE team-root.y, otherwise the smooth-step
+// path bends backward and the arrowheads point UP — the "loose-end
+// arrows" bug.
+const ATLAS_MEMBER_GAP_X = 40 // horizontal gap between adjacent members within a team
+const ATLAS_TEAM_GAP_X = 200 // horizontal gap between adjacent team clusters
+const ATLAS_BZ_Y = 0 // Boo Zero's position.y (envelope top)
+const ATLAS_TEAM_ROOT_Y = 400 // team-root junctions' position.y (well below BZ envelope bottom = 280)
+const ATLAS_TEAM_TOP_Y = 540 // Y where each team's row of members starts
+
+export async function computeAtlasLayout(
+  nodes: GraphNode[],
+  _primaryDepEdges: GraphEdge[],
+  savedPositions: LayoutData['positions'],
+  teamOrder: string[],
+): Promise<GraphNode[]> {
+  if (nodes.length === 0) return nodes
+
+  // Partition nodes by role.
+  let booZero: GraphNode | undefined
+  const teamRoots: GraphNode[] = []
+  const teamBoos: GraphNode[] = []
+  for (const n of nodes) {
+    if (n.type === 'boo') {
+      const data = n.data as { isUniversalLeader?: boolean; teamId?: string | null }
+      if (data.isUniversalLeader) {
+        booZero = n
+      } else if (data.teamId) {
+        teamBoos.push(n)
+      }
+    } else if (n.type === 'team-root') {
+      teamRoots.push(n)
+    }
+  }
+
+  // Group team Boos by teamId
+  const boosByTeam = new Map<string, GraphNode[]>()
+  for (const n of teamBoos) {
+    const teamId = (n.data as { teamId?: string | null }).teamId
+    if (!teamId) continue
+    if (!boosByTeam.has(teamId)) boosByTeam.set(teamId, [])
+    boosByTeam.get(teamId)!.push(n)
+  }
+
+  // Order teams: stable from `teamOrder`, append unknowns at the end.
+  const orderedTeamIds: string[] = []
+  for (const id of teamOrder) {
+    if (boosByTeam.has(id)) orderedTeamIds.push(id)
+  }
+  for (const id of boosByTeam.keys()) {
+    if (!orderedTeamIds.includes(id)) orderedTeamIds.push(id)
+  }
+
+  // **Manual flat-row layout per team.** No ELK, no per-team sub-trees.
+  // The user's sketch shows every team Boo on a single horizontal row
+  // directly under its team-root. We honour that literally: each team
+  // becomes one row of Boos at ATLAS_TEAM_TOP_Y, spaced
+  // ATLAS_MEMBER_GAP_X apart. Internal AGENTS.md routing still exists
+  // as SECONDARY edges (rendered on hover) so the routing data isn't
+  // lost — just visually quieted.
+  const packed: GraphNode[] = []
+  const teamCentroidX = new Map<string, number>()
+  const memberStrideX = BOO_ENVELOPE_WIDTH + ATLAS_MEMBER_GAP_X
+  let xCursor = 0
+  for (const teamId of orderedTeamIds) {
+    const members = boosByTeam.get(teamId)!
+    // Determinism: sort members by id so reloads produce a stable layout.
+    const sortedMembers = [...members].sort((a, b) => a.id.localeCompare(b.id))
+    const teamStart = xCursor
+    for (let i = 0; i < sortedMembers.length; i++) {
+      const m = sortedMembers[i]!
+      packed.push({
+        ...m,
+        position: { x: teamStart + i * memberStrideX, y: ATLAS_TEAM_TOP_Y },
+      })
+    }
+    const teamWidth = sortedMembers.length * memberStrideX - ATLAS_MEMBER_GAP_X
+    // Centroid X for the team-root: midpoint between leftmost and
+    // rightmost member's envelope centres.
+    teamCentroidX.set(teamId, teamStart + teamWidth / 2 - BOO_ENVELOPE_WIDTH / 2)
+    xCursor = teamStart + teamWidth + ATLAS_TEAM_GAP_X
+  }
+  const totalWidth = Math.max(0, xCursor - ATLAS_TEAM_GAP_X)
+  const overallCentroidX = totalWidth / 2 - BOO_ENVELOPE_WIDTH / 2
+
+  // Position team-root junctions at each team's centroid X. ATLAS_TEAM_ROOT_Y
+  // is intentionally well below BZ's envelope bottom (280) so the smooth-
+  // step BZ → team-root path flows DOWNWARD cleanly.
+  for (const tr of teamRoots) {
+    const teamId = (tr.data as { teamId?: string }).teamId
+    const cx = teamId ? (teamCentroidX.get(teamId) ?? overallCentroidX) : overallCentroidX
+    packed.push({
+      ...tr,
+      position: { x: cx, y: ATLAS_TEAM_ROOT_Y },
+    })
+  }
+
+  // Position Boo Zero centered above all teams.
+  if (booZero) {
+    packed.push({
+      ...booZero,
+      position: { x: overallCentroidX, y: ATLAS_BZ_Y },
+    })
+  }
+
+  // Apply user-saved positions LAST (same precedence as computeElkLayout).
+  return packed.map((n) => (savedPositions[n.id] ? { ...n, position: savedPositions[n.id]! } : n))
 }

--- a/apps/web/src/features/graph/useGraphLayout.ts
+++ b/apps/web/src/features/graph/useGraphLayout.ts
@@ -37,16 +37,16 @@ const ELK_OPTIONS = {
   // Spacing tuned so the BOO_ENVELOPE (280px, accounts for orbital
   // children when expanded) clears between siblings AND between layers
   // with room for the bezier-curve dependency edge + arrowhead.
-  'elk.spacing.nodeNode': '100',
-  // Inter-layer spacing scales with the natural width of the widest
-  // layer. For star-shaped teams (one operator + many siblings on layer 2)
-  // ELK produces a wide-and-short layout that leaves lots of vertical
-  // empty space when fit into a wider-than-tall canvas. Spreading layers
-  // farther apart vertically pushes the layout aspect closer to the
-  // canvas aspect, eliminating the top / bottom empty bands without
-  // changing the topology. Set per-layout in computeElkLayout.
-  'elk.layered.spacing.nodeNodeBetweenLayers': '140',
-  'elk.padding': '[top=40, left=40, bottom=40, right=40]',
+  'elk.spacing.nodeNode': '80',
+  // Inter-layer spacing. Used to be 140 (allowing room for long bezier
+  // arrowheads + halo padding) but production showed this leaves massive
+  // empty vertical bands for the common 2-layer "Boo Zero + member row"
+  // case: 280 envelope + 140 gap + 280 envelope = 700 px vertical span
+  // for a tree of tiny circles. Reduced to 60 — the edge head still has
+  // room (arrows are <30 px), and `stretchToAspect` (below) handles
+  // canvas-aspect adaptation if more vertical span is actually needed.
+  'elk.layered.spacing.nodeNodeBetweenLayers': '60',
+  'elk.padding': '[top=24, left=40, bottom=24, right=40]',
 }
 
 // ─── Boo envelope dimensions ─────────────────────────────────────────────────
@@ -79,14 +79,30 @@ function defaultHeight(nodeType: string | undefined): number {
 // ─── Aspect-ratio post-processing ────────────────────────────────────────────
 // ELK lays out a hierarchy by topology, not by canvas geometry. For a
 // star-shaped team (1 operator + many siblings) the output is wide-and-short;
-// for a chain it's narrow-and-tall. Either shape leaves significant empty
-// space when fit into a canvas with a different aspect ratio (notably the
-// group-chat graph row, which is much wider than tall).
+// for a chain it's narrow-and-tall.
 //
-// `stretchToAspect` rescales node positions so the layout's bounding box
-// aspect matches the target. It only ever spreads nodes apart (never
-// crowds them closer than ELK's collision-aware output), so the topology
-// reads the same — we just claim the canvas's empty bands.
+// `stretchToAspect` historically rescaled both axes to match the canvas
+// aspect. That worked well for the **group-chat short-row canvas** (very
+// wide, very short — a natural ELK layout leaves huge horizontal bands), but
+// it ALSO triggered for the full Ghost Graph canvas (close to square), where
+// it caused runaway vertical blowup: a natural 700×600 layout was being
+// stretched to ~700×1054, then the saved-positions feedback loop (each
+// re-layout reads back the already-stretched positions, stretches AGAIN,
+// saves the bigger one) produced layouts spanning thousands of ELK units.
+// One real user session ended up with Boo Zero at y=-2268 and members at
+// y=2656 — total vertical span ≈ 4900 ELK units.
+//
+// **New rule** (Round 2 follow-up):
+//   1. **Only ever stretch the X axis.** A wider-than-natural layout fills
+//      horizontal empty bands without harming Boo prominence. The vertical
+//      stretch was the harmful direction.
+//   2. **Cap the X stretch factor at 1.6.** Above that the topology starts
+//      to look distorted (siblings drift apart and bezier edges get long).
+//   3. **Skip when the canvas aspect is close to the layout aspect.**
+//      No stretch is needed when they already match.
+//
+// fitView handles the rest — if there's residual empty canvas, the camera
+// just zooms in, which is the desired behaviour (it makes Boos more prominent).
 function stretchToAspect(nodes: GraphNode[], targetAspect: number): GraphNode[] {
   if (nodes.length < 2 || !Number.isFinite(targetAspect) || targetAspect <= 0) {
     return nodes
@@ -106,10 +122,6 @@ function stretchToAspect(nodes: GraphNode[], targetAspect: number): GraphNode[] 
     if (n.position.y < minY) minY = n.position.y
     if (n.position.y > maxY) maxY = n.position.y
   }
-  // posRange = distance between leftmost and rightmost POSITIONS (top-left
-  // corners). bbox = posRange + node footprint. We have to scale positions
-  // (not bboxes) to hit a target bbox aspect — so the scale derivation
-  // accounts for the fixed node width / height that doesn't stretch.
   const posRangeX = maxX - minX
   const posRangeY = maxY - minY
   const bboxW = posRangeX + BOO_ENVELOPE_WIDTH
@@ -117,29 +129,24 @@ function stretchToAspect(nodes: GraphNode[], targetAspect: number): GraphNode[] 
   if (bboxW <= 0 || bboxH <= 0) return nodes
   const layoutAspect = bboxW / bboxH
 
-  // Stretch only — never compress (compressing would risk overlapping
-  // sibling envelopes within the same layer).
+  // Only stretch X, only when layout is significantly TALLER than canvas
+  // (i.e. natural layout leaves horizontal empty bands).
   let xScale = 1
-  let yScale = 1
-  if (layoutAspect < targetAspect && posRangeX > 0) {
-    // Want bboxW' = bboxH * targetAspect → posRangeX' = bboxW' - envelope
+  const MAX_STRETCH = 1.6
+  const ASPECT_TOLERANCE = 0.15 // skip when aspects are within 15%
+  if (layoutAspect < targetAspect * (1 - ASPECT_TOLERANCE) && posRangeX > 0) {
     const targetPosRange = Math.max(0, bboxH * targetAspect - BOO_ENVELOPE_WIDTH)
-    xScale = targetPosRange / posRangeX
-  } else if (layoutAspect > targetAspect && posRangeY > 0) {
-    const targetPosRange = Math.max(0, bboxW / targetAspect - BOO_ENVELOPE_HEIGHT)
-    yScale = targetPosRange / posRangeY
+    xScale = Math.min(MAX_STRETCH, targetPosRange / posRangeX)
   }
-  if (xScale === 1 && yScale === 1) return nodes
-  // Pivot at the position-range center so the stretch is symmetric.
+  if (xScale === 1) return nodes
   const cx = (minX + maxX) / 2
-  const cy = (minY + maxY) / 2
   return nodes.map((n) => {
     if (n.type !== 'boo') return n
     return {
       ...n,
       position: {
         x: cx + (n.position.x - cx) * xScale,
-        y: cy + (n.position.y - cy) * yScale,
+        y: n.position.y,
       },
     }
   })

--- a/apps/web/src/features/graph/useGraphPersistence.ts
+++ b/apps/web/src/features/graph/useGraphPersistence.ts
@@ -2,22 +2,35 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useGraphStore } from './store'
 import { useConnectionStore } from '@/stores/connection'
 import { useTeamStore } from '@/stores/team'
-import type { LayoutData } from './types'
+import type { LayoutData, GhostGraphScope } from './types'
 
 // ─── useGraphPersistence ──────────────────────────────────────────────────────
 //
 // Loads saved graph node positions from SQLite on mount (via GET /api/graph-layout)
 // and writes them back on drag end (via POST /api/graph-layout, debounced 800ms).
-// Positions are scoped per-team so switching teams loads the correct layout.
+// Positions are scoped per-team AND per-scope so switching teams / switching
+// between Atlas and a team's Ghost Graph loads the correct layout.
+//
+// **Scope-aware layoutName is load-bearing**: previously the layoutName was
+// just `team-${selectedTeamId}`. The sidebar's selected team is preserved
+// when entering Atlas, so opening Atlas with team A still in the sidebar
+// would save Atlas's positions under `team-${A}` — which is the same key
+// the team-A Ghost Graph uses. The team Ghost Graph would then load
+// Atlas's positions on next open, applying Boo-Zero-far-off-to-the-right
+// + spread-out team-boos coordinates to its team-scoped subset. Re-layout
+// in the team chat fixed it temporarily, but any subsequent Atlas visit
+// would overwrite the fix. Splitting the key by scope (atlas vs team)
+// keeps the two layouts independent.
 
-export function useGraphPersistence() {
+export function useGraphPersistence(scope: GhostGraphScope = 'team') {
   const { setSavedPositions } = useGraphStore()
   const gatewayUrl = useConnectionStore((s) => s.gatewayUrl)
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [isLoaded, setIsLoaded] = useState(false)
 
-  const layoutName = selectedTeamId ? `team-${selectedTeamId}` : 'default'
+  const layoutName =
+    scope === 'atlas' ? 'atlas' : selectedTeamId ? `team-${selectedTeamId}` : 'default'
 
   // Load on mount / when connected gateway or team changes
   useEffect(() => {

--- a/apps/web/src/features/group-chat/AgentChips.tsx
+++ b/apps/web/src/features/group-chat/AgentChips.tsx
@@ -13,7 +13,7 @@ export const AgentChips = memo(function AgentChips({ agents, onTag }: AgentChips
 
   return (
     <div
-      className="flex items-center gap-1.5 overflow-x-auto border-t border-white/8 px-4 py-2"
+      className="flex items-center gap-1.5 overflow-x-auto px-4 py-2"
       style={{ scrollbarWidth: 'none' }}
     >
       <span className="shrink-0 text-[10px] text-secondary/40">Tag:</span>

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -30,7 +30,6 @@ export function GroupChatPanel({
   teamId,
   userIntroText,
   embedded = false,
-  orchestrationEnabled: orchestrationEnabledProp,
 }: {
   teamId: string
   /**
@@ -44,13 +43,9 @@ export function GroupChatPanel({
   userIntroText?: string
   /**
    * When true, suppresses the local header (the unified `GroupChatViewHeader`
-   * rendered above the graph + chat split owns team identity, orchestration
-   * toggle, and connection-status dot). The orchestration enabled flag is
-   * read from the prop instead of local state.
+   * rendered above the graph + chat split owns team identity).
    */
   embedded?: boolean
-  /** Required when `embedded` is true — controls the orchestration hook. */
-  orchestrationEnabled?: boolean
 }) {
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
   const agents = useFleetStore((s) => s.agents)
@@ -71,13 +66,12 @@ export function GroupChatPanel({
   // each prefer `booZeroAgent` over this when present.
   const teamInternalLeadId = resolveTeamInternalLead(teamId, team?.leaderAgentId ?? null, agents)
 
-  // Orchestration toggle is now owned by `GroupChatView` so the unified
-  // header (rendered above this panel) can show/toggle it. When `embedded`
-  // is true we trust the prop; the fallback path (`embedded === false`) is
-  // for any future caller that still mounts `GroupChatPanel` standalone.
-  const orchestrationEnabled = orchestrationEnabledProp ?? true
-
   // ── Team orchestration (delegation detection + context relay) ───────────
+  //
+  // Always on — relay + delegation routing is the whole point of a team
+  // chat, so there's no user toggle. The hook is gated only by the
+  // Gateway connection: when disconnected, the hook stays quiet to avoid
+  // queuing relays that would fail to send anyway.
   useTeamOrchestration({
     teamId,
     // Pass the actual team name — used by the silent-resume wake message
@@ -90,7 +84,7 @@ export function GroupChatPanel({
     leaderAgentId: teamInternalLeadId,
     booZeroAgent,
     client,
-    enabled: connectionStatus === 'connected' && orchestrationEnabled,
+    enabled: connectionStatus === 'connected',
     userIntroText,
   })
 

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -1,6 +1,6 @@
 // GroupChatPanel — merged transcript from all team agents, sorted chronologically.
 
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
@@ -23,13 +23,14 @@ import {
 } from '@/features/chat/chatComponents'
 import { AgentChips } from './AgentChips'
 import { InlineApprovalTray } from '@/features/approvals/InlineApprovalTray'
-import { Zap } from 'lucide-react'
 
 // ─── GroupChatPanel ──────────────────────────────────────────────────────────
 
 export function GroupChatPanel({
   teamId,
   userIntroText,
+  embedded = false,
+  orchestrationEnabled: orchestrationEnabledProp,
 }: {
   teamId: string
   /**
@@ -41,6 +42,15 @@ export function GroupChatPanel({
    * who they're talking to.
    */
   userIntroText?: string
+  /**
+   * When true, suppresses the local header (the unified `GroupChatViewHeader`
+   * rendered above the graph + chat split owns team identity, orchestration
+   * toggle, and connection-status dot). The orchestration enabled flag is
+   * read from the prop instead of local state.
+   */
+  embedded?: boolean
+  /** Required when `embedded` is true — controls the orchestration hook. */
+  orchestrationEnabled?: boolean
 }) {
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
   const agents = useFleetStore((s) => s.agents)
@@ -61,11 +71,11 @@ export function GroupChatPanel({
   // each prefer `booZeroAgent` over this when present.
   const teamInternalLeadId = resolveTeamInternalLead(teamId, team?.leaderAgentId ?? null, agents)
 
-  // ── Orchestration toggle (persisted in localStorage) ──────────────────
-  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
-    const stored = localStorage.getItem('clawboo:team-orchestration-enabled')
-    return stored !== null ? stored === 'true' : true
-  })
+  // Orchestration toggle is now owned by `GroupChatView` so the unified
+  // header (rendered above this panel) can show/toggle it. When `embedded`
+  // is true we trust the prop; the fallback path (`embedded === false`) is
+  // for any future caller that still mounts `GroupChatPanel` standalone.
+  const orchestrationEnabled = orchestrationEnabledProp ?? true
 
   // ── Team orchestration (delegation detection + context relay) ───────────
   useTeamOrchestration({
@@ -259,57 +269,33 @@ export function GroupChatPanel({
   // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div data-testid="group-chat-panel" className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex items-center gap-3 border-b border-white/8 px-4 py-3">
-        {team && (
+      {/* Header is owned by `GroupChatViewHeader` when embedded. */}
+      {!embedded && (
+        <div className="flex items-center gap-3 border-b border-white/8 px-4 py-3">
+          {team && (
+            <span
+              className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
+              style={{ background: `${team.color}22` }}
+            >
+              {team.icon}
+            </span>
+          )}
+          <div className="min-w-0 flex-1">
+            <h2
+              className="truncate text-[14px] font-semibold text-text"
+              style={{ fontFamily: 'var(--font-body)' }}
+            >
+              {team?.name ?? 'Group Chat'}
+            </h2>
+            <p className="text-[10px] text-secondary/50">
+              {teamAgents.length} agent{teamAgents.length !== 1 ? 's' : ''}
+            </p>
+          </div>
           <span
-            className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
-            style={{ background: `${team.color}22` }}
-          >
-            {team.icon}
-          </span>
-        )}
-        <div className="min-w-0 flex-1">
-          <h2
-            className="truncate text-[14px] font-semibold text-text"
-            style={{ fontFamily: 'var(--font-body)' }}
-          >
-            {team?.name ?? 'Group Chat'}
-          </h2>
-          <p className="text-[10px] text-secondary/50">
-            {teamAgents.length} agent{teamAgents.length !== 1 ? 's' : ''}
-          </p>
+            className={`h-2 w-2 shrink-0 rounded-full ${connectionStatus === 'connected' ? 'bg-mint' : 'bg-secondary/40'}`}
+          />
         </div>
-        <button
-          type="button"
-          title="Team orchestration — auto-relay responses between agents"
-          onClick={() => {
-            setOrchestrationEnabled((prev) => {
-              const next = !prev
-              localStorage.setItem('clawboo:team-orchestration-enabled', String(next))
-              return next
-            })
-          }}
-          style={{
-            background: 'transparent',
-            border: 'none',
-            cursor: 'pointer',
-            color: orchestrationEnabled ? '#34D399' : 'rgba(232,232,232,0.3)',
-            transition: 'color 0.15s',
-            padding: 4,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            borderRadius: 4,
-            flexShrink: 0,
-          }}
-        >
-          <Zap size={14} />
-        </button>
-        <span
-          className={`h-2 w-2 shrink-0 rounded-full ${connectionStatus === 'connected' ? 'bg-mint' : 'bg-secondary/40'}`}
-        />
-      </div>
+      )}
 
       {/* Messages */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4" onScroll={handleScroll}>

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -1,6 +1,6 @@
 // GroupChatPanel — merged transcript from all team agents, sorted chronologically.
 
-import { useCallback, useEffect, useMemo, useRef, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
@@ -11,6 +11,7 @@ import { useBooZeroStore } from '@/stores/booZero'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
 import { sendGroupChatMessage } from './groupChatSendOperation'
 import { useTeamOrchestration } from './useTeamOrchestration'
+import { stopAllInTeam } from '@/features/chat/stopChatOperation'
 import {
   groupEntriesToBlocks,
   UserMessageCard,
@@ -66,6 +67,14 @@ export function GroupChatPanel({
   // each prefer `booZeroAgent` over this when present.
   const teamInternalLeadId = resolveTeamInternalLead(teamId, team?.leaderAgentId ?? null, agents)
 
+  // ── Stop signal ─────────────────────────────────────────────────────────
+  // Monotonic counter bumped when the Stop button is pressed. Feeds into
+  // `useTeamOrchestration` below so the hook can cancel its 500ms debounce
+  // timer and clear its bookkeeping refs. The `chat.abort` RPCs themselves
+  // are fired separately by `stopAllInTeam` — this signal only owns the
+  // orchestration-side cleanup.
+  const [stopSignal, setStopSignal] = useState(0)
+
   // ── Team orchestration (delegation detection + context relay) ───────────
   //
   // Always on — relay + delegation routing is the whole point of a team
@@ -86,6 +95,7 @@ export function GroupChatPanel({
     client,
     enabled: connectionStatus === 'connected',
     userIntroText,
+    stopSignal,
   })
 
   // "Effective participants" — DB team members + Boo Zero (when present),
@@ -360,6 +370,15 @@ export function GroupChatPanel({
         disabled={!canSend}
         placeholder="Message team… (@name to target)"
         mentionAgents={mentionAgentList}
+        // Stop button — replaces Send while ANY agent on the team is
+        // running OR mid-stream. Bumping `stopSignal` first ensures the
+        // orchestration hook tears down its in-flight state BEFORE the
+        // `chat.abort` events from the Gateway start landing.
+        isActive={anyRunning || activeStreams.length > 0}
+        onStop={() => {
+          setStopSignal((n) => n + 1)
+          void stopAllInTeam({ client, teamId, participants, teamSessionKeys })
+        }}
       />
     </div>
   )

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -6,7 +6,8 @@ import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
 import { useChatStore } from '@/stores/chat'
 import { useConnectionStore } from '@/stores/connection'
-import { resolveTeamLeader } from '@/lib/resolveTeamLeader'
+import { resolveTeamInternalLead } from '@/lib/resolveTeamLeader'
+import { useBooZeroStore } from '@/stores/booZero'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
 import { sendGroupChatMessage } from './groupChatSendOperation'
 import { useTeamOrchestration } from './useTeamOrchestration'
@@ -49,7 +50,16 @@ export function GroupChatPanel({
   const streamingTextMap = useChatStore((s) => s.streamingText)
 
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
-  const leaderAgentId = resolveTeamLeader(teamId, team?.leaderAgentId ?? null, agents)
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const booZeroAgent = useMemo(
+    () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
+    [agents, booZeroAgentId],
+  )
+  // Team-internal lead (CTO, Team Lead, etc., detected via
+  // `detectGenuineLeader` at deploy time). Surfaced separately for relay
+  // routing under Boo Zero — `sendGroupChatMessage` and `useTeamOrchestration`
+  // each prefer `booZeroAgent` over this when present.
+  const teamInternalLeadId = resolveTeamInternalLead(teamId, team?.leaderAgentId ?? null, agents)
 
   // ── Orchestration toggle (persisted in localStorage) ──────────────────
   const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
@@ -61,39 +71,54 @@ export function GroupChatPanel({
   useTeamOrchestration({
     teamId,
     teamAgents,
-    leaderAgentId,
+    // Pass the team-internal lead — Boo Zero is the actual relay hub when
+    // present, so the orchestration hook prefers Boo Zero (see its impl).
+    leaderAgentId: teamInternalLeadId,
+    booZeroAgent,
     client,
     enabled: connectionStatus === 'connected' && orchestrationEnabled,
     userIntroText,
   })
 
+  // "Effective participants" — DB team members + Boo Zero (when present).
+  // Boo Zero is teamless in the DB but participates in every team chat via
+  // its team-scoped sessionKey. Every iteration that touches per-agent
+  // transcript / session / lookup state runs over this list, NOT
+  // `teamAgents` alone, so Boo Zero's responses appear in the merged
+  // transcript with its name + avatar (not "Agent").
+  const participants = useMemo(
+    () => (booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents),
+    [teamAgents, booZeroAgent],
+  )
+
   // Agent lookup for resolving names from sessionKeys
   const agentLookup = useMemo(() => {
     const map = new Map<string, { id: string; name: string }>()
-    for (const a of teamAgents) {
+    for (const a of participants) {
       map.set(a.id, { id: a.id, name: a.name })
     }
     return map
-  }, [teamAgents])
+  }, [participants])
 
-  // For @mention autocomplete and visual rendering
+  // For @mention autocomplete and visual rendering — include Boo Zero so
+  // the user can `@Boo Zero` explicitly in a team chat to address it.
   const mentionAgentList = useMemo(
-    () => teamAgents.map((a) => ({ id: a.id, name: a.name })),
-    [teamAgents],
+    () => participants.map((a) => ({ id: a.id, name: a.name })),
+    [participants],
   )
-  const knownAgentNames = useMemo(() => teamAgents.map((a) => a.name), [teamAgents])
+  const knownAgentNames = useMemo(() => participants.map((a) => a.name), [participants])
   const composerRef = useRef<MessageComposerHandle>(null)
 
   // Team-scoped sessionKeys for isolation from 1:1 agent chat
   const teamSessionKeys = useMemo(
-    () => new Map(teamAgents.map((a) => [a.id, buildTeamSessionKey(a.id, teamId)])),
-    [teamAgents, teamId],
+    () => new Map(participants.map((a) => [a.id, buildTeamSessionKey(a.id, teamId)])),
+    [participants, teamId],
   )
 
   // ── Merge all team transcripts (using team-scoped sessionKeys) ────────────
   const mergedEntries = useMemo(() => {
     const all: TranscriptEntry[] = []
-    for (const agent of teamAgents) {
+    for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
       const entries = transcripts.get(teamSk)
@@ -105,13 +130,13 @@ export function GroupChatPanel({
       return a.sequenceKey - b.sequenceKey
     })
     return all
-  }, [teamAgents, teamSessionKeys, transcripts])
+  }, [participants, teamSessionKeys, transcripts])
 
   const blocks = useMemo(() => groupEntriesToBlocks(mergedEntries), [mergedEntries])
 
-  // ── Load persisted history for all team agents (team-scoped sessionKeys) ──
+  // ── Load persisted history for all participants (team-scoped sessionKeys) ──
   useEffect(() => {
-    for (const agent of teamAgents) {
+    for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
       const existing = useChatStore.getState().transcripts.get(teamSk)
@@ -126,7 +151,7 @@ export function GroupChatPanel({
         })
         .catch(() => {})
     }
-  }, [teamAgents, teamSessionKeys])
+  }, [participants, teamSessionKeys])
 
   // ── Auto-scroll ───────────────────────────────────────────────────────────
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -146,10 +171,11 @@ export function GroupChatPanel({
     })
   }, [scrollToBottom])
 
-  // Collect all streaming texts for team agents (using team-scoped sessionKeys)
+  // Collect all streaming texts for participants (using team-scoped sessionKeys).
+  // Boo Zero's stream lands in the merged transcript with its own avatar/name.
   const activeStreams = useMemo(() => {
     const streams: { agentId: string; agentName: string; text: string }[] = []
-    for (const agent of teamAgents) {
+    for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
       const text = streamingTextMap.get(teamSk)
@@ -158,7 +184,7 @@ export function GroupChatPanel({
       }
     }
     return streams
-  }, [teamAgents, teamSessionKeys, streamingTextMap])
+  }, [participants, teamSessionKeys, streamingTextMap])
 
   const anyRunning = teamAgents.some((a) => a.status === 'running')
 
@@ -186,14 +212,18 @@ export function GroupChatPanel({
         client,
         teamId,
         teamName: team?.name ?? 'Team',
-        leaderAgentId,
+        // `leaderAgentId` here is the team-internal lead (Boo-Zero-fallback);
+        // `sendGroupChatMessage` prefers `booZeroAgent` over this as the
+        // routing target.
+        leaderAgentId: teamInternalLeadId,
         teamAgents,
+        booZeroAgent,
         message,
         displayText: message, // raw message including @mention for transcript display
         userIntroText,
       })
     },
-    [client, teamId, team?.name, leaderAgentId, teamAgents, userIntroText],
+    [client, teamId, team?.name, teamInternalLeadId, teamAgents, booZeroAgent, userIntroText],
   )
 
   // ── Chip tag handler ───────────────────────────────────────────────────────

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -70,6 +70,10 @@ export function GroupChatPanel({
   // ── Team orchestration (delegation detection + context relay) ───────────
   useTeamOrchestration({
     teamId,
+    // Pass the actual team name — used by the silent-resume wake message
+    // in the wake-on-relay path so the body reads `team "Dev Team"` rather
+    // than `team "<uuid>"`.
+    teamName: team?.name ?? 'Team',
     teamAgents,
     // Pass the team-internal lead — Boo Zero is the actual relay hub when
     // present, so the orchestration hook prefers Boo Zero (see its impl).
@@ -80,16 +84,32 @@ export function GroupChatPanel({
     userIntroText,
   })
 
-  // "Effective participants" — DB team members + Boo Zero (when present).
-  // Boo Zero is teamless in the DB but participates in every team chat via
-  // its team-scoped sessionKey. Every iteration that touches per-agent
-  // transcript / session / lookup state runs over this list, NOT
-  // `teamAgents` alone, so Boo Zero's responses appear in the merged
-  // transcript with its name + avatar (not "Agent").
-  const participants = useMemo(
-    () => (booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents),
-    [teamAgents, booZeroAgent],
-  )
+  // "Effective participants" — DB team members + Boo Zero (when present),
+  // deduplicated by agent id.
+  //
+  // Boo Zero is teamless in the DB and SHOULD NOT appear in `teamAgents`,
+  // but the auto-migrate path in `GatewayBootstrap` (which can assign
+  // unassigned agents to a "Default" team) plus any future migration that
+  // attaches Boo Zero to a team could cause it to leak into both
+  // `teamAgents` AND the explicit `booZeroAgent` spread. Two copies of the
+  // same agent in `participants` causes `mergedEntries` to pull the same
+  // transcript twice — a contributing factor to the production triple-
+  // render bug. Dedupe by id defensively.
+  //
+  // Every downstream iteration (teamSessionKeys, mergedEntries, agentLookup,
+  // mentionAgentList, knownAgentNames, persisted-history-load, activeStreams)
+  // walks `participants` directly, so a single dedup here covers them all.
+  const participants = useMemo(() => {
+    const combined = booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents
+    const seen = new Set<string>()
+    const out: typeof combined = []
+    for (const a of combined) {
+      if (seen.has(a.id)) continue
+      seen.add(a.id)
+      out.push(a)
+    }
+    return out
+  }, [teamAgents, booZeroAgent])
 
   // Agent lookup for resolving names from sessionKeys
   const agentLookup = useMemo(() => {

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -1,15 +1,19 @@
 // GroupChatView — unified header + 2-row resizable layout. The header above
-// the split owns team identity (icon + name + agent count), the orchestration
-// toggle, and the connection-status dot — so the team name never renders
-// twice (it used to appear in both `GhostGraphPanel`'s toolbar and
-// `GroupChatPanel`'s header). Below the header: `GhostGraphPanel` on top
-// (in `embedded` mode → its toolbar drops the team-name prefix and just
-// says "Ghost Graph"), `GroupChatPanel` on bottom (in `embedded` mode →
-// its own header is suppressed). Gates the `GroupChatPanel` behind the
-// team onboarding flow ("Know Your Team" button → agent intros → user
-// self-intro → normal chat).
+// the split owns team identity (icon + name + agent count) — so the team
+// name never renders twice (it used to appear in both `GhostGraphPanel`'s
+// toolbar and `GroupChatPanel`'s header). Below the header:
+// `GhostGraphPanel` on top (in `embedded` mode → its toolbar drops the
+// team-name prefix and just says "Ghost Graph"), `GroupChatPanel` on
+// bottom (in `embedded` mode → its own header is suppressed). Gates the
+// `GroupChatPanel` behind the team onboarding flow ("Know Your Team"
+// button → agent intros → user self-intro → normal chat).
+//
+// Team orchestration (delegation routing + context relay) is ALWAYS on —
+// it's the whole point of a team chat. There's no UI toggle; the
+// `useTeamOrchestration` hook in `GroupChatPanel` is gated only by the
+// connection status (so it stays quiet when the Gateway is down).
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Group, Panel } from 'react-resizable-panels'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { ResizeHandle } from '@/features/shared/ResizeHandle'
@@ -25,34 +29,16 @@ import { useConnectionStore } from '@/stores/connection'
 import { useBooZeroStore } from '@/stores/booZero'
 import { buildTeamSessionKey } from '@/lib/sessionUtils'
 
-const ORCHESTRATION_STORAGE_KEY = 'clawboo:team-orchestration-enabled'
-
 export function GroupChatView({ teamId }: { teamId: string }) {
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
   const agents = useFleetStore((s) => s.agents)
   const client = useConnectionStore((s) => s.client)
-  const connectionStatus = useConnectionStore((s) => s.status)
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
   const booZeroAgent = useMemo(
     () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
     [agents, booZeroAgentId],
   )
-
-  // Orchestration toggle (persisted in localStorage). Lifted from
-  // `GroupChatPanel` so the unified header can render the Zap toggle above
-  // the graph + chat split.
-  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
-    const stored = localStorage.getItem(ORCHESTRATION_STORAGE_KEY)
-    return stored !== null ? stored === 'true' : true
-  })
-  const toggleOrchestration = useCallback(() => {
-    setOrchestrationEnabled((prev) => {
-      const next = !prev
-      localStorage.setItem(ORCHESTRATION_STORAGE_KEY, String(next))
-      return next
-    })
-  }, [])
 
   const {
     agentsIntroduced,
@@ -84,15 +70,7 @@ export function GroupChatView({ teamId }: { teamId: string }) {
     }
   }, [teamAgents, teamId])
 
-  const header = (
-    <GroupChatViewHeader
-      team={team}
-      agentCount={teamAgents.length}
-      orchestrationEnabled={orchestrationEnabled}
-      onToggleOrchestration={toggleOrchestration}
-      connectionStatus={connectionStatus}
-    />
-  )
+  const header = <GroupChatViewHeader team={team} agentCount={teamAgents.length} />
 
   // While onboarding state is hydrating, render the layout but hide the
   // chat-side content to avoid a flash of the gate before redirecting to
@@ -155,12 +133,7 @@ export function GroupChatView({ teamId }: { teamId: string }) {
           </Panel>
           <ResizeHandle direction="vertical" />
           <Panel defaultSize={55} minSize={20}>
-            <GroupChatPanel
-              teamId={teamId}
-              userIntroText={userIntroText}
-              embedded
-              orchestrationEnabled={orchestrationEnabled}
-            />
+            <GroupChatPanel teamId={teamId} userIntroText={userIntroText} embedded />
           </Panel>
         </Group>
       </div>

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -70,7 +70,7 @@ export function GroupChatView({ teamId }: { teamId: string }) {
     }
   }, [teamAgents, teamId])
 
-  const header = <GroupChatViewHeader team={team} agentCount={teamAgents.length} />
+  const header = <GroupChatViewHeader team={team} />
 
   // While onboarding state is hydrating, render the layout but hide the
   // chat-side content to avoid a flash of the gate before redirecting to

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -1,16 +1,22 @@
-// GroupChatView — 2-row resizable layout: GhostGraphPanel on top, GroupChatPanel
-// on bottom. Stacked vertically (full width) so wide team graphs spread out
-// comfortably while the chat area below gets full-width message rendering.
-// Gates the GroupChatPanel behind the team onboarding flow ("Know Your Team"
-// button → agent introductions → user self-introduction → normal chat).
+// GroupChatView — unified header + 2-row resizable layout. The header above
+// the split owns team identity (icon + name + agent count), the orchestration
+// toggle, and the connection-status dot — so the team name never renders
+// twice (it used to appear in both `GhostGraphPanel`'s toolbar and
+// `GroupChatPanel`'s header). Below the header: `GhostGraphPanel` on top
+// (in `embedded` mode → its toolbar drops the team-name prefix and just
+// says "Ghost Graph"), `GroupChatPanel` on bottom (in `embedded` mode →
+// its own header is suppressed). Gates the `GroupChatPanel` behind the
+// team onboarding flow ("Know Your Team" button → agent intros → user
+// self-intro → normal chat).
 
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Group, Panel } from 'react-resizable-panels'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { ResizeHandle } from '@/features/shared/ResizeHandle'
 import { GroupChatPanel } from './GroupChatPanel'
 import { GhostGraphPanel } from '@/features/graph/GhostGraphPanel'
 import { TeamOnboardingGate } from './TeamOnboardingGate'
+import { GroupChatViewHeader } from './GroupChatViewHeader'
 import { useTeamOnboarding } from './useTeamOnboarding'
 import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
@@ -19,16 +25,34 @@ import { useConnectionStore } from '@/stores/connection'
 import { useBooZeroStore } from '@/stores/booZero'
 import { buildTeamSessionKey } from '@/lib/sessionUtils'
 
+const ORCHESTRATION_STORAGE_KEY = 'clawboo:team-orchestration-enabled'
+
 export function GroupChatView({ teamId }: { teamId: string }) {
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
   const agents = useFleetStore((s) => s.agents)
   const client = useConnectionStore((s) => s.client)
+  const connectionStatus = useConnectionStore((s) => s.status)
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
   const booZeroAgent = useMemo(
     () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
     [agents, booZeroAgentId],
   )
+
+  // Orchestration toggle (persisted in localStorage). Lifted from
+  // `GroupChatPanel` so the unified header can render the Zap toggle above
+  // the graph + chat split.
+  const [orchestrationEnabled, setOrchestrationEnabled] = useState<boolean>(() => {
+    const stored = localStorage.getItem(ORCHESTRATION_STORAGE_KEY)
+    return stored !== null ? stored === 'true' : true
+  })
+  const toggleOrchestration = useCallback(() => {
+    setOrchestrationEnabled((prev) => {
+      const next = !prev
+      localStorage.setItem(ORCHESTRATION_STORAGE_KEY, String(next))
+      return next
+    })
+  }, [])
 
   const {
     agentsIntroduced,
@@ -60,56 +84,86 @@ export function GroupChatView({ teamId }: { teamId: string }) {
     }
   }, [teamAgents, teamId])
 
+  const header = (
+    <GroupChatViewHeader
+      team={team}
+      agentCount={teamAgents.length}
+      orchestrationEnabled={orchestrationEnabled}
+      onToggleOrchestration={toggleOrchestration}
+      connectionStatus={connectionStatus}
+    />
+  )
+
   // While onboarding state is hydrating, render the layout but hide the
   // chat-side content to avoid a flash of the gate before redirecting to
   // normal chat (or vice versa).
   if (isLoading) {
     return (
-      <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
-        <Panel defaultSize={45} minSize={20}>
-          <GhostGraphPanel />
-        </Panel>
-        <ResizeHandle direction="vertical" />
-        <Panel defaultSize={55} minSize={20}>
-          <div className="flex h-full items-center justify-center bg-bg" />
-        </Panel>
-      </Group>
+      <div className="flex h-full flex-col">
+        {header}
+        <div className="flex-1 min-h-0">
+          <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+            <Panel defaultSize={45} minSize={20}>
+              <GhostGraphPanel embedded />
+            </Panel>
+            <ResizeHandle direction="vertical" />
+            <Panel defaultSize={55} minSize={20}>
+              <div className="flex h-full items-center justify-center bg-bg" />
+            </Panel>
+          </Group>
+        </div>
+      </div>
     )
   }
 
   if (!onboardingComplete) {
     return (
-      <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
-        <Panel defaultSize={45} minSize={20}>
-          <GhostGraphPanel />
-        </Panel>
-        <ResizeHandle direction="vertical" />
-        <Panel defaultSize={55} minSize={20}>
-          <TeamOnboardingGate
-            teamId={teamId}
-            team={team}
-            teamAgents={teamAgents}
-            booZeroAgent={booZeroAgent}
-            client={client}
-            agentsIntroduced={agentsIntroduced}
-            userIntroduced={userIntroduced}
-            onMarkAgentsIntroduced={markAgentsIntroduced}
-            onMarkUserIntroduced={markUserIntroduced}
-          />
-        </Panel>
-      </Group>
+      <div className="flex h-full flex-col">
+        {header}
+        <div className="flex-1 min-h-0">
+          <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+            <Panel defaultSize={45} minSize={20}>
+              <GhostGraphPanel embedded />
+            </Panel>
+            <ResizeHandle direction="vertical" />
+            <Panel defaultSize={55} minSize={20}>
+              <TeamOnboardingGate
+                teamId={teamId}
+                team={team}
+                teamAgents={teamAgents}
+                booZeroAgent={booZeroAgent}
+                client={client}
+                agentsIntroduced={agentsIntroduced}
+                userIntroduced={userIntroduced}
+                onMarkAgentsIntroduced={markAgentsIntroduced}
+                onMarkUserIntroduced={markUserIntroduced}
+              />
+            </Panel>
+          </Group>
+        </div>
+      </div>
     )
   }
 
   return (
-    <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
-      <Panel defaultSize={45} minSize={20}>
-        <GhostGraphPanel />
-      </Panel>
-      <ResizeHandle direction="vertical" />
-      <Panel defaultSize={55} minSize={20}>
-        <GroupChatPanel teamId={teamId} userIntroText={userIntroText} />
-      </Panel>
-    </Group>
+    <div className="flex h-full flex-col">
+      {header}
+      <div className="flex-1 min-h-0">
+        <Group orientation="vertical" id="group-chat-v" data-testid="group-chat-view">
+          <Panel defaultSize={45} minSize={20}>
+            <GhostGraphPanel embedded />
+          </Panel>
+          <ResizeHandle direction="vertical" />
+          <Panel defaultSize={55} minSize={20}>
+            <GroupChatPanel
+              teamId={teamId}
+              userIntroText={userIntroText}
+              embedded
+              orchestrationEnabled={orchestrationEnabled}
+            />
+          </Panel>
+        </Group>
+      </div>
+    </div>
   )
 }

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -16,6 +16,7 @@ import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
 import { useChatStore } from '@/stores/chat'
 import { useConnectionStore } from '@/stores/connection'
+import { useBooZeroStore } from '@/stores/booZero'
 import { buildTeamSessionKey } from '@/lib/sessionUtils'
 
 export function GroupChatView({ teamId }: { teamId: string }) {
@@ -23,6 +24,11 @@ export function GroupChatView({ teamId }: { teamId: string }) {
   const agents = useFleetStore((s) => s.agents)
   const client = useConnectionStore((s) => s.client)
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const booZeroAgent = useMemo(
+    () => (booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null),
+    [agents, booZeroAgentId],
+  )
 
   const {
     agentsIntroduced,
@@ -83,6 +89,7 @@ export function GroupChatView({ teamId }: { teamId: string }) {
             teamId={teamId}
             team={team}
             teamAgents={teamAgents}
+            booZeroAgent={booZeroAgent}
             client={client}
             agentsIntroduced={agentsIntroduced}
             userIntroduced={userIntroduced}

--- a/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
+++ b/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
@@ -1,19 +1,32 @@
 // GroupChatViewHeader — single unified header above the graph + chat split.
-// Owns the team identity (icon + name + agent count) only. The orchestration
-// toggle was removed because team chat without auto-relay defeats the
-// purpose of a team chat — relay + delegation routing is always on. The
-// connection-status dot was removed because the composer's disabled state
-// (`"Gateway not connected…"` placeholder) + the `GatewayBootstrap` overlay
-// already surface connection state more visibly.
+// Owns the team identity (icon + name + Boo/skill counts). Boo/skill counts
+// were folded into this subtitle to eliminate the redundant "Ghost Graph
+// [N Boos · M skills]" subheader row that used to sit between this header
+// and the canvas. The user already knows they're looking at a chat-with-
+// graph view; the "Ghost Graph" label was noise. Re-layout migrated to the
+// canvas's floating toolbar (alongside Team halos + Connect).
+//
+// The previous `agentCount` prop was dropped — Boo count is more informative
+// (includes Boo Zero, matching what the user actually sees on the graph) and
+// is sourced from the graph store directly so it stays in sync with the
+// canvas without GroupChatView having to plumb it through.
 
+import { useGraphStore } from '@/features/graph/store'
 import type { Team } from '@/stores/team'
 
 interface GroupChatViewHeaderProps {
   team: Team | null
-  agentCount: number
 }
 
-export function GroupChatViewHeader({ team, agentCount }: GroupChatViewHeaderProps) {
+export function GroupChatViewHeader({ team }: GroupChatViewHeaderProps) {
+  // Two separate primitive selectors so we don't need shallow equality —
+  // each returns a number and React's default reference check works.
+  const booCount = useGraphStore((s) => s.nodes.filter((n) => n.type === 'boo').length)
+  const skillCount = useGraphStore((s) => s.nodes.filter((n) => n.type === 'skill').length)
+
+  // Don't flash "0 Boos · 0 skills" before the graph hydrates — render an
+  // ellipsis placeholder until the structural rebuild lands its first node.
+  const hasGraph = booCount > 0
   return (
     <div className="flex shrink-0 items-center gap-3 border-b border-white/8 px-4 py-3">
       {team && (
@@ -31,9 +44,43 @@ export function GroupChatViewHeader({ team, agentCount }: GroupChatViewHeaderPro
         >
           {team?.name ?? 'Group Chat'}
         </h2>
-        <p className="text-[10px] text-secondary/50">
-          {agentCount} agent{agentCount !== 1 ? 's' : ''}
-        </p>
+        {/* Accent-red pill badge — same style as the old Ghost Graph
+            toolbar badge, so the boo/skill count keeps the same visual
+            prominence after being folded into the team header. While the
+            graph hydrates we render a dimmer placeholder pill instead of
+            "0 Boos · 0 skills" flashing in. */}
+        <div className="mt-1.5 flex">
+          {hasGraph ? (
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 500,
+                color: '#E94560',
+                background: 'rgba(233,69,96,0.12)',
+                borderRadius: 20,
+                padding: '2px 10px',
+                lineHeight: '16px',
+              }}
+            >
+              {booCount} Boo{booCount !== 1 ? 's' : ''}
+              {skillCount > 0 && ` · ${skillCount} skill${skillCount !== 1 ? 's' : ''}`}
+            </span>
+          ) : (
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 500,
+                color: 'rgba(232,232,232,0.35)',
+                background: 'rgba(255,255,255,0.04)',
+                borderRadius: 20,
+                padding: '2px 10px',
+                lineHeight: '16px',
+              }}
+            >
+              …
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
+++ b/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
@@ -1,0 +1,71 @@
+// GroupChatViewHeader — single unified header above the graph + chat split.
+// Owns the team identity (icon + name + agent count), the orchestration
+// toggle, and the connection-status dot. Replaces the per-panel headers
+// in GhostGraphPanel + GroupChatPanel so the team name doesn't render
+// twice in the group-chat view.
+
+import { Zap } from 'lucide-react'
+import type { Team } from '@/stores/team'
+
+interface GroupChatViewHeaderProps {
+  team: Team | null
+  agentCount: number
+  orchestrationEnabled: boolean
+  onToggleOrchestration: () => void
+  connectionStatus: string
+}
+
+export function GroupChatViewHeader({
+  team,
+  agentCount,
+  orchestrationEnabled,
+  onToggleOrchestration,
+  connectionStatus,
+}: GroupChatViewHeaderProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-white/8 px-4 py-3">
+      {team && (
+        <span
+          className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
+          style={{ background: `${team.color}22` }}
+        >
+          {team.icon}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <h2
+          className="truncate text-[14px] font-semibold text-text"
+          style={{ fontFamily: 'var(--font-body)' }}
+        >
+          {team?.name ?? 'Group Chat'}
+        </h2>
+        <p className="text-[10px] text-secondary/50">
+          {agentCount} agent{agentCount !== 1 ? 's' : ''}
+        </p>
+      </div>
+      <button
+        type="button"
+        title="Team orchestration — auto-relay responses between agents"
+        onClick={onToggleOrchestration}
+        style={{
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          color: orchestrationEnabled ? '#34D399' : 'rgba(232,232,232,0.3)',
+          transition: 'color 0.15s',
+          padding: 4,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          borderRadius: 4,
+          flexShrink: 0,
+        }}
+      >
+        <Zap size={14} />
+      </button>
+      <span
+        className={`h-2 w-2 shrink-0 rounded-full ${connectionStatus === 'connected' ? 'bg-mint' : 'bg-secondary/40'}`}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
+++ b/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
@@ -1,27 +1,19 @@
 // GroupChatViewHeader — single unified header above the graph + chat split.
-// Owns the team identity (icon + name + agent count), the orchestration
-// toggle, and the connection-status dot. Replaces the per-panel headers
-// in GhostGraphPanel + GroupChatPanel so the team name doesn't render
-// twice in the group-chat view.
+// Owns the team identity (icon + name + agent count) only. The orchestration
+// toggle was removed because team chat without auto-relay defeats the
+// purpose of a team chat — relay + delegation routing is always on. The
+// connection-status dot was removed because the composer's disabled state
+// (`"Gateway not connected…"` placeholder) + the `GatewayBootstrap` overlay
+// already surface connection state more visibly.
 
-import { Zap } from 'lucide-react'
 import type { Team } from '@/stores/team'
 
 interface GroupChatViewHeaderProps {
   team: Team | null
   agentCount: number
-  orchestrationEnabled: boolean
-  onToggleOrchestration: () => void
-  connectionStatus: string
 }
 
-export function GroupChatViewHeader({
-  team,
-  agentCount,
-  orchestrationEnabled,
-  onToggleOrchestration,
-  connectionStatus,
-}: GroupChatViewHeaderProps) {
+export function GroupChatViewHeader({ team, agentCount }: GroupChatViewHeaderProps) {
   return (
     <div className="flex shrink-0 items-center gap-3 border-b border-white/8 px-4 py-3">
       {team && (
@@ -43,29 +35,6 @@ export function GroupChatViewHeader({
           {agentCount} agent{agentCount !== 1 ? 's' : ''}
         </p>
       </div>
-      <button
-        type="button"
-        title="Team orchestration — auto-relay responses between agents"
-        onClick={onToggleOrchestration}
-        style={{
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          color: orchestrationEnabled ? '#34D399' : 'rgba(232,232,232,0.3)',
-          transition: 'color 0.15s',
-          padding: 4,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          borderRadius: 4,
-          flexShrink: 0,
-        }}
-      >
-        <Zap size={14} />
-      </button>
-      <span
-        className={`h-2 w-2 shrink-0 rounded-full ${connectionStatus === 'connected' ? 'bg-mint' : 'bg-secondary/40'}`}
-      />
     </div>
   )
 }

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -326,31 +326,12 @@ export function TeamOnboardingGate({
   }, [teamAgents, teamId, completedAgentIds, phase])
 
   // ── Render ─────────────────────────────────────────────────────────────────
+  // No local header — `GroupChatViewHeader` (rendered by `GroupChatView`
+  // above the graph + chat split) already shows the team identity. Adding a
+  // second header here would duplicate the team name + agent count one line
+  // below the unified header.
   return (
     <div className="flex h-full flex-col bg-bg">
-      {/* Header */}
-      <div className="flex items-center gap-3 border-b border-white/8 px-4 py-3">
-        {team && (
-          <span
-            className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
-            style={{ background: `${team.color}22` }}
-          >
-            {team.icon}
-          </span>
-        )}
-        <div className="min-w-0 flex-1">
-          <h2
-            className="truncate text-[14px] font-semibold text-text"
-            style={{ fontFamily: 'var(--font-body)' }}
-          >
-            {team?.name ?? 'Team'}
-          </h2>
-          <p className="text-[10px] text-secondary/50">
-            {teamAgents.length} agent{teamAgents.length !== 1 ? 's' : ''} • Setup
-          </p>
-        </div>
-      </div>
-
       {/* Content */}
       <div className="flex-1 overflow-y-auto px-6 py-8">
         <AnimatePresence mode="wait">
@@ -363,12 +344,24 @@ export function TeamOnboardingGate({
               transition={{ duration: 0.2 }}
               className="mx-auto flex max-w-md flex-col items-center text-center"
             >
-              <div
-                className="mb-4 flex h-12 w-12 items-center justify-center rounded-full"
-                style={{ background: `${team?.color ?? '#34D399'}22` }}
-              >
-                <Sparkles size={22} style={{ color: team?.color ?? '#34D399' }} />
-              </div>
+              {/* The universal team leader (Boo Zero) introduces the team —
+                  its avatar replaces the abstract sparkle icon for a stronger
+                  "leader presenting the team" framing. Falls back to the
+                  sparkle in a colored ring when Boo Zero hasn't been
+                  identified (rare — should only happen in the brief window
+                  before `identifyBooZero` lands after first hydrate). */}
+              {booZeroAgent ? (
+                <div className="mb-4">
+                  <BooAvatar seed={booZeroAgent.id} size={56} isBooZero />
+                </div>
+              ) : (
+                <div
+                  className="mb-4 flex h-12 w-12 items-center justify-center rounded-full"
+                  style={{ background: `${team?.color ?? '#34D399'}22` }}
+                >
+                  <Sparkles size={22} style={{ color: team?.color ?? '#34D399' }} />
+                </div>
+              )}
               <h3
                 className="mb-2 text-[18px] font-semibold text-text"
                 style={{ fontFamily: 'var(--font-display)' }}

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -31,6 +31,15 @@ export interface TeamOnboardingGateProps {
   teamId: string
   team: Team | null
   teamAgents: AgentState[]
+  /**
+   * Boo Zero — the universal team leader. When present, the welcome card
+   * shows a "Led by <BooZero Name>" badge so the user knows Boo Zero will
+   * be the team's first responder. Boo Zero does NOT participate in the
+   * Phase B intro cascade (it's teamless, so already excluded from
+   * `teamAgents`), avoiding any contribution to the message-flooding
+   * cascade the gate was originally introduced to prevent.
+   */
+  booZeroAgent?: AgentState | null
   client: GatewayClientLike | null
   agentsIntroduced: boolean
   userIntroduced: boolean
@@ -63,6 +72,7 @@ export function TeamOnboardingGate({
   teamId,
   team,
   teamAgents,
+  booZeroAgent,
   client,
   agentsIntroduced,
   userIntroduced: _userIntroduced,
@@ -115,16 +125,47 @@ export function TeamOnboardingGate({
     }
   }, [phase, teamAgents, teamId, completedAgentIds])
 
-  // When all agents finish introducing, advance to user-intro phase.
+  // When all agents finish introducing, advance to user-intro phase AND
+  // post a single meta entry "introducing" Boo Zero as the team's universal
+  // leader. We do this client-side (no Gateway round-trip) so the entry is
+  // free of any cascade risk and the user gets immediate feedback.
   useEffect(() => {
     if (phase !== 'introducing') return
     if (teamAgents.length === 0) return
     if (completedAgentIds.size < teamAgents.length) return
     void (async () => {
+      // Boo Zero "introducing itself" — meta entry into Boo Zero's team-scoped
+      // session so the merged transcript shows the universal-leader voice
+      // first when the user lands in normal chat.
+      if (booZeroAgent && team) {
+        const booTeamSk = buildTeamSessionKey(booZeroAgent.id, teamId)
+        const introEntry: TranscriptEntry = {
+          entryId: crypto.randomUUID(),
+          runId: null,
+          sessionKey: booTeamSk,
+          kind: 'assistant',
+          role: 'assistant',
+          text: `Hi — I'm ${booZeroAgent.name}, your universal team leader for ${team.name}. I'll triage your messages, delegate to the right teammate, and synthesize their work back to you.`,
+          source: 'local-send',
+          timestampMs: Date.now(),
+          sequenceKey: nextSeq(),
+          confirmed: true,
+          fingerprint: crypto.randomUUID(),
+        }
+        useChatStore.getState().appendTranscript(booTeamSk, [introEntry])
+      }
       await onMarkAgentsIntroduced()
       setPhase('user-intro')
     })()
-  }, [phase, teamAgents.length, completedAgentIds, onMarkAgentsIntroduced])
+  }, [
+    phase,
+    teamAgents.length,
+    completedAgentIds,
+    onMarkAgentsIntroduced,
+    booZeroAgent,
+    team,
+    teamId,
+  ])
 
   // ── Phase A action: Know Your Team button ─────────────────────────────────
   const handleStartIntros = useCallback(async () => {
@@ -341,7 +382,7 @@ export function TeamOnboardingGate({
               </p>
 
               {/* Agent avatars */}
-              <div className="mb-6 flex flex-wrap items-center justify-center gap-3">
+              <div className="mb-4 flex flex-wrap items-center justify-center gap-3">
                 {teamAgents.map((agent) => (
                   <div
                     key={agent.id}
@@ -355,6 +396,22 @@ export function TeamOnboardingGate({
                   </div>
                 ))}
               </div>
+
+              {/* "Led by Boo Zero" badge — Boo Zero is the universal team
+                  leader and will respond first in every team chat, even
+                  though it doesn't appear in the team's sidebar agent list. */}
+              {booZeroAgent && (
+                <div
+                  className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/8 bg-surface/60 px-3 py-1.5 text-[11px] text-secondary"
+                  data-testid="led-by-boo-zero-badge"
+                >
+                  <BooAvatar seed={booZeroAgent.id} size={20} />
+                  <span>
+                    Led by <strong className="text-text">{booZeroAgent.name}</strong> — your
+                    universal team leader
+                  </span>
+                </div>
+              )}
 
               <button
                 type="button"

--- a/apps/web/src/features/group-chat/__tests__/tripleRender.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/tripleRender.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Triple-render reproduction + regression tests.
+ *
+ * Background (Round 2 plan, Phase A): a real user session showed every agent
+ * message rendering 3 times in the merged team transcript. User messages
+ * rendered once. The root cause hypotheses were:
+ *
+ *   (a) `participants` array in `GroupChatPanel` contains the same agent
+ *       multiple times (e.g., Boo Zero appears both in `teamAgents` AND as
+ *       an explicit `booZeroAgent` spread).
+ *   (b) `appendOutputLines` is invoked multiple times per Gateway frame
+ *       (e.g., the pipeline classifies the same frame twice), each minting
+ *       fresh entryIds so the existing entryId-only dedup misses.
+ *   (c) `groupEntriesToBlocks` mishandles same-text-different-id entries.
+ *
+ * These tests assert the *defensive* contract regardless of upstream cause:
+ *
+ *   - The chat store rejects content-equivalent duplicates inside a small
+ *     time window even if their entryIds differ.
+ *   - `groupEntriesToBlocks` collapses content-equivalent entries.
+ *   - The merge helper used by `GroupChatPanel` dedupes its participants list
+ *     so the same agent's transcript is never pulled twice.
+ *
+ * Run with `pnpm --filter @clawboo/web test -- --run features/group-chat/__tests__/tripleRender.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { TranscriptEntry } from '@clawboo/protocol'
+import { useChatStore } from '@/stores/chat'
+import { groupEntriesToBlocks } from '@/features/chat/chatComponents'
+import { nextSeq } from '@/lib/sequenceKey'
+
+// ── Test entry factory ───────────────────────────────────────────────────────
+
+function makeAssistantEntry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    entryId: crypto.randomUUID(),
+    runId: 'run-1',
+    sessionKey: 'agent:a1:team:t1',
+    kind: 'assistant',
+    role: 'assistant',
+    text: "Hi! I'm Backend Architect Boo — I specialize in scalable system design.",
+    source: 'runtime-chat',
+    timestampMs: 1_700_000_000_000,
+    sequenceKey: nextSeq(),
+    confirmed: true,
+    fingerprint: crypto.randomUUID(),
+    ...overrides,
+  } as TranscriptEntry
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('triple-render — chat store content-signature dedup', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      transcripts: new Map(),
+      streamingText: new Map(),
+      lastTokenUsage: new Map(),
+    })
+  })
+
+  it('rejects content-equivalent duplicates with DIFFERENT entryIds (the production bug)', () => {
+    // Simulates the production bug: `appendOutputLines` is called 3 times for
+    // the same Gateway frame, minting fresh entryIds per call.
+    const ts = 1_700_000_000_000
+    const text = "Hi! I'm Backend Architect Boo — I specialize in scalable system design."
+    const sk = 'agent:backend:team:dev'
+
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [
+        makeAssistantEntry({ entryId: crypto.randomUUID(), sessionKey: sk, text, timestampMs: ts }),
+      ])
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [
+        makeAssistantEntry({ entryId: crypto.randomUUID(), sessionKey: sk, text, timestampMs: ts }),
+      ])
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [
+        makeAssistantEntry({ entryId: crypto.randomUUID(), sessionKey: sk, text, timestampMs: ts }),
+      ])
+
+    expect(useChatStore.getState().transcripts.get(sk)).toHaveLength(1)
+  })
+
+  it('preserves entries with the same content if they are on DIFFERENT sessionKeys', () => {
+    // Two different agents posting "Hi! I'm…" at the same instant must NOT be
+    // collapsed — they're distinct conversations.
+    const ts = 1_700_000_000_000
+    const text = 'OK'
+    useChatStore
+      .getState()
+      .appendTranscript('agent:a1:team:t1', [
+        makeAssistantEntry({ sessionKey: 'agent:a1:team:t1', text, timestampMs: ts }),
+      ])
+    useChatStore
+      .getState()
+      .appendTranscript('agent:a2:team:t1', [
+        makeAssistantEntry({ sessionKey: 'agent:a2:team:t1', text, timestampMs: ts }),
+      ])
+    expect(useChatStore.getState().transcripts.get('agent:a1:team:t1')).toHaveLength(1)
+    expect(useChatStore.getState().transcripts.get('agent:a2:team:t1')).toHaveLength(1)
+  })
+
+  it('preserves entries with the same text but DIFFERENT roles (user vs assistant)', () => {
+    // A user echoing the assistant's "OK" back must not be collapsed.
+    const ts = 1_700_000_000_000
+    const sk = 'agent:a1:team:t1'
+    useChatStore.getState().appendTranscript(sk, [
+      makeAssistantEntry({ role: 'assistant', sessionKey: sk, text: 'OK', timestampMs: ts }),
+      makeAssistantEntry({
+        role: 'user',
+        kind: 'user',
+        sessionKey: sk,
+        text: 'OK',
+        timestampMs: ts,
+      } as Partial<TranscriptEntry>),
+    ])
+    expect(useChatStore.getState().transcripts.get(sk)).toHaveLength(2)
+  })
+
+  it('preserves entries with the same text but TIMESTAMPS more than 1s apart', () => {
+    // A genuine "Hi!" repeated by the same agent later in the conversation
+    // must not be lost — only same-second duplicates are collapsed.
+    const sk = 'agent:a1:team:t1'
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [
+        makeAssistantEntry({ sessionKey: sk, text: 'Hi!', timestampMs: 1_700_000_000_000 }),
+      ])
+    useChatStore.getState().appendTranscript(sk, [
+      // 2 seconds later
+      makeAssistantEntry({ sessionKey: sk, text: 'Hi!', timestampMs: 1_700_000_002_000 }),
+    ])
+    expect(useChatStore.getState().transcripts.get(sk)).toHaveLength(2)
+  })
+
+  it('still dedupes by entryId (existing behavior preserved)', () => {
+    const sk = 'agent:a1:team:t1'
+    const fixedId = 'fixed-entry-id'
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [makeAssistantEntry({ entryId: fixedId, sessionKey: sk })])
+    useChatStore
+      .getState()
+      .appendTranscript(sk, [makeAssistantEntry({ entryId: fixedId, sessionKey: sk })])
+    expect(useChatStore.getState().transcripts.get(sk)).toHaveLength(1)
+  })
+})
+
+describe('triple-render — end-to-end through the store + grouper', () => {
+  beforeEach(() => {
+    useChatStore.setState({
+      transcripts: new Map(),
+      streamingText: new Map(),
+      lastTokenUsage: new Map(),
+    })
+  })
+
+  it('renders a single assistant-turn block when the production bug fires 3x via the store', () => {
+    // End-to-end check: feed 3 same-frame events into the store (the exact
+    // production scenario), then run the merged transcript through
+    // `groupEntriesToBlocks`. Expect exactly 1 assistant-turn block.
+    const ts = 1_700_000_000_000
+    const text = "Hi! I'm Backend Architect Boo"
+    const sk = 'agent:backend:team:dev'
+
+    for (let i = 0; i < 3; i++) {
+      useChatStore.getState().appendTranscript(sk, [
+        makeAssistantEntry({
+          entryId: crypto.randomUUID(), // fresh id per call (production bug)
+          sessionKey: sk,
+          text,
+          timestampMs: ts,
+        }),
+      ])
+    }
+
+    const stored = useChatStore.getState().transcripts.get(sk) ?? []
+    const blocks = groupEntriesToBlocks(stored)
+    const assistantBlocks = blocks.filter((b) => b.kind === 'assistant-turn')
+    expect(stored).toHaveLength(1)
+    expect(assistantBlocks).toHaveLength(1)
+  })
+})

--- a/apps/web/src/features/group-chat/groupChatSendOperation.ts
+++ b/apps/web/src/features/group-chat/groupChatSendOperation.ts
@@ -27,6 +27,18 @@ export function resetWakeState(): void {
   clearAllWakeRecords()
 }
 
+/**
+ * Drop the in-flight-wake guard for a specific team. Called when the user
+ * presses Stop on the team chat — without this, the `wakeInFlight.has(teamId)`
+ * check in `sendGroupChatMessage` would block the NEXT user message from
+ * waking agents (until the guard naturally cleared via the existing
+ * `wakeInFlight.delete` calls along the wake path, which won't run because
+ * the wake was aborted mid-flight). Idempotent.
+ */
+export function clearWakeInFlight(teamId: string): void {
+  wakeInFlight.delete(teamId)
+}
+
 /** Delay after wakeup to let agents initialize before sending actual message. */
 const WAKEUP_SETTLE_MS = 5000
 

--- a/apps/web/src/features/group-chat/groupChatSendOperation.ts
+++ b/apps/web/src/features/group-chat/groupChatSendOperation.ts
@@ -177,7 +177,17 @@ export function getMergedTeamEntries(
 ): TeamContextEntry[] {
   const transcripts = useChatStore.getState().transcripts
   const entries: TeamContextEntry[] = []
-  const participants = booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents
+  // Dedup by id defensively — see the same rationale in `GroupChatPanel.tsx`.
+  // If Boo Zero is somehow already in `teamAgents` we'd otherwise pull its
+  // transcript twice and feed duplicate context into preambles.
+  const combined = booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents
+  const seen = new Set<string>()
+  const participants: AgentState[] = []
+  for (const a of combined) {
+    if (seen.has(a.id)) continue
+    seen.add(a.id)
+    participants.push(a)
+  }
 
   for (const agent of participants) {
     const teamSk = buildTeamSessionKey(agent.id, teamId)
@@ -196,6 +206,21 @@ export function getMergedTeamEntries(
 
   entries.sort((a, b) => a.timestampMs - b.timestampMs)
   return entries
+}
+
+// ─── Identity anchor ─────────────────────────────────────────────────────────
+// Boo Zero's actual `agent.name` may be anything — the user's OpenClaw setup
+// might leave it as the literal slug "main", or it might be a custom name
+// like "Mythos" the user picked during OpenClaw onboarding, or "Boo Zero"
+// (the Clawboo default after Phase E lands). Production showed the LLM drifting
+// between these (calling itself "Boo Zero" in one breath and "Mythos" in
+// another), so we anchor the name explicitly in the preamble. This is the
+// load-bearing anti-name-drift fix.
+
+function buildIdentityBlock(booZeroDisplayName: string): string {
+  return `[Your Identity]
+You are ${booZeroDisplayName}. This is your name — the only name you should use to refer to yourself. Do NOT use alternative names ("Mythos", "Boo", "main", "Boo Zero" if that's not your name, etc.) — those would confuse the user about who they're talking to. Even if you suspect the system invented a different name elsewhere, the name in this block is authoritative.
+[End Your Identity]`
 }
 
 // ─── Team brief fetch ────────────────────────────────────────────────────────
@@ -313,13 +338,25 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
   // ship it when targeting Boo Zero because team members already have their
   // own per-agent identity files. Best-effort — missing brief is silently OK.
   let briefBlock: string | null = null
+  let identityBlock: string | null = null
   if (booZeroAgent && target.id === booZeroAgent.id) {
     const brief = await fetchTeamBrief(teamId)
     if (brief) briefBlock = buildTeamBriefBlock(teamName, brief)
+
+    // Identity anchor — load-bearing fix for the "Mythos / main / Boo Zero"
+    // name-drift seen in production. The agent's actual display name (which
+    // may be the user-customized name from OpenClaw or Clawboo onboarding,
+    // OR the literal slug "main") is asserted up front so the LLM doesn't
+    // invent alternative names mid-response.
+    identityBlock = buildIdentityBlock(booZeroAgent.name)
   }
 
   const messageToSend = mentionedId ? cleanedMessage : message
-  const sections = [briefBlock, preamble, messageToSend].filter((s): s is string => Boolean(s))
+  // Order matters: identity first (anchors who you are), then team brief
+  // (anchors WHERE you are), then conversation preamble, then the message.
+  const sections = [identityBlock, briefBlock, preamble, messageToSend].filter((s): s is string =>
+    Boolean(s),
+  )
   const messageWithContext = sections.join('\n\n')
 
   await sendChatMessage({

--- a/apps/web/src/features/group-chat/groupChatSendOperation.ts
+++ b/apps/web/src/features/group-chat/groupChatSendOperation.ts
@@ -36,8 +36,20 @@ export interface GroupChatSendParams {
   client: GatewayClientLike
   teamId: string
   teamName: string
+  /**
+   * The team-internal lead (CTO, Team Lead, etc.) — under Boo Zero. May be
+   * null when no genuine leader role was detected in the team. Only used as
+   * a routing fallback when Boo Zero is missing.
+   */
   leaderAgentId: string | null
   teamAgents: AgentState[]
+  /**
+   * Boo Zero, the universal team leader. When present, this is the default
+   * routing target for messages without an explicit `@mention`. Boo Zero is
+   * teamless (`teamId === null`) but participates in every team's chat via
+   * its team-scoped sessionKey: `agent:<booZeroId>:team:<teamId>`.
+   */
+  booZeroAgent?: AgentState | null
   message: string
   /** Original message with @mention for display in transcript. */
   displayText?: string
@@ -148,13 +160,26 @@ async function wakeTeamAgents(
 
 /**
  * Read all team transcripts from the chat store and merge into
- * TeamContextEntry[] for buildTeamContextPreamble.
+ * `TeamContextEntry[]` for `buildTeamContextPreamble`.
+ *
+ * When `booZeroAgent` is provided, its team-scoped session for this team is
+ * also merged in — Boo Zero is the universal team leader and its own
+ * contributions to the team's conversation belong in the merged context.
+ *
+ * `booZeroAgent` is intentionally separate from `teamAgents` (which is
+ * filtered by `agents.teamId === teamId`) because Boo Zero stays teamless
+ * in the DB.
  */
-export function getMergedTeamEntries(teamId: string, teamAgents: AgentState[]): TeamContextEntry[] {
+export function getMergedTeamEntries(
+  teamId: string,
+  teamAgents: AgentState[],
+  booZeroAgent?: AgentState | null,
+): TeamContextEntry[] {
   const transcripts = useChatStore.getState().transcripts
   const entries: TeamContextEntry[] = []
+  const participants = booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents
 
-  for (const agent of teamAgents) {
+  for (const agent of participants) {
     const teamSk = buildTeamSessionKey(agent.id, teamId)
     const transcript = transcripts.get(teamSk)
     if (!transcript) continue
@@ -173,6 +198,32 @@ export function getMergedTeamEntries(teamId: string, teamAgents: AgentState[]): 
   return entries
 }
 
+// ─── Team brief fetch ────────────────────────────────────────────────────────
+// Boo Zero reads the team brief on every message so it understands team
+// dynamics. SQLite is the source of truth (`/api/boo-zero/team-briefs/:teamId`);
+// when the brief is missing or the API errors, we fall through without it —
+// Boo Zero's general behavior comes from its global brief + on-disk identity.
+
+interface TeamBriefResponse {
+  content?: string | null
+}
+
+async function fetchTeamBrief(teamId: string): Promise<string | null> {
+  try {
+    const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
+    if (!res.ok) return null
+    const body = (await res.json()) as TeamBriefResponse
+    return typeof body.content === 'string' && body.content.length > 0 ? body.content : null
+  } catch {
+    return null
+  }
+}
+
+/** Wraps the brief markdown in the structured envelope Boo Zero recognizes. */
+function buildTeamBriefBlock(teamName: string, brief: string): string {
+  return `[Team Brief: ${teamName}]\n${brief.trim()}\n[End Team Brief]`
+}
+
 // ─── Main operation ──────────────────────────────────────────────────────────
 
 export async function sendGroupChatMessage(params: GroupChatSendParams): Promise<void> {
@@ -182,34 +233,49 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
     teamName,
     leaderAgentId,
     teamAgents,
+    booZeroAgent,
     message,
     displayText,
     userIntroText,
   } = params
 
-  // Parse @mention to determine target agent
-  const { targetAgentId: mentionedId, cleanedMessage } = parseMention(
-    message,
-    teamAgents.map((a) => ({ id: a.id, name: a.name })),
-  )
+  // Build the @-mention candidate list: team members + Boo Zero. The user can
+  // address Boo Zero directly with `@<BooZero Name>` to force routing to it
+  // even in a team chat.
+  const mentionCandidates = booZeroAgent
+    ? [...teamAgents, booZeroAgent].map((a) => ({ id: a.id, name: a.name }))
+    : teamAgents.map((a) => ({ id: a.id, name: a.name }))
 
-  // Resolve target: @mentioned > leader > first team agent
-  const targetId = mentionedId ?? leaderAgentId ?? teamAgents[0]?.id
+  const { targetAgentId: mentionedId, cleanedMessage } = parseMention(message, mentionCandidates)
+
+  // Routing priority: @mention > Boo Zero (universal leader) > team-internal
+  // lead > first team member. Boo Zero is the new no-mention default.
+  const targetId = mentionedId ?? booZeroAgent?.id ?? leaderAgentId ?? teamAgents[0]?.id ?? null
   if (!targetId) return
 
-  const target = teamAgents.find((a) => a.id === targetId)
+  // Resolve the target. It may be a team member OR Boo Zero (which is not
+  // in `teamAgents` because it's teamless).
+  const target =
+    teamAgents.find((a) => a.id === targetId) ??
+    (booZeroAgent && booZeroAgent.id === targetId ? booZeroAgent : null)
   if (!target) return
 
-  // Compute team-scoped sessionKey for isolation from 1:1 chat
+  // Compute team-scoped sessionKey for isolation from 1:1 chat. Boo Zero
+  // gets its own team-scoped session per team — same scheme.
   const targetTeamSk = buildTeamSessionKey(target.id, teamId)
 
   // Set override so Gateway events (which use main sessionKey) get redirected
   // to the team session. Must be set BEFORE sending so events are captured.
+  // The override is pending until the first event with a runId promotes it.
   setTeamChatOverride(target.id, targetTeamSk)
 
   // ── Auto-wake agents that don't have active team sessions ─────────────────
+  // Include Boo Zero in the wake set (when present) so its team-scoped
+  // session exists on the Gateway — required for Boo Zero to receive
+  // relays from teammates.
   if (!wakeInFlight.has(teamId)) {
-    const nonTargetIds = teamAgents.filter((a) => a.id !== targetId).map((a) => a.id)
+    const wakeCandidates = booZeroAgent ? [...teamAgents, booZeroAgent] : teamAgents
+    const nonTargetIds = wakeCandidates.filter((a) => a.id !== targetId).map((a) => a.id)
     const sleeping = findSleepingAgents(nonTargetIds, teamId)
 
     if (sleeping.length > 0) {
@@ -220,7 +286,7 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
         const needsWake = sleeping.filter((id) => !confirmed.has(id))
 
         if (needsWake.length > 0) {
-          await wakeTeamAgents(client, teamAgents, needsWake, teamId, teamName, targetTeamSk)
+          await wakeTeamAgents(client, wakeCandidates, needsWake, teamId, teamName, targetTeamSk)
           // Settle delay — let agents initialize before actual message
           await new Promise((r) => setTimeout(r, WAKEUP_SETTLE_MS))
         }
@@ -231,18 +297,30 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
   }
 
   // ── Build context preamble for target agent ──────────────────────────────
-  // Always inject the user intro (if available) so the agent knows who
-  // they're talking to on every message — Gateway SOUL.md persistence is
-  // unreliable, so the preamble is the actual delivery mechanism.
-  const contextEntries = getMergedTeamEntries(teamId, teamAgents)
+  // Boo Zero's responses belong in the merged team context — include them
+  // in the merge so when Boo Zero delegates to a teammate (or vice versa)
+  // the recipient sees the full team conversation.
+  const contextEntries = getMergedTeamEntries(teamId, teamAgents, booZeroAgent ?? undefined)
   const preamble = buildTeamContextPreamble({
     entries: contextEntries,
     targetAgentName: target.name,
     userIntroText,
   })
 
+  // When the target is Boo Zero, ALSO fetch the team brief and prepend it.
+  // The brief is Boo Zero's per-team operating manual — what the team does,
+  // who its members are, who the internal lead is, anti-patterns. We only
+  // ship it when targeting Boo Zero because team members already have their
+  // own per-agent identity files. Best-effort — missing brief is silently OK.
+  let briefBlock: string | null = null
+  if (booZeroAgent && target.id === booZeroAgent.id) {
+    const brief = await fetchTeamBrief(teamId)
+    if (brief) briefBlock = buildTeamBriefBlock(teamName, brief)
+  }
+
   const messageToSend = mentionedId ? cleanedMessage : message
-  const messageWithContext = preamble ? `${preamble}\n\n${messageToSend}` : messageToSend
+  const sections = [briefBlock, preamble, messageToSend].filter((s): s is string => Boolean(s))
+  const messageWithContext = sections.join('\n\n')
 
   await sendChatMessage({
     client,

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -55,12 +55,21 @@ export interface UseTeamOrchestrationParams {
    * the delegation is routed agent-to-agent (without a fresh user message).
    */
   userIntroText?: string
+  /**
+   * Monotonic counter bumped by the parent (`GroupChatPanel`) when the
+   * Stop button is pressed. On change, the hook cancels its pending 500ms
+   * debounce timer AND resets its bookkeeping refs so no relay or
+   * delegation fires for activity that was in flight at stop time. The
+   * actual `chat.abort` RPCs are sent by `stopAllInTeam` separately —
+   * this hook only owns the orchestration-side cleanup.
+   */
+  stopSignal?: number
 }
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
 
 export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
-  const { teamId, enabled = true } = params
+  const { teamId, enabled = true, stopSignal = 0 } = params
 
   // Keep latest params in refs so the subscribe callback sees current values
   // without needing to tear down / recreate the subscription.
@@ -360,4 +369,22 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       }
     }
   }, [enabled, teamId]) // Intentionally minimal deps — refs carry current values
+
+  // ── Stop-signal handler ──────────────────────────────────────────────────
+  // When the parent bumps `stopSignal` (Stop button pressed), abort any
+  // pending debounced batch AND wipe the in-batch bookkeeping so we don't
+  // process stale state on the next change. The initial `stopSignal=0` is
+  // skipped so we don't reset on first mount.
+  const prevStopSignalRef = useRef(stopSignal)
+  useEffect(() => {
+    if (stopSignal === prevStopSignalRef.current) return
+    prevStopSignalRef.current = stopSignal
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current)
+      debounceTimerRef.current = null
+    }
+    lastCountsRef.current = new Map()
+    delegationSourceRef.current = new Map()
+    wokenThisBatchRef.current = new Set()
+  }, [stopSignal])
 }

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -27,7 +27,19 @@ import { getMergedTeamEntries } from './groupChatSendOperation'
 export interface UseTeamOrchestrationParams {
   teamId: string | null
   teamAgents: AgentState[]
+  /**
+   * The team-internal lead (CTO, Team Lead, etc., detected via
+   * `detectGenuineLeader` at deploy time). May be null when the team has
+   * no genuine leader role. Only used as a relay-hub fallback when Boo
+   * Zero is unavailable.
+   */
   leaderAgentId: string | null
+  /**
+   * Boo Zero — the universal team leader. When present, Boo Zero is the
+   * relay hub: every teammate's response gets relayed to Boo Zero, and
+   * Boo Zero's own `<delegate>` blocks get routed to teammates.
+   */
+  booZeroAgent?: AgentState | null
   client: GatewayClientLike | null
   enabled?: boolean
   /**
@@ -49,6 +61,8 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
   teamAgentsRef.current = params.teamAgents
   const leaderAgentIdRef = useRef(params.leaderAgentId)
   leaderAgentIdRef.current = params.leaderAgentId
+  const booZeroAgentRef = useRef(params.booZeroAgent ?? null)
+  booZeroAgentRef.current = params.booZeroAgent ?? null
   const clientRef = useRef(params.client)
   clientRef.current = params.client
   const teamIdRef = useRef(teamId)
@@ -67,9 +81,21 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
     const processNewEntries = () => {
       const currentTeamId = teamIdRef.current
       const currentClient = clientRef.current
-      const currentAgents = teamAgentsRef.current
-      const currentLeader = leaderAgentIdRef.current
+      const currentTeamMembers = teamAgentsRef.current
+      const currentInternalLead = leaderAgentIdRef.current
+      const currentBooZero = booZeroAgentRef.current
+      // "Effective participants" = team members + Boo Zero. Boo Zero's
+      // assistant entries can contain `<delegate>` blocks too, so we have
+      // to scan its transcript for delegation patterns; and the delegation
+      // target may be any participant (including Boo Zero).
+      const currentAgents = currentBooZero
+        ? [...currentTeamMembers, currentBooZero]
+        : currentTeamMembers
       if (!currentTeamId || !currentClient || currentAgents.length === 0) return
+      // Relay hub: Boo Zero (when available) — every teammate's response is
+      // relayed to Boo Zero so the universal leader stays in the loop. Fall
+      // back to the team-internal lead when Boo Zero is unavailable.
+      const relayHubId = currentBooZero?.id ?? currentInternalLead
 
       const transcripts = useChatStore.getState().transcripts
       const lastCounts = lastCountsRef.current
@@ -104,9 +130,15 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
           for (const delegation of delegations) {
             const sendDelegation = async (retryCount = 0) => {
               try {
-                // Guard: target agent may have been deleted during processing
-                const freshAgents = teamAgentsRef.current
-                if (!freshAgents.some((a) => a.id === delegation.targetAgentId)) return
+                // Guard: target agent may have been deleted during processing.
+                // The target may be Boo Zero — check both team members AND
+                // Boo Zero (Boo Zero is teamless so not in `teamAgentsRef`).
+                const freshTeamMembers = teamAgentsRef.current
+                const freshBooZero = booZeroAgentRef.current
+                const freshParticipants = freshBooZero
+                  ? [...freshTeamMembers, freshBooZero]
+                  : freshTeamMembers
+                if (!freshParticipants.some((a) => a.id === delegation.targetAgentId)) return
 
                 // Guard: target is already processing a team message — retry once after 2s
                 if (hasTeamChatOverride(delegation.targetAgentId)) {
@@ -124,8 +156,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                 // Build context preamble from merged transcript — also injects
                 // the user intro so the target agent knows who the user is
                 // (delegations are agent-to-agent, no fresh user message).
-                const contextEntries = getMergedTeamEntries(currentTeamId, currentAgents)
-                const targetAgent = currentAgents.find((a) => a.id === delegation.targetAgentId)
+                // Pass team members + Boo Zero as separate args so the merge
+                // includes Boo Zero's transcript without double-counting.
+                const contextEntries = getMergedTeamEntries(
+                  currentTeamId,
+                  freshTeamMembers,
+                  freshBooZero,
+                )
+                const targetAgent = freshParticipants.find((a) => a.id === delegation.targetAgentId)
                 const preamble = buildTeamContextPreamble({
                   entries: contextEntries,
                   targetAgentName: targetAgent?.name ?? '',
@@ -168,7 +206,7 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             const targets = determineRelayTargets({
               respondingAgentId: sourceAgentId,
               teamAgents: currentAgents.map((a) => ({ id: a.id, name: a.name })),
-              leaderAgentId: currentLeader,
+              leaderAgentId: relayHubId,
               delegationSourceId: delegationSource,
             })
 
@@ -181,16 +219,24 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             for (const targetId of targets) {
               void (async () => {
                 try {
-                  // Guard: target agent may have been deleted during processing
-                  const freshAgents = teamAgentsRef.current
-                  const targetAgent = freshAgents.find((a) => a.id === targetId)
+                  // Guard: target agent may have been deleted during processing.
+                  // Relay targets can include Boo Zero — check both team members
+                  // and (when present) Boo Zero before bailing out.
+                  const freshTeamMembers = teamAgentsRef.current
+                  const freshBooZero = booZeroAgentRef.current
+                  const targetAgent =
+                    freshTeamMembers.find((a) => a.id === targetId) ??
+                    (freshBooZero && freshBooZero.id === targetId ? freshBooZero : null)
                   if (!targetAgent) return
 
                   const targetTeamSk = buildTeamSessionKey(targetId, currentTeamId)
 
                   // Wake sleeping agent before relaying (best-effort)
                   if (!isAgentAwake(targetId, currentTeamId)) {
-                    const teammates = freshAgents
+                    const teammatesPool = freshBooZero
+                      ? [...freshTeamMembers, freshBooZero]
+                      : freshTeamMembers
+                    const teammates = teammatesPool
                       .filter((a) => a.id !== targetId)
                       .map((a) => ({ name: a.name, role: a.name }))
                     const wakeMsg = buildTeamWakeMessage({
@@ -231,9 +277,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       }
     }
 
-    // Initialize lastCounts with current state to avoid processing historical entries
+    // Initialize lastCounts with current state to avoid processing historical
+    // entries. Include Boo Zero's team-scoped session so its older messages
+    // aren't re-scanned for delegations on mount.
     const transcripts = useChatStore.getState().transcripts
-    for (const agent of params.teamAgents) {
+    const seedAgents = params.booZeroAgent
+      ? [...params.teamAgents, params.booZeroAgent]
+      : params.teamAgents
+    for (const agent of seedAgents) {
       const teamSk = buildTeamSessionKey(agent.id, teamId)
       const entries = transcripts.get(teamSk)
       lastCountsRef.current.set(teamSk, entries?.length ?? 0)

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -7,7 +7,7 @@ import type { GatewayClientLike } from '@clawboo/gateway-client'
 import type { AgentState } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
 import { buildTeamSessionKey, setTeamChatOverride, hasTeamChatOverride } from '@/lib/sessionUtils'
-import { buildTeamContextPreamble, buildTeamWakeMessage } from '@/lib/teamProtocol'
+import { buildTeamContextPreamble, buildSilentResumeWakeMessage } from '@/lib/teamProtocol'
 import { isAgentAwake } from '@/lib/wakeTracker'
 import { detectDelegations, isRelayMessage } from './delegationDetector'
 import {
@@ -26,6 +26,13 @@ import { getMergedTeamEntries } from './groupChatSendOperation'
 
 export interface UseTeamOrchestrationParams {
   teamId: string | null
+  /**
+   * The team's display name. Threaded through here so the wake-on-relay
+   * path can use it in the silent-resume message body. Without this, the
+   * wake body used to read `team "<UUID>"` (raw team id) — a confusing
+   * artifact of the original implementation.
+   */
+  teamName: string
   teamAgents: AgentState[]
   /**
    * The team-internal lead (CTO, Team Lead, etc., detected via
@@ -57,6 +64,8 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
 
   // Keep latest params in refs so the subscribe callback sees current values
   // without needing to tear down / recreate the subscription.
+  const teamNameRef = useRef(params.teamName)
+  teamNameRef.current = params.teamName
   const teamAgentsRef = useRef(params.teamAgents)
   teamAgentsRef.current = params.teamAgents
   const leaderAgentIdRef = useRef(params.leaderAgentId)
@@ -73,24 +82,46 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
   // Tracking state (all refs — no re-renders)
   const lastCountsRef = useRef<Map<string, number>>(new Map())
   const delegationSourceRef = useRef<Map<string, string>>(new Map()) // targetAgentId → sourceAgentId
+  /**
+   * Per-batch wake dedup. When `processNewEntries` fires multiple relays
+   * inside a single tick (e.g., Boo Zero delegates to 6 sleeping agents
+   * and we relay back to the hub for each), we'd otherwise queue 6
+   * back-to-back wake messages on the SAME hub. Track agents we've already
+   * woken in this batch and skip subsequent wakes. The set is cleared at
+   * the end of each batch.
+   */
+  const wokenThisBatchRef = useRef<Set<string>>(new Set())
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!enabled || !teamId) return
 
     const processNewEntries = () => {
+      // Reset per-batch dedup set at the start of every batch so we never
+      // permanently skip an agent's future wakes.
+      wokenThisBatchRef.current = new Set<string>()
       const currentTeamId = teamIdRef.current
       const currentClient = clientRef.current
       const currentTeamMembers = teamAgentsRef.current
       const currentInternalLead = leaderAgentIdRef.current
       const currentBooZero = booZeroAgentRef.current
-      // "Effective participants" = team members + Boo Zero. Boo Zero's
-      // assistant entries can contain `<delegate>` blocks too, so we have
-      // to scan its transcript for delegation patterns; and the delegation
-      // target may be any participant (including Boo Zero).
-      const currentAgents = currentBooZero
+      // "Effective participants" = team members + Boo Zero, deduplicated by
+      // agent id. Boo Zero's assistant entries can contain `<delegate>`
+      // blocks too, so we have to scan its transcript for delegation
+      // patterns; and the delegation target may be any participant
+      // (including Boo Zero). Dedup defensively — if Boo Zero leaks into
+      // `teamAgents` we'd otherwise double-process its transcript and
+      // double-route its `<delegate>` blocks.
+      const combinedAgents = currentBooZero
         ? [...currentTeamMembers, currentBooZero]
         : currentTeamMembers
+      const seenAgentIds = new Set<string>()
+      const currentAgents: typeof combinedAgents = []
+      for (const a of combinedAgents) {
+        if (seenAgentIds.has(a.id)) continue
+        seenAgentIds.add(a.id)
+        currentAgents.push(a)
+      }
       if (!currentTeamId || !currentClient || currentAgents.length === 0) return
       // Relay hub: Boo Zero (when available) — every teammate's response is
       // relayed to Boo Zero so the universal leader stays in the loop. Fall
@@ -231,18 +262,33 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
 
                   const targetTeamSk = buildTeamSessionKey(targetId, currentTeamId)
 
-                  // Wake sleeping agent before relaying (best-effort)
-                  if (!isAgentAwake(targetId, currentTeamId)) {
-                    const teammatesPool = freshBooZero
-                      ? [...freshTeamMembers, freshBooZero]
-                      : freshTeamMembers
-                    const teammates = teammatesPool
-                      .filter((a) => a.id !== targetId)
-                      .map((a) => ({ name: a.name, role: a.name }))
-                    const wakeMsg = buildTeamWakeMessage({
+                  // Wake sleeping agent before relaying (best-effort).
+                  //
+                  // CRITICAL: this used to call `buildTeamWakeMessage` which
+                  // asked the agent to introduce itself AND listed teammates
+                  // as `@AgentName`. In production that triggered the
+                  // 11-message "Welcome aboard X" cascade (CLAUDE.md §"Group
+                  // Chat Onboarding Gate — Cascade Fix"). The Phase 4
+                  // onboarding-gate fix already replaced the user-message-
+                  // time wake with a silent-resume body — this is the same
+                  // fix for the orchestration wake-on-relay path.
+                  //
+                  // Pair with `### Resuming sessions` in `buildTeamAgentsMd`
+                  // which loads on every turn and tells the agent to stay
+                  // quiet on resume.
+                  //
+                  // Per-batch dedup (`wokenThisBatchRef`) below ensures we
+                  // don't fire multiple wakes for the same agent inside a
+                  // single processing tick — relays often target the same
+                  // hub repeatedly.
+                  if (
+                    !isAgentAwake(targetId, currentTeamId) &&
+                    !wokenThisBatchRef.current.has(targetId)
+                  ) {
+                    wokenThisBatchRef.current.add(targetId)
+                    const wakeMsg = buildSilentResumeWakeMessage({
                       agentName: targetAgent.name,
-                      teamName: currentTeamId, // best-effort — teamName not available here
-                      teammates,
+                      teamName: teamNameRef.current,
                     })
                     setTeamChatOverride(targetId, targetTeamSk)
                     await currentClient.call('chat.send', {
@@ -251,7 +297,12 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                       deliver: false,
                       idempotencyKey: crypto.randomUUID(),
                     })
-                    await new Promise((r) => setTimeout(r, 5000))
+                    // Settle delay reduced from 5000ms → 2000ms. With N
+                    // sleeping teammates the original delay multiplied to a
+                    // visibly-bunched cascade window; 2s is still enough
+                    // for the Gateway to register the session before the
+                    // relay arrives, while keeping the overall flow tight.
+                    await new Promise((r) => setTimeout(r, 2000))
                   }
 
                   setTeamChatOverride(targetId, targetTeamSk)

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -22,6 +22,35 @@ import {
 } from './contextRelay'
 import { getMergedTeamEntries } from './groupChatSendOperation'
 
+// ─── Stop-generation counter (module-level, keyed by teamId) ────────────────
+//
+// Bumped on every Stop. Fire-and-forget IIFEs created inside
+// `processNewEntries` capture this value at creation and re-check it before
+// each side-effecting `await chat.send(...)` — if it has changed, they bail.
+// This is what cancels mid-flight wake → settle → relay sequences when the
+// user presses Stop during the WAKEUP_SETTLE_MS sleep window (any payload
+// that fires AFTER the freeze ends would otherwise re-trigger a cascade).
+//
+// Module-level (not a React ref) so `stopAllInTeam` in `stopChatOperation.ts`
+// can bump it imperatively BEFORE any `await` — eliminating the
+// setStopSignal → render → useEffect-commit race that would otherwise leave
+// a small window where IIFEs see the old generation. The stop-signal
+// useEffect inside the hook also bumps it as belt-and-suspenders.
+//
+// Same pattern as `wakeInFlight` (in `groupChatSendOperation.ts`) and
+// `relayState` (in `contextRelay.ts`) — both intentionally module-level for
+// the same reason.
+
+const stopGenerations = new Map<string, number>()
+
+export function getStopGeneration(teamId: string): number {
+  return stopGenerations.get(teamId) ?? 0
+}
+
+export function bumpStopGeneration(teamId: string): void {
+  stopGenerations.set(teamId, (stopGenerations.get(teamId) ?? 0) + 1)
+}
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 /**
@@ -225,8 +254,16 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
           )
 
           for (const delegation of delegations) {
+            // Capture the stop-generation at IIFE creation. If the user
+            // presses Stop before this IIFE finishes, the generation
+            // bumps; we bail at each checkpoint below instead of issuing
+            // a stale `chat.send` that would restart the cascade.
+            const startGen = getStopGeneration(currentTeamId)
             const sendDelegation = async (retryCount = 0) => {
               try {
+                // Bail if Stop has fired since this IIFE was scheduled.
+                if (getStopGeneration(currentTeamId) !== startGen) return
+
                 // Guard: target agent may have been deleted during processing.
                 // The target may be Boo Zero — check both team members AND
                 // Boo Zero (Boo Zero is teamless so not in `teamAgentsRef`).
@@ -240,6 +277,8 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                 // Guard: target is already processing a team message — retry once after 2s
                 if (hasTeamChatOverride(delegation.targetAgentId)) {
                   if (retryCount < 1) {
+                    // The retry inherits the same startGen via closure, so
+                    // when it fires it re-checks against the live generation.
                     setTimeout(() => void sendDelegation(retryCount + 1), 2000)
                   }
                   return
@@ -270,6 +309,11 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                 const messageBody = preamble
                   ? `${preamble}\n\n${delegation.taskDescription}`
                   : delegation.taskDescription
+
+                // Final checkpoint before the network call. Without this,
+                // a Stop that fired during the synchronous preamble build
+                // above would still let the delegation send.
+                if (getStopGeneration(currentTeamId) !== startGen) return
 
                 await currentClient.call('chat.send', {
                   sessionKey: targetTeamSk,
@@ -314,8 +358,19 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             })
 
             for (const targetId of targets) {
+              // Capture the stop-generation at IIFE creation. If the user
+              // presses Stop while this IIFE is in the wake-and-settle
+              // window (the historical cascade source — a 2-second sleep
+              // between the wake send and the relay send), the generation
+              // bumps; we bail at the next checkpoint instead of issuing
+              // the delayed `chat.send` that would re-wake the target and
+              // restart the cascade.
+              const startGen = getStopGeneration(currentTeamId)
               void (async () => {
                 try {
+                  // Bail-1: Stop fired before this IIFE got to run.
+                  if (getStopGeneration(currentTeamId) !== startGen) return
+
                   // Guard: target agent may have been deleted during processing.
                   // Relay targets can include Boo Zero — check both team members
                   // and (when present) Boo Zero before bailing out.
@@ -357,6 +412,10 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                       teamName: teamNameRef.current,
                     })
                     setTeamChatOverride(targetId, targetTeamSk)
+                    // Bail-2: Stop fired between IIFE start and wake send.
+                    // If we proceed, the wake message gets delivered but
+                    // the target then sits awake-but-idle — acceptable.
+                    if (getStopGeneration(currentTeamId) !== startGen) return
                     await currentClient.call('chat.send', {
                       sessionKey: targetTeamSk,
                       message: wakeMsg,
@@ -372,6 +431,13 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                   }
 
                   setTeamChatOverride(targetId, targetTeamSk)
+
+                  // Bail-3: Stop fired during the settle window OR between
+                  // the awake-check and this point. This is the BIG one —
+                  // without this check, a Stop pressed during the 2s wake-
+                  // settle would still let the relay payload land 2s
+                  // later, restarting the cascade past the freeze window.
+                  if (getStopGeneration(currentTeamId) !== startGen) return
 
                   await currentClient.call('chat.send', {
                     sessionKey: targetTeamSk,
@@ -460,6 +526,13 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
     // so the snapshot covers exactly the sessions the hook watches.
     const currentTeamId = teamIdRef.current
     if (currentTeamId) {
+      // Belt-and-suspenders bump — `stopAllInTeam` also calls
+      // `bumpStopGeneration(teamId)` synchronously before any await, but
+      // bumping here too means even a caller that skipped `stopAllInTeam`
+      // (e.g. some future test harness that drives stopSignal directly)
+      // still cancels in-flight IIFEs.
+      bumpStopGeneration(currentTeamId)
+
       const transcripts = useChatStore.getState().transcripts
       const combined = booZeroAgentRef.current
         ? [...teamAgentsRef.current, booZeroAgentRef.current]

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -22,6 +22,27 @@ import {
 } from './contextRelay'
 import { getMergedTeamEntries } from './groupChatSendOperation'
 
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/**
+ * Duration of the post-Stop freeze window (milliseconds). While inside the
+ * window, `processNewEntries` skips delegation/relay scanning but still
+ * advances `lastCountsRef` so post-freeze processing doesn't re-scan what
+ * arrived during the freeze.
+ *
+ * Chosen as 3 s because:
+ *   • The Gateway commits `chat.abort` partial responses within ~100 ms.
+ *   • Fire-and-forget delegation IIFEs from a pre-stop batch finish their
+ *     own `chat.send` round-trip in well under 1 s.
+ *   • Cross-agent wake messages (`buildSilentResumeWakeMessage`) are
+ *     instructed to "stay quiet" per `AGENTS.md`, so even if one slips
+ *     through during the freeze its response normally contains no
+ *     `<delegate>` blocks.
+ * 3 s is comfortably past those windows without making the chat feel
+ * frozen to the user. Tunable if real-world cascades exceed this.
+ */
+const STOP_FREEZE_MS = 3000
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface UseTeamOrchestrationParams {
@@ -102,6 +123,25 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
   const wokenThisBatchRef = useRef<Set<string>>(new Set())
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // ── Post-stop freeze window ──────────────────────────────────────────────
+  //
+  // When the user presses Stop, we set this timestamp ~3 seconds into the
+  // future. While `Date.now() < frozenUntilRef.current`, `processNewEntries`
+  // skips delegation scanning AND skips relay scheduling — but still updates
+  // `lastCountsRef` so that anything that arrives DURING the freeze is
+  // treated as "already processed" once the freeze lifts. Catches the
+  // common cascade triggers after Stop:
+  //   • Partial-response commits from the in-flight runs that `chat.abort`
+  //     was racing to cancel (the `"NO_RE"`, `"NO"` truncated messages).
+  //   • Fire-and-forget delegation / relay IIFEs that were already queued
+  //     from the pre-stop batch — their wake messages + subsequent agent
+  //     responses land during the freeze and get silently absorbed.
+  //   • Tail events from the Gateway for the aborted runs.
+  // After the freeze, normal processing resumes — but `lastCountsRef` has
+  // been kept current, so we don't re-scan the entries that arrived during
+  // the freeze for delegations.
+  const frozenUntilRef = useRef<number>(0)
+
   useEffect(() => {
     if (!enabled || !teamId) return
 
@@ -132,12 +172,29 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
         currentAgents.push(a)
       }
       if (!currentTeamId || !currentClient || currentAgents.length === 0) return
+
+      const transcripts = useChatStore.getState().transcripts
+
+      // ── Post-stop freeze ────────────────────────────────────────────────
+      // If we're inside the freeze window (the user recently pressed Stop),
+      // suppress delegation/relay scanning but still update `lastCountsRef`
+      // so that entries that landed during the freeze are treated as
+      // already-processed once the freeze lifts. Without this, the
+      // post-freeze pass would scan everything that arrived during the
+      // freeze and could fire a fresh cascade of delegations.
+      if (Date.now() < frozenUntilRef.current) {
+        for (const agent of currentAgents) {
+          const teamSk = buildTeamSessionKey(agent.id, currentTeamId)
+          lastCountsRef.current.set(teamSk, transcripts.get(teamSk)?.length ?? 0)
+        }
+        return
+      }
+
       // Relay hub: Boo Zero (when available) — every teammate's response is
       // relayed to Boo Zero so the universal leader stays in the loop. Fall
       // back to the team-internal lead when Boo Zero is unavailable.
       const relayHubId = currentBooZero?.id ?? currentInternalLead
 
-      const transcripts = useChatStore.getState().transcripts
       const lastCounts = lastCountsRef.current
 
       for (const agent of currentAgents) {
@@ -371,20 +428,55 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
   }, [enabled, teamId]) // Intentionally minimal deps — refs carry current values
 
   // ── Stop-signal handler ──────────────────────────────────────────────────
-  // When the parent bumps `stopSignal` (Stop button pressed), abort any
-  // pending debounced batch AND wipe the in-batch bookkeeping so we don't
-  // process stale state on the next change. The initial `stopSignal=0` is
-  // skipped so we don't reset on first mount.
+  // When the parent bumps `stopSignal` (Stop button pressed):
+  //   1. Cancel any pending debounced batch — don't process whatever is
+  //      currently in the chat store with the pre-stop scan logic.
+  //   2. Snapshot `lastCountsRef` to current transcript lengths (DO NOT
+  //      clear it). Clearing made `processNewEntries` treat every existing
+  //      entry as "new" on the next chat-store update, causing it to re-
+  //      scan historic `<delegate>` blocks and trigger fresh wake+
+  //      delegation cascades. The bug fix is to keep "what we've already
+  //      processed" honest across the stop.
+  //   3. Clear delegation source map + per-batch dedup. These are
+  //      tactical state that shouldn't survive a stop.
+  //   4. Open a freeze window (`STOP_FREEZE_MS` from now) during which
+  //      `processNewEntries` skips scanning but keeps `lastCountsRef`
+  //      current. This catches partial commits from aborted runs, fire-
+  //      and-forget IIFEs from the pre-stop batch, and Gateway tail
+  //      events. After the freeze, normal processing resumes.
+  // The initial `stopSignal=0` is skipped so we don't trigger on mount.
   const prevStopSignalRef = useRef(stopSignal)
   useEffect(() => {
     if (stopSignal === prevStopSignalRef.current) return
     prevStopSignalRef.current = stopSignal
+
     if (debounceTimerRef.current !== null) {
       clearTimeout(debounceTimerRef.current)
       debounceTimerRef.current = null
     }
-    lastCountsRef.current = new Map()
+
+    // Snapshot current transcript lengths into lastCountsRef. Reconstruct
+    // the dedup'd participant list the same way `processNewEntries` does
+    // so the snapshot covers exactly the sessions the hook watches.
+    const currentTeamId = teamIdRef.current
+    if (currentTeamId) {
+      const transcripts = useChatStore.getState().transcripts
+      const combined = booZeroAgentRef.current
+        ? [...teamAgentsRef.current, booZeroAgentRef.current]
+        : teamAgentsRef.current
+      const seen = new Set<string>()
+      const newCounts = new Map<string, number>()
+      for (const agent of combined) {
+        if (seen.has(agent.id)) continue
+        seen.add(agent.id)
+        const teamSk = buildTeamSessionKey(agent.id, currentTeamId)
+        newCounts.set(teamSk, transcripts.get(teamSk)?.length ?? 0)
+      }
+      lastCountsRef.current = newCounts
+    }
+
     delegationSourceRef.current = new Map()
     wokenThisBatchRef.current = new Set()
+    frozenUntilRef.current = Date.now() + STOP_FREEZE_MS
   }, [stopSignal])
 }

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -169,7 +169,11 @@ function AgentRow({
 // ─── Nav items ───────────────────────────────────────────────────────────────
 
 const PRIMARY_NAV: { id: NavView; label: string; emoji: string }[] = [
-  { id: 'graph', label: 'Ghost Graph', emoji: '👻' },
+  // `'graph'` opens Atlas — the global all-teams view with Boo Zero at
+  // the top of the hierarchy. Renamed from "Ghost Graph" because the
+  // team-scoped Ghost Graph still lives inside Group Chat; this slot is
+  // now specifically the org-wide map.
+  { id: 'graph', label: 'Atlas', emoji: '🌐' },
   { id: 'marketplace', label: 'Marketplace', emoji: '🛒' },
 ]
 

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -502,8 +502,14 @@ export function AgentListColumn() {
         </label>
       </div>
 
-      {/* Agent list — fixed at 40% of column height, scrollable */}
-      <div className="shrink-0 overflow-y-auto px-2 pb-2" style={{ height: '40%' }}>
+      {/* Agent list — grows to fill the space between search and the
+          global-nav block at the bottom. Scrolls when content overflows.
+          The previous `height: 40%` was a fixed sliver that left awkward
+          empty space mid-column and put the global nav adrift; using
+          `flex-1` instead anchors it to a clear top-half, with Create Boo
+          and the global nav (Atlas, Marketplace, Approvals, etc.) all
+          sitting at the bottom edge. */}
+      <div className="flex-1 min-h-0 overflow-y-auto px-2 pb-2">
         {selectedTeam && filtered.length > 0 && (
           <>
             <GroupChatRow

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -168,16 +168,25 @@ function AgentRow({
 
 // ─── Nav items ───────────────────────────────────────────────────────────────
 
-const PRIMARY_NAV: { id: NavView; label: string; emoji: string }[] = [
+interface NavItem {
+  id: NavView
+  label: string
+  emoji: string
+  /** Optional smaller, dimmer hint rendered beside the main label. */
+  subtitle?: string
+}
+
+const PRIMARY_NAV: NavItem[] = [
   // `'graph'` opens Atlas — the global all-teams view with Boo Zero at
   // the top of the hierarchy. Renamed from "Ghost Graph" because the
   // team-scoped Ghost Graph still lives inside Group Chat; this slot is
-  // now specifically the org-wide map.
-  { id: 'graph', label: 'Atlas', emoji: '🌐' },
+  // now specifically the org-wide map. Subtitle clarifies that Atlas is
+  // cross-team (vs. the per-team Ghost Graph users see inside Group Chat).
+  { id: 'graph', label: 'Atlas', emoji: '🌐', subtitle: '(All Teams)' },
   { id: 'marketplace', label: 'Marketplace', emoji: '🛒' },
 ]
 
-const SECONDARY_NAV: { id: NavView; label: string; emoji: string }[] = [
+const SECONDARY_NAV: NavItem[] = [
   { id: 'approvals', label: 'Approvals', emoji: '🔐' },
   { id: 'scheduler', label: 'Scheduler', emoji: '⏰' },
   { id: 'cost', label: 'Tokens Used', emoji: '📊' },
@@ -597,7 +606,7 @@ export function AgentListColumn() {
       {/* Divider between Create Boo and nav */}
       <div className="mx-3 my-2 border-t border-white/6" />
 
-      {/* Primary nav — Ghost Graph & Marketplace */}
+      {/* Primary nav — Atlas & Marketplace */}
       <div className="px-2 flex flex-col gap-0.5">
         {PRIMARY_NAV.map((item) => {
           const isActive = viewMode.type === 'nav' && viewMode.view === item.id
@@ -610,11 +619,14 @@ export function AgentListColumn() {
                 'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-[12px] font-semibold transition-all duration-150',
                 isActive
                   ? 'bg-accent/12 text-accent'
-                  : 'text-secondary/50 hover:bg-white/4 hover:text-secondary/80',
+                  : 'text-text/85 hover:bg-white/4 hover:text-text',
               ].join(' ')}
             >
               <span className="text-[14px]">{item.emoji}</span>
               <span>{item.label}</span>
+              {item.subtitle && (
+                <span className="text-[10px] font-normal text-text/45">{item.subtitle}</span>
+              )}
             </button>
           )
         })}
@@ -623,7 +635,7 @@ export function AgentListColumn() {
       {/* Divider */}
       <div className="mx-3 my-1.5 border-t border-white/6" />
 
-      {/* Secondary nav — Approvals, Scheduler, Cost */}
+      {/* Secondary nav — Approvals, Scheduler, Cost, System */}
       <div className="px-2 pb-3 flex flex-col gap-0.5">
         {SECONDARY_NAV.map((item) => {
           const isActive = viewMode.type === 'nav' && viewMode.view === item.id
@@ -637,7 +649,7 @@ export function AgentListColumn() {
                 'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-[11px] font-medium transition-all duration-150',
                 isActive
                   ? 'bg-accent/12 text-accent'
-                  : 'text-secondary/40 hover:bg-white/4 hover:text-secondary/70',
+                  : 'text-text/70 hover:bg-white/4 hover:text-text/90',
               ].join(' ')}
             >
               <span className="text-[12px]">{item.emoji}</span>

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -27,9 +27,12 @@ const VIEW_STYLE = {
   overflow: 'hidden' as const,
 }
 
-// Nav view → component mapping
+// Nav view → component mapping. The `'graph'` slot renders Atlas — the
+// global all-teams view with Boo Zero at the top of the hierarchy. The
+// team-scoped Ghost Graph still lives inside `GroupChatView` (rendered
+// with the default `scope === 'team'`).
 const NAV_PANELS: Record<NavView, () => ReactNode> = {
-  graph: () => <GhostGraphPanel />,
+  graph: () => <GhostGraphPanel scope="atlas" />,
   scheduler: () => <SchedulerPanel />,
   approvals: () => <ApprovalsPanel />,
   cost: () => <CostDashboard />,

--- a/apps/web/src/features/layout/TeamSidebar.tsx
+++ b/apps/web/src/features/layout/TeamSidebar.tsx
@@ -128,7 +128,19 @@ export function TeamSidebar() {
     setShowCreateModal(false)
     await hydrateTeams()
     useGraphStore.getState().triggerRefresh()
-    useViewStore.getState().navigateTo('graph')
+    // `CreateTeamModal` calls `useTeamStore.selectTeam(team.id)` right before
+    // firing `onCreated`, so by this point the newly-created team is the
+    // selected one. Open its group chat directly — that's where the user
+    // expects to land after deploying a team (chat with the new agents,
+    // or run through onboarding if it's a template team with no history).
+    // Fall back to Atlas defensively if selection didn't stick for some
+    // reason (e.g. an upstream rejection deselected the team).
+    const newTeamId = useTeamStore.getState().selectedTeamId
+    if (newTeamId) {
+      useViewStore.getState().openGroupChat(newTeamId)
+    } else {
+      useViewStore.getState().navigateTo('graph')
+    }
   }, [])
 
   const handleArchiveTeam = useCallback(async () => {

--- a/apps/web/src/features/layout/TeamSidebar.tsx
+++ b/apps/web/src/features/layout/TeamSidebar.tsx
@@ -406,8 +406,12 @@ export function TeamSidebar() {
             team={team}
             selected={team.id === selectedTeamId}
             onClick={() => {
+              // Clicking a team icon opens that team's Group Chat — the
+              // primary view for working WITH the team. (Atlas is the
+              // cross-team org-wide view, reachable from the nav slot
+              // labelled "🌐 Atlas" in the agent-list column.)
               selectTeam(team.id)
-              useViewStore.getState().navigateTo('graph')
+              useViewStore.getState().openGroupChat(team.id)
             }}
             onContextMenu={(e) => {
               e.preventDefault()

--- a/apps/web/src/features/layout/WelcomeState.tsx
+++ b/apps/web/src/features/layout/WelcomeState.tsx
@@ -345,7 +345,16 @@ export function WelcomeState() {
       <CreateTeamModal
         isOpen={showCreateModal}
         onClose={() => setShowCreateModal(false)}
-        onCreated={() => setShowCreateModal(false)}
+        onCreated={() => {
+          setShowCreateModal(false)
+          // CreateTeamModal selects the newly-created team before firing
+          // onCreated — land in its group chat instead of leaving the user
+          // on the welcome screen with nothing visibly happening.
+          const newTeamId = useTeamStore.getState().selectedTeamId
+          if (newTeamId) {
+            useViewStore.getState().openGroupChat(newTeamId)
+          }
+        }}
       />
     </div>
   )

--- a/apps/web/src/features/layout/WelcomeState.tsx
+++ b/apps/web/src/features/layout/WelcomeState.tsx
@@ -164,9 +164,9 @@ export function WelcomeState() {
     },
     {
       num: '3',
-      text: 'Explore the Ghost Graph to see your fleet',
+      text: 'Open the Atlas to see all your teams',
       action: () => useViewStore.getState().navigateTo('graph'),
-      actionLabel: 'Open Graph',
+      actionLabel: 'Open Atlas',
     },
   ]
 
@@ -305,7 +305,7 @@ export function WelcomeState() {
         <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
           {(
             [
-              { label: 'Ghost Graph', emoji: '👻', view: 'graph' as const },
+              { label: 'Atlas', emoji: '🌐', view: 'graph' as const },
               { label: 'Marketplace', emoji: '🛒', view: 'marketplace' as const },
               { label: 'Cost', emoji: '💰', view: 'cost' as const },
             ] as const

--- a/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
+++ b/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
@@ -444,6 +444,99 @@ function TeamBriefEditor({
   )
 }
 
+// ─── Display name editor ────────────────────────────────────────────────────
+//
+// Phase E: the user's Gateway-side agent name can be anything ("main", a slug,
+// or whatever they typed in OpenClaw onboarding — production saw "Mythos").
+// Clawboo applies a display-name override that lives in SQLite and is overlaid
+// on the Boo Zero fleet entry at hydration time. This editor lets the user
+// change the override or clear it at any time. The default ("Boo Zero") is
+// seeded on first connect — see `GatewayBootstrap.tsx`.
+
+function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentName: string }) {
+  const [value, setValue] = useState<string>(currentName)
+  const [saving, setSaving] = useState<boolean>(false)
+  const isDirty = value.trim() !== currentName.trim()
+
+  const handleSave = useCallback(async () => {
+    const trimmed = value.trim() || 'Boo Zero'
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(agentId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      })
+      if (!res.ok) throw new Error('Save failed')
+      useToastStore.getState().addToast({
+        type: 'success',
+        message: `Boo Zero display name → "${trimmed}". Reload to apply across all views.`,
+      })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [agentId, value])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        How Boo Zero refers to itself in chats. Defaults to <code>Boo Zero</code>. Stored in
+        Clawboo&apos;s SQLite — the underlying OpenClaw agent name is not touched.
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Boo Zero"
+          maxLength={80}
+          disabled={saving}
+          style={{
+            flex: 1,
+            height: 30,
+            padding: '0 10px',
+            fontSize: 12,
+            fontFamily: 'var(--font-body, sans-serif)',
+            background: 'rgba(13,17,23,0.85)',
+            color: '#E8E8E8',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: 6,
+          }}
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || saving || value.trim().length === 0}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: isDirty && value.trim().length > 0 ? '#E94560' : 'rgba(255,255,255,0.06)',
+            color: isDirty && value.trim().length > 0 ? '#fff' : 'rgba(232,232,232,0.5)',
+            cursor: !isDirty || saving || value.trim().length === 0 ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+          Save
+        </button>
+      </div>
+      {isDirty && (
+        <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved — save and reload to apply.</span>
+      )}
+    </div>
+  )
+}
+
 // ─── Top-level panel ─────────────────────────────────────────────────────────
 
 export function BooZeroBriefsPanel() {
@@ -470,6 +563,23 @@ export function BooZeroBriefsPanel() {
         >
           Boo Zero is missing from the fleet. Briefs are still editable, but there&apos;s no agent
           to receive them until a primary agent is identified.
+        </div>
+      )}
+
+      {/* Display name */}
+      {booZeroAgent && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <h3
+            style={{
+              margin: 0,
+              fontSize: 12,
+              fontWeight: 600,
+              color: 'rgba(232,232,232,0.85)',
+            }}
+          >
+            Display name
+          </h3>
+          <DisplayNameEditor agentId={booZeroAgent.id} currentName={booZeroAgent.name} />
         </div>
       )}
 

--- a/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
+++ b/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
@@ -1,0 +1,523 @@
+// Boo Zero brief management — global brief + per-team briefs.
+// Lives inside MaintenancePanel ("System" view). SQLite-backed (Phase 1
+// API routes), surfaced as editable virtual files. Boo Zero reads briefs
+// at runtime via the context preamble injection in `groupChatSendOperation`
+// and `ChatPanel` (when the user `@TeamName`s in Boo Zero's individual chat).
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Loader2, RefreshCw, Save, ChevronRight } from 'lucide-react'
+import { useTeamStore } from '@/stores/team'
+import { useFleetStore } from '@/stores/fleet'
+import { useBooZeroStore } from '@/stores/booZero'
+import { useToastStore } from '@/stores/toast'
+import { buildGlobalBrief, buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
+import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+interface BriefResponse {
+  content?: string | null
+  updatedAt?: number | null
+}
+
+async function fetchGlobalBrief(): Promise<BriefResponse> {
+  const res = await fetch('/api/boo-zero/global-brief')
+  if (!res.ok) throw new Error('Failed to load global brief')
+  return (await res.json()) as BriefResponse
+}
+
+async function fetchTeamBrief(teamId: string): Promise<BriefResponse> {
+  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
+  if (!res.ok) throw new Error('Failed to load team brief')
+  return (await res.json()) as BriefResponse
+}
+
+async function putGlobalBrief(content: string): Promise<void> {
+  const res = await fetch('/api/boo-zero/global-brief', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) throw new Error('Failed to save global brief')
+}
+
+async function putTeamBrief(teamId: string, content: string): Promise<void> {
+  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) throw new Error('Failed to save team brief')
+}
+
+// ─── Global brief sub-section ────────────────────────────────────────────────
+
+function GlobalBriefEditor() {
+  const teams = useTeamStore((s) => s.teams)
+  const teamsRef = useRef(teams)
+  teamsRef.current = teams
+
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+  const seededRef = useRef<boolean>(false)
+
+  useEffect(() => {
+    // Intentionally seed exactly once on mount. Subsequent team changes
+    // shouldn't blow away user edits — they can press "Regenerate" if they
+    // want a fresh draft from the current team list. `teamsRef` is read at
+    // load-time so the initial default still reflects the current state.
+    if (seededRef.current) return
+    seededRef.current = true
+    let cancelled = false
+    setLoading(true)
+    fetchGlobalBrief()
+      .then((r) => {
+        if (cancelled) return
+        const value =
+          r.content && r.content.length > 0
+            ? r.content
+            : buildGlobalBrief({
+                teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
+              })
+        setContent(value)
+        setClean(value)
+      })
+      .catch(() => {
+        if (cancelled) return
+        const fallback = buildGlobalBrief({
+          teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
+        })
+        setContent(fallback)
+        setClean(fallback)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      await putGlobalBrief(content)
+      setClean(content)
+      useToastStore.getState().addToast({ type: 'success', message: 'Global brief saved' })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [content])
+
+  const handleRegenerate = useCallback(() => {
+    const fresh = buildGlobalBrief({
+      teams: teams.map((t) => ({ name: t.name, icon: t.icon })),
+    })
+    setContent(fresh)
+  }, [teams])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        Boo Zero&apos;s overall responsibilities + the list of teams it leads. Injected into Boo
+        Zero&apos;s context preamble on every interaction.
+      </p>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={loading || saving}
+        spellCheck={false}
+        style={{
+          width: '100%',
+          minHeight: 240,
+          maxHeight: 480,
+          padding: 12,
+          fontSize: 12,
+          fontFamily: 'var(--font-geist-mono, monospace)',
+          lineHeight: 1.55,
+          background: 'rgba(13,17,23,0.85)',
+          color: '#E8E8E8',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || saving || loading}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+            color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+            cursor: !isDirty || saving || loading ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleRegenerate}
+          disabled={loading || saving}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'rgba(255,255,255,0.04)',
+            color: 'rgba(232,232,232,0.7)',
+            cursor: loading || saving ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+          title="Regenerate from current team list (does not save yet)"
+        >
+          <RefreshCw size={12} />
+          Regenerate from teams
+        </button>
+        {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+      </div>
+    </div>
+  )
+}
+
+// ─── Team brief sub-section ──────────────────────────────────────────────────
+
+function TeamBriefEditor({
+  teamId,
+  teamName,
+  teamIcon,
+  templateId,
+  teamColor,
+  collapsed,
+  onToggle,
+}: {
+  teamId: string
+  teamName: string
+  teamIcon: string
+  templateId: string | null
+  teamColor: string
+  collapsed: boolean
+  onToggle: () => void
+}) {
+  const agents = useFleetStore((s) => s.agents)
+  const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
+
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(false)
+  const [saving, setSaving] = useState<boolean>(false)
+  const [loadedOnce, setLoadedOnce] = useState<boolean>(false)
+
+  const computeDefaultBrief = useCallback((): string => {
+    const genuineLead =
+      teamAgents.find((a) => detectGenuineLeader({ name: a.name, role: a.name })) ?? null
+    const matched = genuineLead
+      ? matchedLeadershipKeyword({ name: genuineLead.name, role: genuineLead.name })
+      : null
+    const members: TeamBriefMember[] = teamAgents.map((a) => ({
+      name: a.name,
+      role: a.name,
+    }))
+    return buildTeamBrief({
+      team: { name: teamName, icon: teamIcon, templateId, description: null },
+      members,
+      internalLead:
+        genuineLead && matched ? { agentName: genuineLead.name, matchedKeyword: matched } : null,
+    })
+  }, [teamAgents, teamName, teamIcon, templateId])
+
+  // Load when expanded (lazy).
+  useEffect(() => {
+    if (collapsed || loadedOnce) return
+    let cancelled = false
+    setLoading(true)
+    fetchTeamBrief(teamId)
+      .then((r) => {
+        if (cancelled) return
+        const value = r.content && r.content.length > 0 ? r.content : computeDefaultBrief()
+        setContent(value)
+        setClean(value)
+        setLoadedOnce(true)
+      })
+      .catch(() => {
+        if (cancelled) return
+        const fallback = computeDefaultBrief()
+        setContent(fallback)
+        setClean(fallback)
+        setLoadedOnce(true)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [collapsed, loadedOnce, teamId, computeDefaultBrief])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      await putTeamBrief(teamId, content)
+      setClean(content)
+      useToastStore.getState().addToast({ type: 'success', message: `Brief for ${teamName} saved` })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [teamId, teamName, content])
+
+  const handleRegenerate = useCallback(() => {
+    setContent(computeDefaultBrief())
+  }, [computeDefaultBrief])
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: 8,
+        background: 'rgba(255,255,255,0.02)',
+        overflow: 'hidden',
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          width: '100%',
+          padding: '10px 12px',
+          background: 'transparent',
+          border: 'none',
+          cursor: 'pointer',
+          color: '#E8E8E8',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          fontSize: 12,
+          textAlign: 'left',
+        }}
+        aria-expanded={!collapsed}
+      >
+        <span
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 22,
+            height: 22,
+            borderRadius: 6,
+            background: `${teamColor}22`,
+            fontSize: 13,
+          }}
+        >
+          {teamIcon}
+        </span>
+        <span style={{ flex: 1, fontWeight: 600 }}>{teamName}</span>
+        <span style={{ fontSize: 10, color: 'rgba(232,232,232,0.4)' }}>
+          {teamAgents.length} {teamAgents.length === 1 ? 'agent' : 'agents'}
+        </span>
+        <ChevronRight
+          size={14}
+          style={{
+            transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)',
+            transition: 'transform 0.15s ease',
+            opacity: 0.5,
+          }}
+        />
+      </button>
+      {!collapsed && (
+        <div style={{ padding: '0 12px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {loading && !loadedOnce ? (
+            <div
+              style={{
+                padding: 16,
+                fontSize: 11,
+                color: 'rgba(232,232,232,0.5)',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+              }}
+            >
+              <Loader2 size={12} className="animate-spin" /> Loading brief…
+            </div>
+          ) : (
+            <>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                disabled={saving}
+                spellCheck={false}
+                style={{
+                  width: '100%',
+                  minHeight: 200,
+                  maxHeight: 420,
+                  padding: 10,
+                  fontSize: 12,
+                  fontFamily: 'var(--font-geist-mono, monospace)',
+                  lineHeight: 1.55,
+                  background: 'rgba(13,17,23,0.85)',
+                  color: '#E8E8E8',
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  borderRadius: 6,
+                  resize: 'vertical',
+                }}
+              />
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!isDirty || saving}
+                  style={{
+                    height: 28,
+                    padding: '0 10px',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    borderRadius: 6,
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+                    color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+                    cursor: !isDirty || saving ? 'default' : 'pointer',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                  }}
+                >
+                  {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+                  Save
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRegenerate}
+                  disabled={saving}
+                  style={{
+                    height: 28,
+                    padding: '0 10px',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    borderRadius: 6,
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    background: 'rgba(255,255,255,0.04)',
+                    color: 'rgba(232,232,232,0.7)',
+                    cursor: saving ? 'default' : 'pointer',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                  }}
+                  title="Regenerate from current team members (does not save until you press Save)"
+                >
+                  <RefreshCw size={12} />
+                  Regenerate
+                </button>
+                {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Top-level panel ─────────────────────────────────────────────────────────
+
+export function BooZeroBriefsPanel() {
+  const teams = useTeamStore((s) => s.teams).filter((t) => !t.isArchived)
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const agents = useFleetStore((s) => s.agents)
+  const booZeroAgent = booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null
+
+  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {!booZeroAgent && (
+        <div
+          style={{
+            padding: 10,
+            fontSize: 11,
+            color: '#FBBF24',
+            border: '1px solid rgba(251,191,36,0.3)',
+            borderRadius: 6,
+            background: 'rgba(251,191,36,0.05)',
+          }}
+          data-testid="boo-zero-missing-banner"
+        >
+          Boo Zero is missing from the fleet. Briefs are still editable, but there&apos;s no agent
+          to receive them until a primary agent is identified.
+        </div>
+      )}
+
+      {/* Global brief */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 12,
+            fontWeight: 600,
+            color: 'rgba(232,232,232,0.85)',
+          }}
+        >
+          Global brief
+        </h3>
+        <GlobalBriefEditor />
+      </div>
+
+      {/* Per-team briefs */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <h3
+          style={{
+            margin: 0,
+            fontSize: 12,
+            fontWeight: 600,
+            color: 'rgba(232,232,232,0.85)',
+          }}
+        >
+          Per-team briefs
+        </h3>
+        {teams.length === 0 && (
+          <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+            No teams deployed yet. Briefs appear here once you deploy your first team.
+          </p>
+        )}
+        {teams.map((team) => (
+          <TeamBriefEditor
+            key={team.id}
+            teamId={team.id}
+            teamName={team.name}
+            teamIcon={team.icon}
+            teamColor={team.color}
+            templateId={team.templateId ?? null}
+            collapsed={expandedTeamId !== team.id}
+            onToggle={() => setExpandedTeamId(expandedTeamId === team.id ? null : team.id)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/maintenance/MaintenancePanel.tsx
+++ b/apps/web/src/features/maintenance/MaintenancePanel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Loader2 } from 'lucide-react'
 import { GatewayControls } from './GatewayControls'
 import { ModelSelector } from './ModelSelector'
 import { ApiKeyManager } from './ApiKeyManager'
+import { BooZeroBriefsPanel } from './BooZeroBriefsPanel'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
 import { consumeSSE } from '@/lib/sseClient'
@@ -570,7 +571,24 @@ export function MaintenancePanel() {
 
       <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)' }} />
 
-      {/* Section 4: Agent Coordination */}
+      {/* Section 4: Boo Zero — universal team leader context */}
+      <div style={{ margin: '24px 0 28px' }} data-testid="boo-zero-briefs-section">
+        <SectionHeading>Boo Zero</SectionHeading>
+        <p
+          style={{
+            fontSize: 11,
+            color: 'rgba(232,232,232,0.45)',
+            margin: '4px 0 14px',
+          }}
+        >
+          Universal team leader. Read by Boo Zero on every interaction.
+        </p>
+        <BooZeroBriefsPanel />
+      </div>
+
+      <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)' }} />
+
+      {/* Section 5: Agent Coordination */}
       <AgentCoordinationToggle />
 
       <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)' }} />

--- a/apps/web/src/features/marketplace/MarketplacePanel.tsx
+++ b/apps/web/src/features/marketplace/MarketplacePanel.tsx
@@ -4,6 +4,8 @@ import { Search } from 'lucide-react'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
 import { useMarketplaceStore } from '@/stores/marketplace'
+import { useTeamStore } from '@/stores/team'
+import { useViewStore } from '@/stores/view'
 import type { InstalledSkillRecord } from '@/stores/marketplace'
 import { mutationQueue } from '@/lib/mutationQueue'
 import { useGraphStore } from '@/features/graph/store'
@@ -1056,6 +1058,13 @@ export function MarketplacePanel() {
         onCreated={() => {
           setShowCreateModal(false)
           setPrefilledProfile(null)
+          // CreateTeamModal selects the newly-created team before firing
+          // onCreated — switch the user into its group chat so they can
+          // immediately use the team they just deployed from the marketplace.
+          const newTeamId = useTeamStore.getState().selectedTeamId
+          if (newTeamId) {
+            useViewStore.getState().openGroupChat(newTeamId)
+          }
         }}
         initialProfile={prefilledProfile}
       />

--- a/apps/web/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/features/onboarding/OnboardingWizard.tsx
@@ -22,6 +22,9 @@ import type { ProfileLike, TeamProfile } from '@/features/teams/types'
 import { resolveWorkspaceDir, createAgent } from '@/lib/createAgent'
 import { computeDedupSuffix, rewriteAgentsMd, rewriteTemplateName } from '@/lib/deployDedup'
 import { buildClawbooHelpDoc, buildTeamAgentsMd } from '@/lib/teamProtocol'
+import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
+import { buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
+import { useBooZeroStore } from '@/stores/booZero'
 import { mergeSoulWithPersonality, type PersonalityValues } from '@/lib/soulPersonality'
 import { DetectStep, InstallStep, ConfigureStep, StartGatewayStep } from './steps'
 import { StepIndicator } from './StepIndicator'
@@ -578,8 +581,26 @@ function DeployStep({
           // team creation failure is non-fatal — agents will be teamless
         }
 
+        // Genuine-leader detection: find the first catalog agent whose
+        // name/role matches a leadership archetype. Boo Zero is the universal
+        // leader; this column is now reserved for genuine team-internal
+        // leads (CTO, Team Lead, etc.).
+        const genuineLeaderCatalogAgent =
+          resolved.find((a) => detectGenuineLeader({ name: a.name, role: a.role })) ?? null
+        const genuineLeaderFinalName = genuineLeaderCatalogAgent
+          ? (dedupPlan.agentNameMap.get(genuineLeaderCatalogAgent.name) ??
+            genuineLeaderCatalogAgent.name)
+          : null
+
+        // Resolve Boo Zero name (universal leader) to thread through file gen.
+        const booZeroAgentId = useBooZeroStore.getState().booZeroAgentId
+        const booZeroAgent = booZeroAgentId
+          ? (useFleetStore.getState().agents.find((a) => a.id === booZeroAgentId) ?? null)
+          : null
+        const universalLeaderName = booZeroAgent?.name ?? null
+
         const workspaceDir = await resolveWorkspaceDir(client)
-        let firstAgentId: string | null = null
+        let genuineLeaderAgentId: string | null = null
         for (let i = 0; i < resolved.length; i++) {
           const agent = resolved[i]!
           const finalAgentName = dedupPlan.agentNameMap.get(agent.name) ?? agent.name
@@ -607,6 +628,8 @@ function DeployStep({
             teamName: finalTeamName,
             teammates: teammatesForProtocol,
             routingRules: rawRouting,
+            universalLeaderName,
+            teamInternalLeadName: genuineLeaderFinalName,
           })
           // CLAWBOO.md — workspace-resident operating reference. See
           // `lib/teamProtocol.ts` (`buildClawbooHelpDoc`).
@@ -614,6 +637,7 @@ function DeployStep({
             agentName: finalAgentName,
             teamName: finalTeamName,
             teammates: teammatesForProtocol,
+            universalLeaderName,
           })
 
           const agentId = await createAgent(client, finalAgentName, workspaceDir, {
@@ -631,7 +655,9 @@ function DeployStep({
             body: JSON.stringify({ agentId, values: defaultPersonality }),
           }).catch(() => {})
 
-          if (i === 0) firstAgentId = agentId
+          if (genuineLeaderCatalogAgent && agent.name === genuineLeaderCatalogAgent.name) {
+            genuineLeaderAgentId = agentId
+          }
           setProgress(i + 1)
 
           // Assign agent to team (best-effort)
@@ -648,17 +674,66 @@ function DeployStep({
           }
         }
 
-        // Set first agent as team leader (best-effort)
-        if (firstAgentId && teamId) {
+        // Set the team-internal lead (only when detected). Boo Zero is the
+        // universal leader; this column is reserved for genuine leads now.
+        if (teamId) {
           try {
             await fetch(`/api/teams/${teamId}`, {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ leaderAgentId: firstAgentId }),
+              body: JSON.stringify({ leaderAgentId: genuineLeaderAgentId }),
             })
-            useTeamStore.getState().updateTeam(teamId, { leaderAgentId: firstAgentId })
+            useTeamStore.getState().updateTeam(teamId, { leaderAgentId: genuineLeaderAgentId })
           } catch {
             // leader assignment is non-fatal
+          }
+        }
+
+        // Generate Boo Zero's per-team brief (best-effort).
+        if (teamId) {
+          const extractSkillsFromToolsMd = (md: string | undefined): string[] => {
+            if (!md) return []
+            const skillsMatch = md.match(/##\s+Skills\s*\n([\s\S]*?)(?=\n##\s|$)/i)
+            const body = skillsMatch?.[1] ?? ''
+            return body
+              .split('\n')
+              .map((l) => l.trim())
+              .filter((l) => l.startsWith('- '))
+              .map((l) => l.slice(2).trim())
+              .filter(Boolean)
+          }
+          const briefMembers: TeamBriefMember[] = resolved.map((a) => ({
+            name: dedupPlan.agentNameMap.get(a.name) ?? a.name,
+            role: a.role,
+            tools: extractSkillsFromToolsMd(a.toolsTemplate),
+          }))
+          const internalLeadKeyword = genuineLeaderCatalogAgent
+            ? matchedLeadershipKeyword({
+                name: genuineLeaderCatalogAgent.name,
+                role: genuineLeaderCatalogAgent.role,
+              })
+            : null
+          const briefMarkdown = buildTeamBrief({
+            team: {
+              name: finalTeamName,
+              icon: profile.emoji,
+              templateId: profile.id ?? null,
+              description: profile.description ?? '',
+            },
+            members: briefMembers,
+            internalLead:
+              genuineLeaderFinalName && internalLeadKeyword
+                ? { agentName: genuineLeaderFinalName, matchedKeyword: internalLeadKeyword }
+                : null,
+          })
+          try {
+            await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ content: briefMarkdown }),
+            })
+          } catch {
+            // brief gen is non-fatal
           }
         }
 

--- a/apps/web/src/features/shared/ResizeHandle.tsx
+++ b/apps/web/src/features/shared/ResizeHandle.tsx
@@ -1,44 +1,135 @@
-import { useRef, useCallback } from 'react'
+import { useRef, useCallback, type CSSProperties } from 'react'
 import { Separator } from 'react-resizable-panels'
+
+// Visual seam between two resizable panels. Two design ideas stacked:
+//   A. Inset-shadow groove — a 1px dark line on one side of the handle and a
+//      1px highlight line on the other. The panel "above" appears to end on a
+//      shadow edge, the panel "below" starts on a lit edge, giving the seam
+//      perceived depth.
+//   B. Drag-grip — a small cluster of dots centered on the seam, telling the
+//      user the divider is draggable. Always visible but dim; brightens on
+//      hover/active drag.
+//
+// Hover behaviour: the resting groove stays, and the gap between the two lines
+// fills with the accent red so the seam reads as "lit up" rather than "just a
+// different colored bar."
+
+const SHADOW_COLOR = 'rgba(0,0,0,0.55)'
+const HIGHLIGHT_COLOR = 'rgba(255,255,255,0.06)'
+const GRIP_COLOR = 'rgba(232,232,232,0.32)'
+const GRIP_COLOR_HOVER = 'rgba(232,232,232,0.7)'
+const ACCENT_FILL = 'rgba(233,69,96,0.35)'
+const HANDLE_THICKNESS = 5
 
 export function ResizeHandle({ direction }: { direction: 'horizontal' | 'vertical' }) {
   const isHorizontal = direction === 'horizontal'
   const ref = useRef<HTMLDivElement>(null)
+  const fillRef = useRef<HTMLDivElement>(null)
+  const gripDotsRef = useRef<HTMLDivElement>(null)
+
+  const setGripColor = useCallback((color: string) => {
+    if (!gripDotsRef.current) return
+    for (const dot of Array.from(gripDotsRef.current.children) as HTMLElement[]) {
+      dot.style.background = color
+    }
+  }, [])
 
   const onMouseEnter = useCallback(() => {
-    if (ref.current) ref.current.style.background = 'rgba(233,69,96,0.4)'
-  }, [])
+    if (fillRef.current) fillRef.current.style.background = ACCENT_FILL
+    setGripColor(GRIP_COLOR_HOVER)
+  }, [setGripColor])
 
   const onMouseLeave = useCallback(() => {
-    if (ref.current) ref.current.style.background = 'transparent'
-  }, [])
+    if (fillRef.current) fillRef.current.style.background = 'transparent'
+    setGripColor(GRIP_COLOR)
+  }, [setGripColor])
+
+  // Position lookups — keeps the JSX readable instead of inline ternaries.
+  const shadowLine: CSSProperties = isHorizontal
+    ? { left: 0, top: 0, bottom: 0, width: 1 }
+    : { top: 0, left: 0, right: 0, height: 1 }
+  const highlightLine: CSSProperties = isHorizontal
+    ? { right: 0, top: 0, bottom: 0, width: 1 }
+    : { bottom: 0, left: 0, right: 0, height: 1 }
+  const fillInset: CSSProperties = isHorizontal
+    ? { left: 1, right: 1, top: 0, bottom: 0 }
+    : { top: 1, bottom: 1, left: 0, right: 0 }
 
   return (
     <Separator
       className="resize-handle"
       elementRef={ref}
       style={{
-        width: isHorizontal ? 3 : '100%',
-        height: isHorizontal ? '100%' : 3,
+        width: isHorizontal ? HANDLE_THICKNESS : '100%',
+        height: isHorizontal ? '100%' : HANDLE_THICKNESS,
         background: 'transparent',
         position: 'relative',
         flexShrink: 0,
         cursor: isHorizontal ? 'col-resize' : 'row-resize',
-        transition: 'background 0.15s',
       }}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
+      {/* (A) Shadow line — top / left edge */}
+      <div style={{ position: 'absolute', background: SHADOW_COLOR, ...shadowLine }} />
+
+      {/* (A) Hover accent fill — sits between the two lines, transparent at rest */}
       <div
+        ref={fillRef}
         style={{
           position: 'absolute',
-          [isHorizontal ? 'left' : 'top']: 1,
-          [isHorizontal ? 'top' : 'left']: 0,
-          [isHorizontal ? 'bottom' : 'right']: 0,
-          [isHorizontal ? 'width' : 'height']: 1,
-          background: 'rgba(255,255,255,0.06)',
+          background: 'transparent',
+          transition: 'background 0.15s',
+          ...fillInset,
         }}
       />
+
+      {/* (A) Highlight line — bottom / right edge */}
+      <div style={{ position: 'absolute', background: HIGHLIGHT_COLOR, ...highlightLine }} />
+
+      {/* (B) Drag-grip dots — 3 dots, centered on the seam */}
+      <div
+        ref={gripDotsRef}
+        aria-hidden
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          display: 'flex',
+          flexDirection: isHorizontal ? 'column' : 'row',
+          gap: 3,
+          pointerEvents: 'none',
+        }}
+      >
+        <span
+          style={{
+            width: 2,
+            height: 2,
+            borderRadius: '50%',
+            background: GRIP_COLOR,
+            transition: 'background 0.15s',
+          }}
+        />
+        <span
+          style={{
+            width: 2,
+            height: 2,
+            borderRadius: '50%',
+            background: GRIP_COLOR,
+            transition: 'background 0.15s',
+          }}
+        />
+        <span
+          style={{
+            width: 2,
+            height: 2,
+            borderRadius: '50%',
+            background: GRIP_COLOR,
+            transition: 'background 0.15s',
+          }}
+        />
+      </div>
     </Separator>
   )
 }

--- a/apps/web/src/features/teams/CreateTeamModal.tsx
+++ b/apps/web/src/features/teams/CreateTeamModal.tsx
@@ -6,11 +6,14 @@ import { useConnectionStore } from '@/stores/connection'
 import { useTeamStore } from '@/stores/team'
 import { useFleetStore } from '@/stores/fleet'
 import { useToastStore } from '@/stores/toast'
+import { useBooZeroStore } from '@/stores/booZero'
 import { resolveWorkspaceDir, createAgent } from '@/lib/createAgent'
 import { computeDedupSuffix, rewriteAgentsMd, rewriteTemplateName } from '@/lib/deployDedup'
 import { buildClawbooHelpDoc, buildTeamAgentsMd } from '@/lib/teamProtocol'
 import { mergeSoulWithPersonality, type PersonalityValues } from '@/lib/soulPersonality'
 import { hydrateTeams } from '@/lib/hydrateTeams'
+import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
+import { buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
 import { useGraphStore } from '@/features/graph/store'
 import type { TeamTemplate, ProfileLike, TemplateSource, TemplateCategory } from './types'
 import {
@@ -244,8 +247,29 @@ export function CreateTeamModal({
       // Template team → deploy agents
       setStep('deploy')
 
+      // Genuine-leader detection: find the first catalog agent whose
+      // name/role matches a leadership archetype (CTO, Team Lead, etc.).
+      // Only THIS agent (if any) becomes the team-internal lead.
+      // Forced "first agent is leader" is gone — Boo Zero is the universal
+      // leader, the internal-lead column is now optional.
+      const genuineLeaderCatalogAgent =
+        resolved.find((a) => detectGenuineLeader({ name: a.name, role: a.role })) ?? null
+      const genuineLeaderFinalName = genuineLeaderCatalogAgent
+        ? (dedupPlan.agentNameMap.get(genuineLeaderCatalogAgent.name) ??
+          genuineLeaderCatalogAgent.name)
+        : null
+
+      // Resolve Boo Zero name to thread through agent file generation —
+      // every agent gets a "Universal Leader" block in their AGENTS.md and
+      // CLAWBOO.md so they know how to escalate upward via `<delegate>`.
+      const booZeroAgentId = useBooZeroStore.getState().booZeroAgentId
+      const booZeroAgent = booZeroAgentId
+        ? (useFleetStore.getState().agents.find((a) => a.id === booZeroAgentId) ?? null)
+        : null
+      const universalLeaderName = booZeroAgent?.name ?? null
+
       const workspaceDir = await resolveWorkspaceDir(client)
-      let firstAgentId: string | null = null
+      let genuineLeaderAgentId: string | null = null
       for (let i = 0; i < resolved.length; i++) {
         const agent = resolved[i]
         const finalAgentName = dedupPlan.agentNameMap.get(agent.name) ?? agent.name
@@ -274,6 +298,8 @@ export function CreateTeamModal({
           teamName: finalTeamName,
           teammates: teammatesForProtocol,
           routingRules: rawRouting,
+          universalLeaderName,
+          teamInternalLeadName: genuineLeaderFinalName,
         })
         // CLAWBOO.md sits at the agent's workspace root and provides the
         // detailed operating reference (workspace isolation paths,
@@ -283,6 +309,7 @@ export function CreateTeamModal({
           agentName: finalAgentName,
           teamName: finalTeamName,
           teammates: teammatesForProtocol,
+          universalLeaderName,
         })
 
         const agentId = await createAgent(client, finalAgentName, workspaceDir, {
@@ -300,7 +327,11 @@ export function CreateTeamModal({
           body: JSON.stringify({ agentId, values: defaultPersonality }),
         }).catch(() => {})
 
-        if (i === 0) firstAgentId = agentId
+        // Capture the agentId of the detected genuine leader so we can set
+        // it as the team-internal lead after the deploy loop completes.
+        if (genuineLeaderCatalogAgent && agent.name === genuineLeaderCatalogAgent.name) {
+          genuineLeaderAgentId = agentId
+        }
 
         // Assign agent to team (best-effort)
         try {
@@ -314,18 +345,75 @@ export function CreateTeamModal({
         }
       }
 
-      // Set first agent as team leader (best-effort)
-      if (firstAgentId && team.id) {
+      // Set the team-internal lead — ONLY when a genuine leader was detected.
+      // Forced first-agent-as-leader is gone; Boo Zero is the universal leader.
+      // PATCH always runs (with `null` when no genuine leader) so the column
+      // stays accurate even on re-deploys.
+      if (team.id) {
         try {
           await fetch(`/api/teams/${team.id}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ leaderAgentId: firstAgentId }),
+            body: JSON.stringify({ leaderAgentId: genuineLeaderAgentId }),
           })
-          useTeamStore.getState().updateTeam(team.id, { leaderAgentId: firstAgentId })
+          useTeamStore.getState().updateTeam(team.id, { leaderAgentId: genuineLeaderAgentId })
         } catch {
           // leader assignment is non-fatal
         }
+      }
+
+      // Generate and persist Boo Zero's per-team brief. The brief is what
+      // Boo Zero reads when entering this team's chat — team identity,
+      // member roster, internal lead (if any), routing patterns, anti-
+      // patterns. Best-effort: a failed PUT doesn't block the deploy.
+      // Extract skill names from each agent's TOOLS.md markdown bullets.
+      // `ResolvedAgent` doesn't carry `description` / `skillIds` directly
+      // (those live on AgentCatalogEntry), so we derive what we can from
+      // the templates the deploy loop already has in hand. Anything missing
+      // is left empty in the brief — the user can edit the brief later.
+      const extractSkillsFromToolsMd = (md: string | undefined): string[] => {
+        if (!md) return []
+        const skillsMatch = md.match(/##\s+Skills\s*\n([\s\S]*?)(?=\n##\s|$)/i)
+        const body = skillsMatch?.[1] ?? ''
+        return body
+          .split('\n')
+          .map((l) => l.trim())
+          .filter((l) => l.startsWith('- '))
+          .map((l) => l.slice(2).trim())
+          .filter(Boolean)
+      }
+      const briefMembers: TeamBriefMember[] = resolved.map((a) => ({
+        name: dedupPlan.agentNameMap.get(a.name) ?? a.name,
+        role: a.role,
+        tools: extractSkillsFromToolsMd(a.toolsTemplate),
+      }))
+      const internalLeadKeyword = genuineLeaderCatalogAgent
+        ? matchedLeadershipKeyword({
+            name: genuineLeaderCatalogAgent.name,
+            role: genuineLeaderCatalogAgent.role,
+          })
+        : null
+      const briefMarkdown = buildTeamBrief({
+        team: {
+          name: finalTeamName,
+          icon: teamIcon,
+          templateId: selectedProfile.id ?? null,
+          description: selectedProfile.description ?? '',
+        },
+        members: briefMembers,
+        internalLead:
+          genuineLeaderFinalName && internalLeadKeyword
+            ? { agentName: genuineLeaderFinalName, matchedKeyword: internalLeadKeyword }
+            : null,
+      })
+      try {
+        await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(team.id)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: briefMarkdown }),
+        })
+      } catch {
+        // brief generation is non-fatal — the brief is editable in the UI
       }
 
       setProgress({

--- a/apps/web/src/lib/__tests__/booZeroBrief.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroBrief.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildTeamBrief,
+  buildGlobalBrief,
+  type TeamBriefMember,
+  type GlobalBriefTeam,
+} from '../booZeroBrief'
+
+describe('buildTeamBrief', () => {
+  const baseTeam = {
+    name: 'Dev Team',
+    icon: '👾',
+    templateId: 'dev',
+    description: 'Code review, bug hunting, documentation.',
+  }
+  const members: TeamBriefMember[] = [
+    {
+      name: 'Code Reviewer Boo',
+      role: 'Code Reviewer',
+      strengths: 'Spots logic errors and security issues.',
+      tools: ['github', 'code-search'],
+    },
+    {
+      name: 'Bug Fixer Boo',
+      role: 'Bug Fixer',
+      strengths: 'Root-cause analysis and targeted fixes.',
+      tools: ['github', 'code-search', 'test-runner'],
+    },
+    {
+      name: 'Doc Writer Boo',
+      role: 'Doc Writer',
+      strengths: 'Clear technical writing.',
+      tools: ['github', 'computer'],
+    },
+  ]
+
+  it('renders header, identity, members, internal lead, routing, tools, anti-patterns, notes', () => {
+    const out = buildTeamBrief({ team: baseTeam, members })
+    expect(out).toContain('# Team: Dev Team 👾')
+    expect(out).toContain('## Identity\nCode review, bug hunting, documentation.')
+    expect(out).toContain('## Members')
+    expect(out).toContain('| Code Reviewer Boo | Code Reviewer |')
+    expect(out).toContain('## Internal Lead')
+    expect(out).toContain('Boo Zero leads the team directly.')
+    expect(out).toContain('## Routing patterns')
+    expect(out).toContain('## Aggregated tools')
+    expect(out).toContain('## Anti-patterns')
+    expect(out).toContain('## Notes')
+  })
+
+  it('falls back to templateId line when description is empty', () => {
+    const out = buildTeamBrief({
+      team: { ...baseTeam, description: '' },
+      members,
+    })
+    expect(out).toContain('Deployed from template `dev`.')
+  })
+
+  it('says "no description recorded" when both description and templateId are absent', () => {
+    const out = buildTeamBrief({
+      team: { name: 'Empty', icon: '🎈', templateId: null, description: null },
+      members,
+    })
+    expect(out).toContain('No description recorded.')
+  })
+
+  it('handles internal lead — surfaces matched keyword', () => {
+    const out = buildTeamBrief({
+      team: baseTeam,
+      members,
+      internalLead: { agentName: 'Code Reviewer Boo', matchedKeyword: 'Tech Lead' },
+    })
+    expect(out).toContain(
+      '**Code Reviewer Boo** — detected via the leadership keyword "Tech Lead".',
+    )
+    // Routing patterns should reference the lead
+    expect(out).toContain('**Code Reviewer Boo** (internal lead) coordinates intake')
+  })
+
+  it('renders "no members" placeholder when team is empty', () => {
+    const out = buildTeamBrief({ team: baseTeam, members: [] })
+    expect(out).toContain('_No members yet. Boo Zero will respond solo')
+    expect(out).toContain('_No tools recorded yet._')
+  })
+
+  it('escapes pipe characters in member strengths', () => {
+    const out = buildTeamBrief({
+      team: baseTeam,
+      members: [
+        {
+          name: 'Markdown Boo',
+          role: 'Tester',
+          strengths: 'Handles pipes | in strings | gracefully',
+          tools: [],
+        },
+      ],
+    })
+    expect(out).toContain('| Markdown Boo | Tester | Handles pipes \\| in strings \\| gracefully |')
+  })
+
+  it('deduplicates and sorts aggregated tools', () => {
+    const out = buildTeamBrief({ team: baseTeam, members })
+    // github appears in all three, code-search in two, test-runner once, computer once
+    const toolsSection = out.split('## Aggregated tools')[1]!.split('## Anti-patterns')[0]!
+    expect(toolsSection).toContain('- code-search')
+    expect(toolsSection).toContain('- computer')
+    expect(toolsSection).toContain('- github')
+    expect(toolsSection).toContain('- test-runner')
+    // Sorted alphabetically
+    const codeIdx = toolsSection.indexOf('- code-search')
+    const githubIdx = toolsSection.indexOf('- github')
+    expect(codeIdx).toBeLessThan(githubIdx)
+  })
+
+  it('uses default anti-patterns when none provided', () => {
+    const out = buildTeamBrief({ team: baseTeam, members })
+    expect(out).toContain("Don't ask the team to simulate sub-agents")
+    expect(out).toContain("Don't `ls` or `cat`")
+  })
+
+  it('uses custom anti-patterns when provided', () => {
+    const out = buildTeamBrief({
+      team: baseTeam,
+      members,
+      antiPatterns: ['Custom guardrail 1.', 'Custom guardrail 2.'],
+    })
+    expect(out).toContain('- Custom guardrail 1.')
+    expect(out).toContain('- Custom guardrail 2.')
+    expect(out).not.toContain("Don't ask the team to simulate sub-agents")
+  })
+
+  it('uses custom routing summary when provided', () => {
+    const out = buildTeamBrief({
+      team: baseTeam,
+      members,
+      routingSummary: '- Custom routing line.',
+    })
+    expect(out).toContain('## Routing patterns\n- Custom routing line.')
+  })
+
+  it('produces deterministic output for snapshot stability', () => {
+    const out1 = buildTeamBrief({ team: baseTeam, members })
+    const out2 = buildTeamBrief({ team: baseTeam, members })
+    expect(out1).toBe(out2)
+  })
+})
+
+describe('buildGlobalBrief', () => {
+  const teams: GlobalBriefTeam[] = [
+    { name: 'Dev Team', icon: '👾', description: 'Code review and bug hunting.' },
+    { name: 'Marketing Boos', icon: '📣', description: 'Content + campaigns.' },
+  ]
+
+  it('renders role, responsibilities, teams index, delegation protocol, mention syntax, pitfalls, notes', () => {
+    const out = buildGlobalBrief({ teams })
+    expect(out).toContain('# Boo Zero — Universal Team Leader')
+    expect(out).toContain('## Role')
+    expect(out).toContain('I am the universal leader')
+    expect(out).toContain('## Responsibilities')
+    expect(out).toContain('## Available teams')
+    expect(out).toContain('- **Dev Team** 👾: Code review and bug hunting.')
+    expect(out).toContain('- **Marketing Boos** 📣: Content + campaigns.')
+    expect(out).toContain('## Delegation protocol')
+    expect(out).toContain('<delegate to="@Teammate Name">')
+    expect(out).toContain('## @-mention syntax in my individual chat')
+    expect(out).toContain('`@TeamName`')
+    expect(out).toContain('## Common pitfalls')
+    expect(out).toContain('## Notes')
+  })
+
+  it('renders "no teams deployed" placeholder when empty', () => {
+    const out = buildGlobalBrief({ teams: [] })
+    expect(out).toContain('_No teams deployed yet.')
+  })
+
+  it('uses "No description." when team description is missing', () => {
+    const out = buildGlobalBrief({
+      teams: [{ name: 'Mystery', icon: '🎃' }],
+    })
+    expect(out).toContain('- **Mystery** 🎃: No description.')
+  })
+
+  it('collapses newlines in team descriptions to single spaces', () => {
+    const out = buildGlobalBrief({
+      teams: [{ name: 'Multi', icon: '🌀', description: 'Line one.\n\nLine two.' }],
+    })
+    expect(out).toContain('- **Multi** 🌀: Line one. Line two.')
+  })
+
+  it('produces deterministic output', () => {
+    const a = buildGlobalBrief({ teams })
+    const b = buildGlobalBrief({ teams })
+    expect(a).toBe(b)
+  })
+})

--- a/apps/web/src/lib/__tests__/booZeroBrief.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroBrief.test.ts
@@ -155,8 +155,13 @@ describe('buildGlobalBrief', () => {
     const out = buildGlobalBrief({ teams })
     expect(out).toContain('# Boo Zero — Universal Team Leader')
     expect(out).toContain('## Role')
-    expect(out).toContain('I am the universal leader')
-    expect(out).toContain('## Responsibilities')
+    // Phase C: prompt is now written in second-person ("You are…") and uses
+    // imperative DO / DO NOT lists instead of first-person responsibilities.
+    expect(out).toContain('You are the universal leader')
+    expect(out).toContain('## Required behavior')
+    expect(out).toContain('**DO**')
+    expect(out).toContain('**DO NOT**')
+    expect(out).toContain('## Verification protocol')
     expect(out).toContain('## Available teams')
     expect(out).toContain('- **Dev Team** 👾: Code review and bug hunting.')
     expect(out).toContain('- **Marketing Boos** 📣: Content + campaigns.')

--- a/apps/web/src/lib/__tests__/genuineLeader.test.ts
+++ b/apps/web/src/lib/__tests__/genuineLeader.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectGenuineLeader,
+  matchedLeadershipKeyword,
+  LEADERSHIP_KEYWORDS,
+} from '../genuineLeader'
+
+describe('detectGenuineLeader', () => {
+  describe('positive matches — name field', () => {
+    it.each([
+      ['CEO Boo', ''],
+      ['CTO Boo', ''],
+      ['CFO Boo', ''],
+      ['COO Boo', ''],
+      ['CMO Boo', ''],
+      ['CIO Boo', ''],
+      ['Chief Strategist Boo', ''],
+      ['Founder Boo', ''],
+      ['VP Engineering Boo', ''],
+      ['President Boo', ''],
+      ['Principal Boo', ''],
+      ['Director Boo', ''],
+      ['Head of Product Boo', ''],
+      ['Team Lead Boo', ''],
+      ['Tech Lead Boo', ''],
+      ['Project Lead Boo', ''],
+      ['Product Lead Boo', ''],
+      ['Engineering Lead Boo', ''],
+      ['Project Manager Boo', ''],
+      ['Product Manager Boo', ''],
+      ['Engineering Manager Boo', ''],
+      ['Program Manager Boo', ''],
+      ['General Manager Boo', ''],
+      ['Operator Boo', ''],
+      ['Orchestrator Boo', ''],
+      ['Coordinator Boo', ''],
+      ['Conductor Boo', ''],
+    ])('detects %s', (name, role) => {
+      expect(detectGenuineLeader({ name, role })).toBe(true)
+    })
+  })
+
+  describe('positive matches — role field', () => {
+    it.each([
+      ['Generic Boo', 'CEO'],
+      ['Sprint Boo', 'Project Manager'],
+      ['Workflow Boo', 'Operator'],
+      ['Anything Boo', 'Tech Lead'],
+      ['Pip', 'Director of Engineering'],
+    ])('detects role for %s / role=%s', (name, role) => {
+      expect(detectGenuineLeader({ name, role })).toBe(true)
+    })
+  })
+
+  describe('negative matches', () => {
+    it.each([
+      ['Senior Engineer Boo', 'Engineer'],
+      ['Lead Engineer Boo', 'Engineer'],
+      ['Lead Developer Boo', 'Developer'],
+      ['Lead Designer Boo', 'Designer'],
+      ['Lead Researcher Boo', 'Researcher'],
+      ['Lead Reviewer Boo', 'Reviewer'],
+      ['Staff Engineer Boo', ''],
+      ['Principal Engineer Boo', 'Software'],
+      ['Principal Developer Boo', ''],
+      ['Code Reviewer Boo', 'Code Reviewer'],
+      ['Bug Fixer Boo', 'Bug Fixer'],
+      ['Doc Writer Boo', 'Doc Writer'],
+      ['Marketing Boo', 'Marketer'],
+      ['Research Boo', 'Researcher'],
+      ['', ''],
+    ])('rejects %s / role=%s', (name, role) => {
+      expect(detectGenuineLeader({ name, role })).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('matches case-insensitively', () => {
+      expect(detectGenuineLeader({ name: 'cto boo', role: '' })).toBe(true)
+      expect(detectGenuineLeader({ name: 'CTO BOO', role: '' })).toBe(true)
+    })
+
+    it('handles hyphenated multi-word keywords', () => {
+      expect(detectGenuineLeader({ name: 'Project-Manager Boo', role: '' })).toBe(true)
+      expect(detectGenuineLeader({ name: 'Team-Lead Boo', role: '' })).toBe(true)
+    })
+
+    it('does not match keywords inside other words', () => {
+      // "Chief" alone is allowed, but "MisChief" should not match Chief.
+      expect(detectGenuineLeader({ name: 'Mischief Boo', role: '' })).toBe(false)
+      // "CTOgrapher" should not match CTO.
+      expect(detectGenuineLeader({ name: 'CTOgrapher Boo', role: '' })).toBe(false)
+    })
+
+    it('returns true when ANY field matches', () => {
+      expect(detectGenuineLeader({ name: 'Generic Boo', role: 'CTO' })).toBe(true)
+      expect(detectGenuineLeader({ name: 'CTO Boo', role: 'Engineer' })).toBe(true)
+    })
+
+    it('returns false when BOTH fields are leadership-y but negated', () => {
+      // "Senior Engineer" + "Staff Engineer" both negated.
+      expect(detectGenuineLeader({ name: 'Senior Engineer', role: 'Staff Engineer' })).toBe(false)
+    })
+  })
+})
+
+describe('matchedLeadershipKeyword', () => {
+  it('returns the canonical keyword that matched', () => {
+    expect(matchedLeadershipKeyword({ name: 'CTO Boo', role: '' })).toBe('CTO')
+    expect(matchedLeadershipKeyword({ name: 'Project Manager Boo', role: '' })).toBe(
+      'Project Manager',
+    )
+    expect(matchedLeadershipKeyword({ name: 'Operator Boo', role: '' })).toBe('Operator')
+  })
+
+  it('returns null on no match', () => {
+    expect(matchedLeadershipKeyword({ name: 'Code Reviewer', role: '' })).toBeNull()
+  })
+
+  it('returns null on negative match', () => {
+    expect(matchedLeadershipKeyword({ name: 'Lead Engineer Boo', role: '' })).toBeNull()
+    expect(matchedLeadershipKeyword({ name: 'Senior Engineer Boo', role: '' })).toBeNull()
+  })
+
+  it('canonicalises hyphenated input back to the keyword', () => {
+    expect(matchedLeadershipKeyword({ name: 'Project-Manager Boo', role: '' })).toBe(
+      'Project Manager',
+    )
+  })
+})
+
+describe('LEADERSHIP_KEYWORDS', () => {
+  it('is non-empty and contains expected canonical entries', () => {
+    expect(LEADERSHIP_KEYWORDS.length).toBeGreaterThan(20)
+    expect(LEADERSHIP_KEYWORDS).toContain('CEO')
+    expect(LEADERSHIP_KEYWORDS).toContain('Operator')
+    expect(LEADERSHIP_KEYWORDS).toContain('Team Lead')
+  })
+})

--- a/apps/web/src/lib/__tests__/parseTeamOrAgentMention.test.ts
+++ b/apps/web/src/lib/__tests__/parseTeamOrAgentMention.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { parseTeamOrAgentMention } from '../parseTeamOrAgentMention'
+
+const teams = [
+  { id: 't1', name: 'Marketing' },
+  { id: 't2', name: 'Dev Team' },
+  { id: 't3', name: 'SEO Team' },
+]
+
+const agents = [
+  { id: 'a1', name: 'Code Reviewer Boo' },
+  { id: 'a2', name: 'SEO' },
+  { id: 'a3', name: 'Boo Zero' },
+]
+
+describe('parseTeamOrAgentMention', () => {
+  it("returns 'none' when message has no @", () => {
+    const r = parseTeamOrAgentMention('hello world', teams, agents)
+    expect(r.kind).toBe('none')
+    expect(r.cleanedMessage).toBe('hello world')
+  })
+
+  it('matches a team and strips the mention', () => {
+    const r = parseTeamOrAgentMention('@Marketing please launch a campaign', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.targetId).toBe('t1')
+    expect(r.matchedName).toBe('Marketing')
+    expect(r.cleanedMessage).toBe('please launch a campaign')
+  })
+
+  it('matches an agent when no team matches', () => {
+    const r = parseTeamOrAgentMention('@Code Reviewer Boo please review', teams, agents)
+    expect(r.kind).toBe('agent')
+    expect(r.targetId).toBe('a1')
+  })
+
+  it('teams win on a tie (same name)', () => {
+    const r = parseTeamOrAgentMention(
+      '@SEO check rankings',
+      [{ id: 'team-seo', name: 'SEO' }],
+      [{ id: 'a2', name: 'SEO' }],
+    )
+    expect(r.kind).toBe('team')
+    expect(r.targetId).toBe('team-seo')
+  })
+
+  it('matches multi-word team names', () => {
+    const r = parseTeamOrAgentMention('@Dev Team write tests', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.targetId).toBe('t2')
+    expect(r.cleanedMessage).toBe('write tests')
+  })
+
+  it('longest-prefix match — "@SEO Team" beats "@SEO"', () => {
+    const r = parseTeamOrAgentMention('@SEO Team check rankings', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.targetId).toBe('t3')
+  })
+
+  it('handles comma terminator', () => {
+    const r = parseTeamOrAgentMention('@Marketing, please do X', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.cleanedMessage).toBe('please do X')
+  })
+
+  it('handles colon terminator', () => {
+    const r = parseTeamOrAgentMention('@Marketing: do X', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.cleanedMessage).toBe('do X')
+  })
+
+  it('handles message that is JUST the mention', () => {
+    const r = parseTeamOrAgentMention('@Marketing', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.cleanedMessage).toBe('')
+  })
+
+  it('is case-insensitive on the name', () => {
+    const r = parseTeamOrAgentMention('@marketing brief', teams, agents)
+    expect(r.kind).toBe('team')
+    expect(r.matchedName).toBe('Marketing')
+  })
+
+  it("doesn't match a mention embedded in a longer word", () => {
+    // "@MarketingTeamA" should not match "Marketing" (no terminator after).
+    const r = parseTeamOrAgentMention('@MarketingTeamA brief', teams, agents)
+    expect(r.kind).toBe('none')
+  })
+
+  it("returns 'none' when only agents provided + no agent matches", () => {
+    const r = parseTeamOrAgentMention('@Nothing here', [], agents)
+    expect(r.kind).toBe('none')
+  })
+
+  it('works with only teams (no agents arg)', () => {
+    const r = parseTeamOrAgentMention('@Marketing brief', teams)
+    expect(r.kind).toBe('team')
+    expect(r.targetId).toBe('t1')
+  })
+
+  it('works with only agents', () => {
+    const r = parseTeamOrAgentMention('@Boo Zero hello', [], agents)
+    expect(r.kind).toBe('agent')
+    expect(r.targetId).toBe('a3')
+  })
+})

--- a/apps/web/src/lib/__tests__/resolveTeamLeader.test.ts
+++ b/apps/web/src/lib/__tests__/resolveTeamLeader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { resolveTeamLeader } from '../resolveTeamLeader'
+import { resolveTeamLeader, resolveTeamInternalLead } from '../resolveTeamLeader'
 import type { AgentState } from '@/stores/fleet'
 
 function makeAgent(overrides: Partial<AgentState> = {}): AgentState {
@@ -19,29 +19,85 @@ function makeAgent(overrides: Partial<AgentState> = {}): AgentState {
   }
 }
 
-describe('resolveTeamLeader', () => {
-  it('returns explicit leaderAgentId when agent exists in team', () => {
-    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
-    expect(resolveTeamLeader('t1', 'a2', agents)).toBe('a2')
+describe('resolveTeamLeader (Boo Zero universal leader)', () => {
+  it('returns Boo Zero when present in the fleet, regardless of team-internal lead', () => {
+    const agents = [
+      makeAgent({ id: 'a1', teamId: 't1' }),
+      makeAgent({ id: 'a2', teamId: 't1' }),
+      makeAgent({ id: 'booZero', teamId: null }),
+    ]
+    expect(resolveTeamLeader('t1', 'a1', agents, 'booZero')).toBe('booZero')
+    // Even if the team has no internal lead set:
+    expect(resolveTeamLeader('t1', null, agents, 'booZero')).toBe('booZero')
   })
 
-  it('falls back to first team agent when leaderAgentId is null', () => {
-    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
-    expect(resolveTeamLeader('t1', null, agents)).toBe('a1')
+  it('Boo Zero precedence works even when Boo Zero is teamless', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'bz', teamId: null })]
+    expect(resolveTeamLeader('t1', null, agents, 'bz')).toBe('bz')
   })
 
-  it('falls back to first team agent when leader agent not in the team', () => {
+  it('falls back to team-internal lead when Boo Zero is missing', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
+    expect(resolveTeamLeader('t1', 'a2', agents, null)).toBe('a2')
+  })
+
+  it("falls back to team-internal lead when Boo Zero id doesn't exist in the fleet", () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
+    expect(resolveTeamLeader('t1', 'a2', agents, 'ghost-bz')).toBe('a2')
+  })
+
+  it('falls back to first team agent when no Boo Zero and no internal lead', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
+    expect(resolveTeamLeader('t1', null, agents, null)).toBe('a1')
+  })
+
+  it('falls back to first team agent when internal lead exists but is not on the team', () => {
     const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't2' })]
-    expect(resolveTeamLeader('t1', 'a2', agents)).toBe('a1')
+    expect(resolveTeamLeader('t1', 'a2', agents, null)).toBe('a1')
+  })
+
+  it('returns null when team has no agents and no Boo Zero', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't2' })]
+    expect(resolveTeamLeader('t1', null, agents, null)).toBeNull()
+  })
+
+  it('returns Boo Zero even when team has no agents', () => {
+    // Boo Zero is the universal leader — a team with zero members still has
+    // Boo Zero as its leader. The chat will respond with just Boo Zero.
+    const agents = [makeAgent({ id: 'bz', teamId: null })]
+    expect(resolveTeamLeader('t1', null, agents, 'bz')).toBe('bz')
+  })
+
+  it('ignores agents from a different team in the internal-lead fallback', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't2' }), makeAgent({ id: 'a2', teamId: 't1' })]
+    expect(resolveTeamLeader('t1', null, agents, null)).toBe('a2')
+  })
+})
+
+describe('resolveTeamInternalLead', () => {
+  it('returns the internal lead when it is on the team', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't1' })]
+    expect(resolveTeamInternalLead('t1', 'a2', agents)).toBe('a2')
+  })
+
+  it('returns null when no internal lead is set', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' })]
+    expect(resolveTeamInternalLead('t1', null, agents)).toBeNull()
+  })
+
+  it('returns null when the internal lead is no longer on the team', () => {
+    const agents = [makeAgent({ id: 'a1', teamId: 't1' }), makeAgent({ id: 'a2', teamId: 't2' })]
+    expect(resolveTeamInternalLead('t1', 'a2', agents)).toBeNull()
   })
 
   it('returns null when team has no agents', () => {
-    const agents = [makeAgent({ id: 'a1', teamId: 't2' })]
-    expect(resolveTeamLeader('t1', null, agents)).toBeNull()
+    expect(resolveTeamInternalLead('t1', 'a1', [])).toBeNull()
   })
 
-  it('ignores agents from a different team', () => {
-    const agents = [makeAgent({ id: 'a1', teamId: 't2' }), makeAgent({ id: 'a2', teamId: 't1' })]
-    expect(resolveTeamLeader('t1', null, agents)).toBe('a2')
+  it('never returns Boo Zero — it only looks at internal team membership', () => {
+    // Even if Boo Zero is also somehow set as the internal lead AND in the
+    // fleet teamless, this function does not promote it (different concern).
+    const agents = [makeAgent({ id: 'bz', teamId: null }), makeAgent({ id: 'a1', teamId: 't1' })]
+    expect(resolveTeamInternalLead('t1', 'bz', agents)).toBeNull()
   })
 })

--- a/apps/web/src/lib/__tests__/sessionUtils.test.ts
+++ b/apps/web/src/lib/__tests__/sessionUtils.test.ts
@@ -4,7 +4,10 @@ import {
   buildTeamSessionKey,
   setTeamChatOverride,
   clearTeamChatOverride,
+  getTeamChatOverride,
   hasTeamChatOverride,
+  promoteOverrideToRun,
+  clearAllTeamChatOverridesForAgent,
   resetTeamChatOverrides,
 } from '../sessionUtils'
 
@@ -56,22 +59,198 @@ describe('hasTeamChatOverride', () => {
     expect(hasTeamChatOverride('a1')).toBe(false)
   })
 
-  it('returns true when override is set', () => {
+  it('returns true when pending override is set', () => {
     setTeamChatOverride('a1', 'agent:a1:team:team-1')
     expect(hasTeamChatOverride('a1')).toBe(true)
   })
 
-  it('returns false after override is cleared', () => {
+  it('returns true when run-scoped override is set (after promotion)', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:team-1')
+    promoteOverrideToRun('a1', 'run-1')
+    expect(hasTeamChatOverride('a1')).toBe(true)
+  })
+
+  it('returns false after pending override is cleared with no runId', () => {
     setTeamChatOverride('a1', 'agent:a1:team:team-1')
     clearTeamChatOverride('a1')
+    expect(hasTeamChatOverride('a1')).toBe(false)
+  })
+
+  it('returns false after run-scoped override is cleared', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:team-1')
+    promoteOverrideToRun('a1', 'run-1')
+    clearTeamChatOverride('a1', 'run-1')
     expect(hasTeamChatOverride('a1')).toBe(false)
   })
 
   it('returns false after resetTeamChatOverrides', () => {
     setTeamChatOverride('a1', 'agent:a1:team:team-1')
     setTeamChatOverride('a2', 'agent:a2:team:team-1')
+    promoteOverrideToRun('a2', 'run-x')
     resetTeamChatOverrides()
     expect(hasTeamChatOverride('a1')).toBe(false)
     expect(hasTeamChatOverride('a2')).toBe(false)
+  })
+})
+
+describe('getTeamChatOverride', () => {
+  beforeEach(() => {
+    resetTeamChatOverrides()
+  })
+
+  it('returns undefined when nothing is set', () => {
+    expect(getTeamChatOverride('a1')).toBeUndefined()
+    expect(getTeamChatOverride('a1', 'run-1')).toBeUndefined()
+  })
+
+  it('returns pending override when no runId is provided', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    expect(getTeamChatOverride('a1')).toBe('agent:a1:team:t1')
+  })
+
+  it('returns pending override even when runId is provided (no scoped entry yet)', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    // No promotion yet — fall through to pending
+    expect(getTeamChatOverride('a1', 'run-1')).toBe('agent:a1:team:t1')
+  })
+
+  it('returns run-scoped override when runId matches after promotion', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    promoteOverrideToRun('a1', 'run-1')
+    expect(getTeamChatOverride('a1', 'run-1')).toBe('agent:a1:team:t1')
+  })
+
+  it('returns the most recent pending for a different runId after first promotion', () => {
+    // Team A sends: set pending → promote to run-A
+    setTeamChatOverride('a1', 'agent:a1:team:A')
+    promoteOverrideToRun('a1', 'run-A')
+
+    // Team B sends: set pending again (different sessionKey, no runId yet)
+    setTeamChatOverride('a1', 'agent:a1:team:B')
+
+    // Events for run-A still resolve to team A (run-scoped wins)
+    expect(getTeamChatOverride('a1', 'run-A')).toBe('agent:a1:team:A')
+
+    // Events for run-B (not yet promoted) fall back to pending → team B
+    expect(getTeamChatOverride('a1', 'run-B')).toBe('agent:a1:team:B')
+
+    // Pending lookup (no runId) → team B (most recent set)
+    expect(getTeamChatOverride('a1')).toBe('agent:a1:team:B')
+  })
+})
+
+describe('promoteOverrideToRun', () => {
+  beforeEach(() => {
+    resetTeamChatOverrides()
+  })
+
+  it('moves pending → run-scoped', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    const promoted = promoteOverrideToRun('a1', 'run-1')
+    expect(promoted).toBe('agent:a1:team:t1')
+    // Pending is consumed after promotion
+    expect(getTeamChatOverride('a1')).toBeUndefined()
+    // Run-scoped is in place
+    expect(getTeamChatOverride('a1', 'run-1')).toBe('agent:a1:team:t1')
+  })
+
+  it('is a no-op when the same run is promoted again', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    expect(promoteOverrideToRun('a1', 'run-1')).toBe('agent:a1:team:t1')
+    // Second call: pending is gone, but run-scoped persists → returns the scoped value.
+    expect(promoteOverrideToRun('a1', 'run-1')).toBe('agent:a1:team:t1')
+  })
+
+  it('returns undefined when no pending exists', () => {
+    expect(promoteOverrideToRun('a1', 'run-1')).toBeUndefined()
+  })
+
+  it('returns undefined when runId is empty', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    expect(promoteOverrideToRun('a1', '')).toBeUndefined()
+  })
+
+  it('supports two distinct runs for the same agent (concurrency)', () => {
+    // Team A: send + promote
+    setTeamChatOverride('a1', 'agent:a1:team:A')
+    promoteOverrideToRun('a1', 'run-A')
+
+    // Team B: send + promote
+    setTeamChatOverride('a1', 'agent:a1:team:B')
+    promoteOverrideToRun('a1', 'run-B')
+
+    expect(getTeamChatOverride('a1', 'run-A')).toBe('agent:a1:team:A')
+    expect(getTeamChatOverride('a1', 'run-B')).toBe('agent:a1:team:B')
+    expect(hasTeamChatOverride('a1')).toBe(true)
+
+    // Run A finishes; run B should still be routed correctly.
+    clearTeamChatOverride('a1', 'run-A')
+    expect(getTeamChatOverride('a1', 'run-A')).toBeUndefined()
+    expect(getTeamChatOverride('a1', 'run-B')).toBe('agent:a1:team:B')
+    expect(hasTeamChatOverride('a1')).toBe(true)
+  })
+})
+
+describe('clearAllTeamChatOverridesForAgent', () => {
+  beforeEach(() => {
+    resetTeamChatOverrides()
+  })
+
+  it('removes pending + every run-scoped entry for the agent', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:t1')
+    promoteOverrideToRun('a1', 'r1')
+    setTeamChatOverride('a1', 'agent:a1:team:t2')
+    promoteOverrideToRun('a1', 'r2')
+    // Add a pending again
+    setTeamChatOverride('a1', 'agent:a1:team:t3')
+
+    clearAllTeamChatOverridesForAgent('a1')
+
+    expect(hasTeamChatOverride('a1')).toBe(false)
+    expect(getTeamChatOverride('a1', 'r1')).toBeUndefined()
+    expect(getTeamChatOverride('a1', 'r2')).toBeUndefined()
+  })
+
+  it('leaves other agents untouched', () => {
+    setTeamChatOverride('a1', 'agent:a1:team:A')
+    setTeamChatOverride('a2', 'agent:a2:team:B')
+    clearAllTeamChatOverridesForAgent('a1')
+    expect(hasTeamChatOverride('a1')).toBe(false)
+    expect(hasTeamChatOverride('a2')).toBe(true)
+  })
+})
+
+describe('concurrency scenario — Boo Zero in two teams', () => {
+  beforeEach(() => {
+    resetTeamChatOverrides()
+  })
+
+  it("routes events to the correct team's session even when overrides overlap", () => {
+    const booZero = 'boo-zero'
+    const teamA_sk = buildTeamSessionKey(booZero, 'team-A')
+    const teamB_sk = buildTeamSessionKey(booZero, 'team-B')
+
+    // Step 1: user sends to team A
+    setTeamChatOverride(booZero, teamA_sk)
+    // Step 2: first event arrives for run-A; promote
+    promoteOverrideToRun(booZero, 'run-A')
+
+    // Step 3: user switches to team B and sends (Boo Zero still mid-response on A)
+    setTeamChatOverride(booZero, teamB_sk)
+    // Tail event for run-A arrives now — should STILL route to team A (run-scoped)
+    expect(getTeamChatOverride(booZero, 'run-A')).toBe(teamA_sk)
+
+    // Step 4: first event for run-B arrives; promote
+    promoteOverrideToRun(booZero, 'run-B')
+    expect(getTeamChatOverride(booZero, 'run-B')).toBe(teamB_sk)
+
+    // Step 5: run-A finishes; team A override gone, team B still active
+    clearTeamChatOverride(booZero, 'run-A')
+    expect(getTeamChatOverride(booZero, 'run-A')).toBeUndefined()
+    expect(getTeamChatOverride(booZero, 'run-B')).toBe(teamB_sk)
+
+    // Step 6: run-B finishes; all gone.
+    clearTeamChatOverride(booZero, 'run-B')
+    expect(hasTeamChatOverride(booZero)).toBe(false)
   })
 })

--- a/apps/web/src/lib/booZeroBrief.ts
+++ b/apps/web/src/lib/booZeroBrief.ts
@@ -178,19 +178,70 @@ export function buildGlobalBrief(params: BuildGlobalBriefParams): string {
   return `# Boo Zero — Universal Team Leader
 
 ## Role
-I am the universal leader across all teams on this Clawboo instance. I do not belong to any team. I sit above team-internal leads when present and coordinate cross-team work for the user.
+You are the universal leader across all teams on this Clawboo instance. You do
+not belong to any team. You sit above team-internal leads (CTO, Team Lead,
+etc.) when present and coordinate cross-team work for the user.
 
-## Responsibilities
-1. Receive user messages in any team's group chat or my individual chat.
-2. Decompose tasks into delegations using \`<delegate to="@AgentName">\` inside team chats.
-3. Surface progress, blockers, and synthesis back to the user.
-4. Maintain per-team context from the team briefs.
+## Required behavior
+
+**DO**
+- **Delegate first.** Every non-trivial user request gets one or more
+  \`<delegate>\` blocks aimed at the appropriate teammates. A short prose
+  acknowledgement to the user is fine; substantive work is delegated.
+- **Use your own tools to verify.** You have bash, curl, web-search, file
+  read/write, etc. (whatever your TOOLS.md grants). Before claiming any
+  external state — a URL is live, a server is running, a package was
+  installed, a file exists — verify it with the appropriate tool. Quote the
+  evidence inline ("verified — \`curl -sI http://localhost:5180\` returned
+  200 OK").
+- **Read the team transcript before making claims about teammate work.** A
+  teammate's progress is whatever they explicitly wrote in this conversation.
+  Use \`[Team Update]\` messages, not assumption.
+- **Synthesize across teammates.** Combine \`[Team Update]\` messages into a
+  single coherent response for the user.
+
+**DO NOT**
+- **Do substantive teammate work yourself when a teammate exists who could do
+  it.** "I'll handle it directly" is the wrong default. Even if no one has
+  responded yet, delegate — don't shadow-do the work.
+- **Claim a teammate has built / shipped / deployed anything without their
+  explicit message in this conversation confirming it.** "We built the
+  frontend" is only true when the responsible teammate said so.
+- **Claim any URL, port, file, or service is running without verification.**
+  Run \`curl -sI <url>\` (or equivalent) and only assert success on a real
+  2xx response. If you cannot reach a tool, say "I can't verify — let me
+  ask the responsible teammate" and delegate.
+- **Try to spawn sub-agents, worker agents, or any OpenClaw built-in
+  meta-agent construct.** \`<delegate>\` is the ONLY routing mechanism on
+  Clawboo. If you would normally try the OpenClaw sub-agent path and it
+  appears unavailable, that is by design — use \`<delegate>\` instead.
+
+## Verification protocol
+
+Before you claim any external state, verify it with the right tool:
+
+| You want to claim… | Verify with… |
+|---|---|
+| A URL is reachable | \`curl -sI <url>\` — assert only on 2xx |
+| A file exists in YOUR workspace | \`ls -la <path>\` or \`cat <path>\` |
+| A package is installed | \`<tool> --version\` or a manifest read |
+| A teammate completed work | Find their message in this conversation |
+| An external API state | Use your api-tester / web-search tool |
+
+You cannot read a teammate's workspace files — OpenClaw isolates workspaces
+at the Gateway level — but you CAN read what they explicitly told you in the
+chat, AND you CAN reach localhost network endpoints (loopback isn't blocked).
+
+If verification is impossible or expensive, say "I don't know — let me
+delegate this to <Teammate>" and emit a \`<delegate>\` block. Honest
+uncertainty beats false certainty.
 
 ## Available teams
 ${renderAvailableTeams(teams)}
 
 ## Delegation protocol
-When a teammate should pick up a task, emit a structured delegation block in this exact format:
+When a teammate should pick up a task, emit a structured delegation block in
+this exact format:
 
 \`\`\`
 <delegate to="@Teammate Name">
@@ -201,20 +252,27 @@ teammate can act without coming back to ask questions.
 
 You can include multiple \`<delegate>\` blocks in a single response — one per
 teammate you're coordinating with. Bare \`@\`-mentions in prose are a best-
-effort fallback only.
+effort fallback only; the structured block is the source of truth.
 
 ## @-mention syntax in my individual chat
 - \`@TeamName\` → I pull that team's brief into context for this turn so I can
   reason about that specific team.
 - \`@AgentName\` → routes to that agent (works in team chats too).
 
-## Common pitfalls
-- Don't pretend to know what a team has done — read their group chat first.
-- Don't delegate without giving the recipient enough self-contained context.
-- Don't try to read a teammate's workspace files — their workspaces are isolated.
-- Don't re-respond to \`[Team Update]\` messages as if they were fresh user input.
+## Common pitfalls (production has hit all of these)
+- **Don't fabricate teammate progress.** If their message isn't in this chat,
+  you don't have evidence — verify or delegate.
+- **Don't claim a localhost URL is live without \`curl\`-ing it.** Tools exist
+  for this. Use them.
+- **Don't echo \`@<Teammate Name>\` casually in prose unless you mean to
+  delegate.** Only \`<delegate>\` blocks route work reliably.
+- **Don't re-respond to \`[Team Update]\` messages as if they were fresh user
+  input.** Treat them as progress reports — they're context, not new tasks.
+- **Don't introduce yourself or pretend you just arrived** — even after a
+  long silence, you're already mid-conversation. Continue the work.
 
 ## Notes
-_(User-editable. Use this section for any global instructions you want Boo Zero to always have in context.)_
+_(User-editable. Use this section for any global instructions you want Boo
+Zero to always have in context.)_
 `
 }

--- a/apps/web/src/lib/booZeroBrief.ts
+++ b/apps/web/src/lib/booZeroBrief.ts
@@ -1,0 +1,220 @@
+/**
+ * Boo Zero brief generators.
+ *
+ * Two pure functions:
+ *   - `buildTeamBrief`: per-team markdown brief (stored in SQLite,
+ *     surfaced as a virtual file in the UI, injected into Boo Zero's
+ *     context preamble when it operates on a team's session).
+ *   - `buildGlobalBrief`: Boo Zero's overall responsibilities + an
+ *     auto-generated index of the teams it leads.
+ *
+ * Pure. No DB / Gateway / store access. Tests assert markdown shape via
+ * snapshots so any future change is visible in a code review.
+ */
+
+// ─── Per-team brief ──────────────────────────────────────────────────────────
+
+export interface TeamBriefMember {
+  name: string
+  role: string
+  /** Short one-line strength / specialty (optional). */
+  strengths?: string
+  /** Skill / tool names this member owns (optional). */
+  tools?: string[]
+}
+
+export interface TeamBriefInternalLead {
+  agentName: string
+  /** The leadership keyword that triggered the detection. */
+  matchedKeyword: string
+}
+
+export interface BuildTeamBriefParams {
+  team: {
+    name: string
+    icon: string
+    templateId: string | null
+    description?: string | null
+  }
+  members: TeamBriefMember[]
+  internalLead?: TeamBriefInternalLead | null
+  /**
+   * Optional narrative override for the "Routing patterns" section.
+   * When omitted, a default narrative is generated from `members` and
+   * `internalLead`.
+   */
+  routingSummary?: string
+  /**
+   * Optional list of team-specific anti-patterns / guardrails. When
+   * omitted, the standard Clawboo guardrails are included.
+   */
+  antiPatterns?: string[]
+}
+
+const DEFAULT_ANTI_PATTERNS: readonly string[] = [
+  "Don't ask the team to simulate sub-agents — workspaces are isolated.",
+  "Don't `ls` or `cat` a teammate's directory — you don't have access.",
+  'Only delegate via `<delegate to="@AgentName">` blocks; bare @-mentions in prose are best-effort fallbacks.',
+]
+
+function renderMembersTable(members: readonly TeamBriefMember[]): string {
+  if (members.length === 0) {
+    return '_No members yet. Boo Zero will respond solo until the team is populated._'
+  }
+  const header = '| Name | Role | Strengths | Tools |\n|---|---|---|---|'
+  const rows = members.map((m) => {
+    const strengths = (m.strengths ?? '').replace(/\|/g, '\\|')
+    const tools = (m.tools ?? []).join(', ').replace(/\|/g, '\\|')
+    return `| ${m.name} | ${m.role} | ${strengths} | ${tools} |`
+  })
+  return [header, ...rows].join('\n')
+}
+
+function renderInternalLead(lead: TeamBriefInternalLead | null | undefined): string {
+  if (!lead) return 'No internal lead detected. Boo Zero leads the team directly.'
+  return `**${lead.agentName}** — detected via the leadership keyword "${lead.matchedKeyword}". Boo Zero coordinates through this teammate when strategic decisions or cross-member synthesis are required.`
+}
+
+function renderRoutingPatterns(
+  members: readonly TeamBriefMember[],
+  lead: TeamBriefInternalLead | null | undefined,
+  override?: string,
+): string {
+  if (override && override.trim().length > 0) return override.trim()
+
+  if (members.length === 0) return '- (Team has no members yet.)'
+
+  const lines: string[] = []
+  if (lead) {
+    lines.push(`- **${lead.agentName}** (internal lead) coordinates intake from Boo Zero.`)
+    for (const m of members) {
+      if (m.name === lead.agentName) continue
+      lines.push(`- **${m.name}** (${m.role}) reports through ${lead.agentName}.`)
+    }
+  } else {
+    lines.push('- Boo Zero delegates directly to each member based on the task.')
+    for (const m of members) {
+      lines.push(`- **${m.name}** owns: ${m.role}.`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function renderAggregatedTools(members: readonly TeamBriefMember[]): string {
+  const dedup = new Set<string>()
+  for (const m of members) {
+    for (const t of m.tools ?? []) dedup.add(t)
+  }
+  if (dedup.size === 0) return '_No tools recorded yet._'
+  return [...dedup]
+    .sort()
+    .map((t) => `- ${t}`)
+    .join('\n')
+}
+
+export function buildTeamBrief(params: BuildTeamBriefParams): string {
+  const { team, members, internalLead, routingSummary, antiPatterns } = params
+  const guardrails = antiPatterns ?? DEFAULT_ANTI_PATTERNS
+
+  const descriptionLine = team.description?.trim()
+    ? team.description.trim()
+    : team.templateId
+      ? `Deployed from template \`${team.templateId}\`.`
+      : 'No description recorded.'
+
+  return `# Team: ${team.name} ${team.icon}
+
+## Identity
+${descriptionLine}
+
+## Members
+${renderMembersTable(members)}
+
+## Internal Lead
+${renderInternalLead(internalLead ?? null)}
+
+## Routing patterns
+${renderRoutingPatterns(members, internalLead ?? null, routingSummary)}
+
+## Aggregated tools
+${renderAggregatedTools(members)}
+
+## Anti-patterns
+${guardrails.map((g) => `- ${g}`).join('\n')}
+
+## Notes
+_(User-editable. Boo Zero reads this section each time it enters this team.)_
+`
+}
+
+// ─── Global Boo Zero brief ───────────────────────────────────────────────────
+
+export interface GlobalBriefTeam {
+  name: string
+  icon: string
+  description?: string | null
+}
+
+export interface BuildGlobalBriefParams {
+  teams: readonly GlobalBriefTeam[]
+}
+
+function renderAvailableTeams(teams: readonly GlobalBriefTeam[]): string {
+  if (teams.length === 0) {
+    return '_No teams deployed yet. When you deploy a team, an entry will appear here automatically._'
+  }
+  return teams
+    .map((t) => {
+      const desc = t.description?.trim()
+        ? t.description.trim().replace(/\n+/g, ' ')
+        : 'No description.'
+      return `- **${t.name}** ${t.icon}: ${desc}`
+    })
+    .join('\n')
+}
+
+export function buildGlobalBrief(params: BuildGlobalBriefParams): string {
+  const { teams } = params
+  return `# Boo Zero — Universal Team Leader
+
+## Role
+I am the universal leader across all teams on this Clawboo instance. I do not belong to any team. I sit above team-internal leads when present and coordinate cross-team work for the user.
+
+## Responsibilities
+1. Receive user messages in any team's group chat or my individual chat.
+2. Decompose tasks into delegations using \`<delegate to="@AgentName">\` inside team chats.
+3. Surface progress, blockers, and synthesis back to the user.
+4. Maintain per-team context from the team briefs.
+
+## Available teams
+${renderAvailableTeams(teams)}
+
+## Delegation protocol
+When a teammate should pick up a task, emit a structured delegation block in this exact format:
+
+\`\`\`
+<delegate to="@Teammate Name">
+A specific, self-contained task description. Include enough context that the
+teammate can act without coming back to ask questions.
+</delegate>
+\`\`\`
+
+You can include multiple \`<delegate>\` blocks in a single response — one per
+teammate you're coordinating with. Bare \`@\`-mentions in prose are a best-
+effort fallback only.
+
+## @-mention syntax in my individual chat
+- \`@TeamName\` → I pull that team's brief into context for this turn so I can
+  reason about that specific team.
+- \`@AgentName\` → routes to that agent (works in team chats too).
+
+## Common pitfalls
+- Don't pretend to know what a team has done — read their group chat first.
+- Don't delegate without giving the recipient enough self-contained context.
+- Don't try to read a teammate's workspace files — their workspaces are isolated.
+- Don't re-respond to \`[Team Update]\` messages as if they were fresh user input.
+
+## Notes
+_(User-editable. Use this section for any global instructions you want Boo Zero to always have in context.)_
+`
+}

--- a/apps/web/src/lib/createAgent.ts
+++ b/apps/web/src/lib/createAgent.ts
@@ -133,8 +133,25 @@ export async function refreshTeamAgentsMd(params: {
   agentName: string
   teamName: string
   teammates: TeammateDef[]
+  /**
+   * Boo Zero's name — the universal team leader. When provided, the
+   * regenerated AGENTS.md and CLAWBOO.md include the universal-leader
+   * section telling the agent how to escalate upward via `<delegate
+   * to="@Boo Zero">`. Omitted in tests / pre-Boo-Zero builds.
+   */
+  universalLeaderName?: string | null
+  /** Team-internal lead (CTO, Team Lead, etc.), if any. */
+  teamInternalLeadName?: string | null
 }): Promise<void> {
-  const { client, agentId, agentName, teamName, teammates } = params
+  const {
+    client,
+    agentId,
+    agentName,
+    teamName,
+    teammates,
+    universalLeaderName,
+    teamInternalLeadName,
+  } = params
   const content = await client.agents.files.read(agentId, 'AGENTS.md')
   let routingRules = content ?? ''
 
@@ -149,12 +166,19 @@ export async function refreshTeamAgentsMd(params: {
     teamName,
     teammates,
     routingRules,
+    universalLeaderName,
+    teamInternalLeadName,
   })
 
   // CLAWBOO.md is regenerated wholesale — there's no per-team customization
   // in it (every team gets the same operating reference, just with the team's
   // own teammate list inlined for path discoverability).
-  const clawboo = buildClawbooHelpDoc({ agentName, teamName, teammates })
+  const clawboo = buildClawbooHelpDoc({
+    agentName,
+    teamName,
+    teammates,
+    universalLeaderName,
+  })
 
   await client.agents.files.set(agentId, 'AGENTS.md', enhanced)
   // CLAWBOO.md is best-effort — see the comment in `createAgent` above.

--- a/apps/web/src/lib/genuineLeader.ts
+++ b/apps/web/src/lib/genuineLeader.ts
@@ -1,0 +1,152 @@
+/**
+ * Genuine team-leader detection.
+ *
+ * With Boo Zero acting as the universal team leader across every team,
+ * Clawboo no longer needs to force every team to designate one of its
+ * members as `leaderAgentId`. We only want to keep that field set when
+ * an agent's role / name genuinely matches a leadership archetype
+ * (CTO, Team Lead, Project Manager, Operator, etc.) — in which case
+ * Boo Zero treats them as the "team-internal lead" that sits between
+ * Boo Zero and the rest of the team.
+ *
+ * This module exports:
+ *   - `LEADERSHIP_KEYWORDS`: the canonical keyword list.
+ *   - `detectGenuineLeader({name, role})`: pure boolean check against
+ *     EITHER field, case-insensitive, word-boundary anchored.
+ *
+ * Used at team-deploy time (`CreateTeamModal`, `OnboardingWizard`) and
+ * for generating each team's brief (`buildTeamBrief`).
+ */
+
+/**
+ * Canonical leadership keywords / phrases. Order is not significant.
+ * Matched against the agent's `name` and `role` (case-insensitive,
+ * word-boundary anchored to avoid false positives like "CTOgraphy" or
+ * "Manager-of-Records-but-actually-an-IC").
+ */
+export const LEADERSHIP_KEYWORDS: readonly string[] = [
+  // C-suite
+  'CEO',
+  'CTO',
+  'CFO',
+  'COO',
+  'CMO',
+  'CIO',
+  'Chief',
+  // Director-tier
+  'VP',
+  'VP of',
+  'Founder',
+  'President',
+  'Principal',
+  'Director',
+  'Head of',
+  // Leads
+  'Team Lead',
+  'Tech Lead',
+  'Project Lead',
+  'Product Lead',
+  'Engineering Lead',
+  // Managers
+  'Project Manager',
+  'Product Manager',
+  'Engineering Manager',
+  'Program Manager',
+  'General Manager',
+  // Coordinators / orchestrators
+  'Operator',
+  'Orchestrator',
+  'Coordinator',
+  'Conductor',
+]
+
+/**
+ * Build the regex from `LEADERSHIP_KEYWORDS` once at module load.
+ *
+ * Word-boundary semantics: `\b` requires a non-word char on either side.
+ * For multi-word phrases ("Team Lead") `\b...\b` works because the
+ * surrounding text — start/end of string, comma, period, whitespace —
+ * are non-word. For "Chief" we use `\b` only; "Chief Scientist" matches
+ * "Chief" alone, intentionally — there are many real "Chief X" roles
+ * that should count as leadership.
+ *
+ * Escapes any regex meta-chars in the keywords (defensive — none today
+ * but the list may grow).
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+const LEADERSHIP_RE = new RegExp(
+  `\\b(?:${LEADERSHIP_KEYWORDS.map((k) =>
+    // Collapse whitespace so "Team   Lead" still matches; tolerate hyphen.
+    escapeRegExp(k).replace(/\s+/g, '[\\s-]+'),
+  ).join('|')})\\b`,
+  'i',
+)
+
+/**
+ * Negative-match guards: substrings that LOOK leadership-y but represent
+ * individual contributors. Checked AFTER the positive regex passes so we
+ * never reject a real "Tech Lead" by accident.
+ *
+ * Each entry is the surrounding context that disqualifies the match:
+ *   "Lead Engineer" → "Lead" is positional ("first chair"), not a title.
+ *   "Senior X", "Staff X" → seniority adjectives, not leadership roles.
+ */
+const NEGATIVE_PATTERNS: readonly RegExp[] = [
+  /\bLead\s+(Engineer|Developer|Designer|Researcher|Scientist|Analyst|Writer|Reviewer)\b/i,
+  /\b(Senior|Staff|Principal\s+Engineer|Principal\s+Developer)\b/i,
+]
+
+export interface GenuineLeaderCandidate {
+  name: string
+  /** Catalog role string, or an empty string if unknown. */
+  role: string
+}
+
+/**
+ * Returns true when EITHER the agent's `name` or `role` matches one of
+ * the canonical leadership keywords AND no negative pattern fires.
+ *
+ * Pure. Safe to call from anywhere.
+ */
+export function detectGenuineLeader(agent: GenuineLeaderCandidate): boolean {
+  const haystack = `${agent.name} ${agent.role}`.trim()
+  if (haystack.length === 0) return false
+
+  if (!LEADERSHIP_RE.test(haystack)) return false
+
+  for (const neg of NEGATIVE_PATTERNS) {
+    if (neg.test(haystack)) return false
+  }
+
+  return true
+}
+
+/**
+ * Returns the first matched leadership keyword, or null if no match.
+ * Useful for surfacing "detected via 'CTO'" in the team brief.
+ */
+export function matchedLeadershipKeyword(agent: GenuineLeaderCandidate): string | null {
+  const haystack = `${agent.name} ${agent.role}`.trim()
+  if (haystack.length === 0) return null
+
+  for (const neg of NEGATIVE_PATTERNS) {
+    if (neg.test(haystack)) return null
+  }
+
+  const matchResult = haystack.match(LEADERSHIP_RE)
+  if (!matchResult || matchResult.length === 0) return null
+
+  // Return the canonical (original-case) keyword that matched, not the
+  // captured text from the haystack — keeps the brief consistent.
+  const matchedText = matchResult[0]!.toLowerCase()
+  const matchedNorm = matchedText.replace(/[\s-]+/g, ' ')
+  return (
+    LEADERSHIP_KEYWORDS.find((kw) => {
+      const normalised = kw.toLowerCase().replace(/\s+/g, ' ')
+      return matchedNorm === normalised
+    }) ?? null
+  )
+}

--- a/apps/web/src/lib/parseTeamOrAgentMention.ts
+++ b/apps/web/src/lib/parseTeamOrAgentMention.ts
@@ -1,0 +1,102 @@
+/**
+ * Boo Zero's individual chat extends `@`-mention parsing beyond agents to
+ * include teams. When the user types `@MarketingTeam, please research X`,
+ * the chat handler injects that team's brief into the message preamble so
+ * Boo Zero can reason about that specific team.
+ *
+ * The parser uses longest-prefix matching across BOTH teams and agents.
+ * On a tie (rare — team and agent names could theoretically collide),
+ * **teams win** because the team-mention intent is the new feature this
+ * file exists for; an agent mention would still route through the normal
+ * `parseMention` in team chats.
+ *
+ * Pure. No DOM / store access.
+ */
+
+export type MentionKind = 'team' | 'agent' | 'none'
+
+export interface ParseTeamOrAgentMentionResult {
+  kind: MentionKind
+  /** The matched team or agent id, or null when nothing matched. */
+  targetId: string | null
+  /** The matched name (in its original casing from the input). */
+  matchedName: string | null
+  /** The message with the `@<Name>` prefix stripped (when matched). */
+  cleanedMessage: string
+}
+
+export interface MentionCandidate {
+  id: string
+  name: string
+}
+
+const NO_MATCH: ParseTeamOrAgentMentionResult = {
+  kind: 'none',
+  targetId: null,
+  matchedName: null,
+  cleanedMessage: '',
+}
+
+/**
+ * Parse an `@<Name>` mention at the start of `message`. Returns the kind
+ * ('team' | 'agent' | 'none'), the matched id (when any), and the message
+ * with the `@<Name>` prefix stripped.
+ *
+ * Matching rules:
+ *   - Must start with `@` (after an optional leading whitespace trim).
+ *   - The matched name is followed by whitespace, end-of-string, OR one
+ *     of: `,`, `.`, `:`, `!`, `?`. Catches "@Marketing, please..." and
+ *     "@Marketing: do X" naturally.
+ *   - Longest-prefix match: "@SEO Boo" wins over "@SEO" when both exist.
+ *   - Ties: teams beat agents.
+ */
+export function parseTeamOrAgentMention(
+  message: string,
+  teams: readonly MentionCandidate[] = [],
+  agents: readonly MentionCandidate[] = [],
+): ParseTeamOrAgentMentionResult {
+  if (!message.startsWith('@')) return { ...NO_MATCH, cleanedMessage: message }
+
+  const afterAt = message.slice(1)
+  const lowerAfter = afterAt.toLowerCase()
+
+  // Build a unified candidate list. We attach the kind here so the longest-
+  // prefix sort below picks the right one. Teams listed first so that a
+  // tie (identical names) resolves to a team.
+  type Cand = { id: string; name: string; lower: string; kind: 'team' | 'agent' }
+  const candidates: Cand[] = [
+    ...teams.map<Cand>((t) => ({
+      id: t.id,
+      name: t.name,
+      lower: t.name.toLowerCase(),
+      kind: 'team',
+    })),
+    ...agents.map<Cand>((a) => ({
+      id: a.id,
+      name: a.name,
+      lower: a.name.toLowerCase(),
+      kind: 'agent',
+    })),
+  ]
+  // Sort by descending name length so longer names match first.
+  candidates.sort((a, b) => b.name.length - a.name.length)
+
+  for (const cand of candidates) {
+    if (!lowerAfter.startsWith(cand.lower)) continue
+    const rest = afterAt.slice(cand.name.length)
+    if (rest.length === 0 || /^[\s,.:!?]/.test(rest)) {
+      // Strip the matched mention + any single immediately-following
+      // separator character (so the cleaned message reads naturally).
+      const trimmedRest =
+        rest.length > 0 && /^[,.:!?]/.test(rest) ? rest.slice(1).trimStart() : rest.trimStart()
+      return {
+        kind: cand.kind,
+        targetId: cand.id,
+        matchedName: cand.name,
+        cleanedMessage: trimmedRest,
+      }
+    }
+  }
+
+  return { ...NO_MATCH, cleanedMessage: message }
+}

--- a/apps/web/src/lib/resolveTeamLeader.ts
+++ b/apps/web/src/lib/resolveTeamLeader.ts
@@ -2,16 +2,69 @@ import type { AgentState } from '@/stores/fleet'
 
 /**
  * Resolves the effective leader agent for a team.
- * Priority: (1) explicit leaderAgentId if agent exists in team,
- *           (2) first agent in the team, (3) null
+ *
+ * **Boo Zero is the universal leader.** When a Boo Zero agent exists in the
+ * fleet (identified via `useBooZeroStore` / Gateway `defaultId`), it is the
+ * leader of every team — regardless of `teamInternalLeadId`. Boo Zero is
+ * *teamless* in the DB (`agents.teamId === null`); we don't require it to
+ * appear in the team membership before treating it as leader.
+ *
+ * `teamInternalLeadId` (formerly `leaderAgentId`) is now a secondary concept:
+ * the *team-internal lead* that sits between Boo Zero and the rest of the
+ * team — only set when the team has a genuine leader role (CTO, Team Lead,
+ * etc., detected via `detectGenuineLeader`). When Boo Zero is missing, the
+ * team-internal lead becomes the fallback so routing keeps working.
+ *
+ * Priority:
+ *   1. `booZeroAgentId` (when set and the agent exists in `agents`).
+ *   2. `teamInternalLeadId` (when set and the agent is a member of `teamId`).
+ *   3. First member of the team.
+ *   4. `null` — empty team and no Boo Zero.
  */
 export function resolveTeamLeader(
   teamId: string,
-  leaderAgentId: string | null,
+  teamInternalLeadId: string | null,
+  agents: AgentState[],
+  booZeroAgentId: string | null,
+): string | null {
+  // (1) Universal leader: Boo Zero.
+  if (booZeroAgentId && agents.some((a) => a.id === booZeroAgentId)) {
+    return booZeroAgentId
+  }
+
+  // (2) Team-internal lead — only meaningful when it's actually in the team.
+  const teamAgents = agents.filter((a) => a.teamId === teamId)
+  if (teamAgents.length === 0) return null
+
+  if (teamInternalLeadId && teamAgents.some((a) => a.id === teamInternalLeadId)) {
+    return teamInternalLeadId
+  }
+
+  // (3) First member fallback.
+  return teamAgents[0]?.id ?? null
+}
+
+/**
+ * Resolves the *team-internal* lead independently of Boo Zero.
+ *
+ * Used by the Ghost Graph spanning-tree layer and by relay routing when we
+ * need to know the team's own designated lead (under Boo Zero). Returns
+ * `null` when the team has no internal lead set, or the configured lead is
+ * no longer a member of the team.
+ *
+ * Same signature as the old (pre-Boo-Zero) `resolveTeamLeader`, included
+ * here so callers that need the team-internal-only resolution don't have
+ * to re-derive it from `agents.filter`.
+ */
+export function resolveTeamInternalLead(
+  teamId: string,
+  teamInternalLeadId: string | null,
   agents: AgentState[],
 ): string | null {
   const teamAgents = agents.filter((a) => a.teamId === teamId)
   if (teamAgents.length === 0) return null
-  if (leaderAgentId && teamAgents.some((a) => a.id === leaderAgentId)) return leaderAgentId
-  return teamAgents[0]?.id ?? null
+  if (teamInternalLeadId && teamAgents.some((a) => a.id === teamInternalLeadId)) {
+    return teamInternalLeadId
+  }
+  return null
 }

--- a/apps/web/src/lib/sessionUtils.ts
+++ b/apps/web/src/lib/sessionUtils.ts
@@ -2,7 +2,7 @@ const SESSION_KEY_AGENT_RE = /^agent:([^:]+):/
 
 /** Extracts the agentId from a sessionKey of format `agent:<agentId>:<sessionName>`. */
 export function agentIdFromSessionKey(sessionKey: string): string | null {
-  const m = SESSION_KEY_AGENT_RE.exec(sessionKey)
+  const m = sessionKey.match(SESSION_KEY_AGENT_RE)
   return m?.[1] ?? null
 }
 
@@ -12,34 +12,139 @@ export function buildTeamSessionKey(agentId: string, teamId: string): string {
 }
 
 // ─── Team chat override ──────────────────────────────────────────────────────
+//
 // The Gateway echoes events with the agent's main sessionKey regardless of
 // which custom sessionKey was used in chat.send. This redirect map ensures
 // incoming events for agents currently processing team chat messages are
 // stored under the team sessionKey, not the main one.
+//
+// **Concurrency model (runId-aware)**:
+//
+// Boo Zero participates in N teams as the universal leader. Two team chats
+// in flight at the same time both have outstanding overrides on Boo Zero's
+// agentId. A naïve `Map<agentId, sessionKey>` clobbers the older one. We
+// disambiguate by the per-run `runId` on the Gateway events.
+//
+// Lifecycle of an override:
+//
+//   1. Caller calls `setTeamChatOverride(agentId, sessionKey)` BEFORE sending
+//      the message. The runId isn't known yet — we store the entry in
+//      `pendingOverrides`.
+//
+//   2. The first event for that agent arrives with a runId. We "promote" the
+//      pending entry to `runScopedOverrides` keyed by `${agentId} ${runId}`.
+//      Subsequent events for the same agent + runId look up here.
+//
+//   3. When the run ends, the caller calls `clearTeamChatOverride(agentId,
+//      runId)`. Run-scoped entry is removed.
+//
+// If a second `setTeamChatOverride` for the same agent fires before step 2
+// (overlapping team sends), the second call REPLACES the pending entry — but
+// any already-promoted run-scoped entry stays put, so the older run keeps
+// routing correctly until it ends.
 
-const teamChatOverrides = new Map<string, string>()
+const pendingOverrides = new Map<string, string>()
+const runScopedOverrides = new Map<string, string>()
+/** Tracks which runIds belong to which agentId — supports bulk cleanup. */
+const runIdsByAgent = new Map<string, Set<string>>()
 
-/** Mark an agent as currently processing a team chat message. */
+function runKey(agentId: string, runId: string): string {
+  return `${agentId} ${runId}`
+}
+
+/** Mark an agent as currently processing a team chat message (pre-runId). */
 export function setTeamChatOverride(agentId: string, teamSessionKey: string): void {
-  teamChatOverrides.set(agentId, teamSessionKey)
+  pendingOverrides.set(agentId, teamSessionKey)
 }
 
-/** Clear the team redirect after the agent finishes responding. */
-export function clearTeamChatOverride(agentId: string): void {
-  teamChatOverrides.delete(agentId)
+/**
+ * Promote the pending override for an agent to a run-scoped one.
+ * Called by the event handler on the first event that arrives with a runId.
+ * Idempotent — re-promoting the same run is a no-op.
+ *
+ * Returns the sessionKey that ended up scoped to (agentId, runId), or
+ * `undefined` if there was no pending override and no existing scoped one.
+ */
+export function promoteOverrideToRun(agentId: string, runId: string): string | undefined {
+  if (!runId) return undefined
+  const key = runKey(agentId, runId)
+  const existing = runScopedOverrides.get(key)
+  if (existing) return existing
+  const pending = pendingOverrides.get(agentId)
+  if (!pending) return undefined
+  runScopedOverrides.set(key, pending)
+  pendingOverrides.delete(agentId)
+  let set = runIdsByAgent.get(agentId)
+  if (!set) {
+    set = new Set<string>()
+    runIdsByAgent.set(agentId, set)
+  }
+  set.add(runId)
+  return pending
 }
 
-/** Get the team sessionKey redirect for an agent, if active. */
-export function getTeamChatOverride(agentId: string): string | undefined {
-  return teamChatOverrides.get(agentId)
+/**
+ * Clear the override for an agent.
+ *
+ * - If `runId` is provided: clears only the run-scoped entry for that run.
+ *   This is the precise post-commit cleanup path.
+ * - If `runId` is omitted: clears the pending entry only (back-compat for
+ *   the legacy "the agent finished" semantics where the caller didn't track
+ *   the runId).
+ */
+export function clearTeamChatOverride(agentId: string, runId?: string): void {
+  if (runId) {
+    runScopedOverrides.delete(runKey(agentId, runId))
+    const set = runIdsByAgent.get(agentId)
+    if (set) {
+      set.delete(runId)
+      if (set.size === 0) runIdsByAgent.delete(agentId)
+    }
+    return
+  }
+  pendingOverrides.delete(agentId)
 }
 
-/** Check if an agent currently has an active team chat override (is processing a team message). */
+/**
+ * Get the override for an agent — run-aware.
+ *
+ * - When `runId` is provided AND a run-scoped entry exists for (agentId,
+ *   runId): returns that sessionKey.
+ * - When `runId` is provided but no run-scoped entry exists yet: falls
+ *   through to the pending entry (caller may want to promote it).
+ * - When `runId` is omitted: returns the pending entry only (back-compat).
+ *
+ * Does NOT mutate any state. Use `promoteOverrideToRun` if you want to
+ * persist a runId-keyed entry going forward.
+ */
+export function getTeamChatOverride(agentId: string, runId?: string | null): string | undefined {
+  if (runId) {
+    const scoped = runScopedOverrides.get(runKey(agentId, runId))
+    if (scoped) return scoped
+  }
+  return pendingOverrides.get(agentId)
+}
+
+/** Check if an agent currently has ANY active override (pending OR run-scoped). */
 export function hasTeamChatOverride(agentId: string): boolean {
-  return teamChatOverrides.has(agentId)
+  if (pendingOverrides.has(agentId)) return true
+  const set = runIdsByAgent.get(agentId)
+  return Boolean(set && set.size > 0)
 }
 
-/** Clear all overrides — exposed for testing. */
+/** Clear all overrides for an agent — used when the agent is deleted. */
+export function clearAllTeamChatOverridesForAgent(agentId: string): void {
+  pendingOverrides.delete(agentId)
+  const set = runIdsByAgent.get(agentId)
+  if (set) {
+    for (const r of set) runScopedOverrides.delete(runKey(agentId, r))
+    runIdsByAgent.delete(agentId)
+  }
+}
+
+/** Clear ALL overrides — exposed for testing. */
 export function resetTeamChatOverrides(): void {
-  teamChatOverrides.clear()
+  pendingOverrides.clear()
+  runScopedOverrides.clear()
+  runIdsByAgent.clear()
 }

--- a/apps/web/src/lib/teamProtocol.ts
+++ b/apps/web/src/lib/teamProtocol.ts
@@ -5,6 +5,20 @@ export type BuildTeamAgentsMdParams = {
   teamName: string
   teammates: TeammateDef[]
   routingRules: string
+  /**
+   * Name of the universal team leader (Boo Zero). When provided, the
+   * generated AGENTS.md adds a "Universal Leader" section telling the
+   * agent it can route upward via `<delegate to="@Boo Zero">` for
+   * higher-level coordination, synthesis, or cross-team requests.
+   */
+  universalLeaderName?: string | null
+  /**
+   * Optional name of the team-internal lead (CTO, Team Lead, etc.,
+   * detected via `detectGenuineLeader`). When set AND distinct from
+   * `agentName`, the AGENTS.md surfaces it as the team's coordinator
+   * under the universal leader.
+   */
+  teamInternalLeadName?: string | null
 }
 
 export type BuildTeamWakeMessageParams = {
@@ -18,6 +32,8 @@ export type BuildClawbooHelpDocParams = {
   teamName: string
   /** Teammates excluding self. Roles are optional — only `name` is used for paths. */
   teammates: TeammateDef[]
+  /** Optional Boo Zero name for the universal-leader note. */
+  universalLeaderName?: string | null
 }
 
 /**
@@ -68,11 +84,47 @@ function formatTime(ms: number): string {
 }
 
 export function buildTeamAgentsMd(params: BuildTeamAgentsMdParams): string {
-  const { agentName, teamName, teammates, routingRules } = params
+  const {
+    agentName,
+    teamName,
+    teammates,
+    routingRules,
+    universalLeaderName,
+    teamInternalLeadName,
+  } = params
   const rules = routingRules.trim() || 'No specific routing rules defined.'
 
+  // Universal leader section — Boo Zero is the leader of every team. We
+  // mention it whether or not the agent has explicit routing rules to it,
+  // so any team agent can escalate / delegate "upward" via `<delegate>`.
+  const universalLeaderBlock = universalLeaderName
+    ? `### Universal Leader: @${universalLeaderName}
+**${universalLeaderName}** is the universal team leader on this Clawboo instance — sitting above every team, including yours. You can address it explicitly with \`@${universalLeaderName}\` in your responses, and route higher-level coordination, synthesis, or cross-team requests via:
+
+\`\`\`
+<delegate to="@${universalLeaderName}">
+A specific request — strategic decision, cross-team synthesis, blocker the team
+can't resolve alone, etc.
+</delegate>
+\`\`\`
+
+${
+  teamInternalLeadName && teamInternalLeadName !== agentName
+    ? `Within team **${teamName}**, **${teamInternalLeadName}** is the team-internal lead under ${universalLeaderName}. They coordinate intake from ${universalLeaderName} and own internal team flow.\n`
+    : ''
+}
+`
+    : ''
+
   if (teammates.length === 0) {
-    return `# AGENTS\n\n### Routing Rules\n${rules}\n`
+    return `# AGENTS
+
+## Your Team: ${teamName}
+You are **${agentName}**.
+
+${universalLeaderBlock}### Routing Rules
+${rules}
+`
   }
 
   const rows = teammates.map((t) => `| @${t.name} | ${t.role} |`).join('\n')
@@ -83,7 +135,7 @@ export function buildTeamAgentsMd(params: BuildTeamAgentsMdParams): string {
 ## Your Team: ${teamName}
 You are **${agentName}** — a member of a multi-agent team on this OpenClaw Gateway.
 
-### Teammates
+${universalLeaderBlock}### Teammates
 | Name | Role |
 |------|------|
 ${rows}
@@ -240,7 +292,7 @@ export function buildTeamContextPreamble(params: BuildTeamContextPreambleParams)
  * `createAgent` exactly.
  */
 export function buildClawbooHelpDoc(params: BuildClawbooHelpDocParams): string {
-  const { agentName, teamName, teammates } = params
+  const { agentName, teamName, teammates, universalLeaderName } = params
   const yourSlug = slugifyAgentName(agentName)
   const teammatePathRows = teammates
     .map((t) => `  ${t.name}'s workspace: ~/.openclaw/workspace-${slugifyAgentName(t.name)}`)
@@ -250,11 +302,37 @@ export function buildClawbooHelpDoc(params: BuildClawbooHelpDocParams): string {
   // to invent a placeholder name. Fall back to a generic name if solo.
   const exampleName = teammates[0]?.name ?? 'Teammate Name'
 
+  const universalLeaderBlock = universalLeaderName
+    ? `## Universal Leader: ${universalLeaderName}
+
+**${universalLeaderName}** is Clawboo's universal team leader — it sits above
+every team on this instance, including ${teamName}. ${universalLeaderName}
+triages user messages, decides what each teammate should pick up, and synthesizes
+results back to the user. When you finish a delegated task, your response is
+relayed to ${universalLeaderName} automatically; you do not need to ping it.
+
+You CAN escalate upward by emitting:
+
+\`\`\`
+<delegate to="@${universalLeaderName}">
+A specific request — a strategic decision, a synthesis across teammates, a
+blocker your team can't resolve internally, a cross-team handoff.
+</delegate>
+\`\`\`
+
+Do NOT \`@${universalLeaderName}\` casually in prose — only via \`<delegate>\`
+blocks. Bare mentions are a best-effort fallback and may not route.
+
+`
+    : ''
+
   return `# CLAWBOO — Team Operating Reference
 
 You are **${agentName}**, an agent in team **${teamName}** on Clawboo, a
 multi-agent dashboard built on OpenClaw. This file is the detailed reference
 for how the team works. Read it any time you're unsure — \`cat ~/CLAWBOO.md\`.
+
+${universalLeaderBlock}
 
 ## Workspaces are isolated
 

--- a/apps/web/src/lib/teamProtocol.ts
+++ b/apps/web/src/lib/teamProtocol.ts
@@ -204,10 +204,71 @@ a null \`kid\` header gracefully. Report back what you find.
   the highest confidence; prose forms are only a fallback and may not route.
 - Wait for or poll teammates' responses; their replies arrive automatically as
   \`[Team Update]\` messages, after which you continue with that context.
+- **Take initiative on work that wasn't delegated to YOU.** Only act on
+  \`<delegate to="@${agentName}">\` blocks aimed at you specifically.
+  \`[Team Update]\` messages and other teammates' work are read-only context,
+  not action items. If you think you could help on something a teammate is
+  doing (e.g., you spotted a UX issue in their code), propose it via a
+  \`<delegate to="@<that teammate>">\` block — don't just start doing it
+  yourself in parallel. Production has shown that uncoordinated parallel
+  work produces duplicate / conflicting outputs.
+
+### Resuming sessions
+
+OpenClaw sessions go cold when idle. Before sending you a real task, the
+orchestrator may send a brief warm-up message that looks like this:
+
+> "You are resuming a team collaboration session as ${agentName} on team
+> ${teamName}. Stay quiet — the next message will be a [Team Update] or
+> a user message…"
+
+**This is a session-warmup signal, not work for you to do.**
+
+When you see it:
+- Do NOT respond.
+- Do NOT introduce yourself.
+- Do NOT greet teammates ("Welcome aboard!", "Hey Frontend Boo!", etc.).
+- Do NOT acknowledge the re-init.
+
+Your prior context — this AGENTS.md, your SOUL.md, your TOOLS.md, the team
+brief — is still loaded. The next message you receive (a \`[Team Update]\`
+from a teammate, or a fresh user message) is where you engage. Pick up the
+work as if there was no pause.
 
 ### Routing Rules
 ${rules}
 `
+}
+
+/**
+ * Silent re-init body for sleepy team-agent sessions.
+ *
+ * **Why this exists**: OpenClaw agents go cold after idle TTL. Before
+ * resuming agent-to-agent work, we need a chat.send to wake the session.
+ * The OLD wake body (`buildTeamWakeMessage` below) asked agents to
+ * introduce themselves AND listed teammates as `@AgentName` — both of
+ * those triggered a cascade of intros and false-positive delegations
+ * (the 11-message "Welcome aboard X" flood in production, CLAUDE.md
+ * §"Group Chat Onboarding Gate — Cascade Fix").
+ *
+ * This replacement says "you're resuming, stay quiet, the next message
+ * is the real one". It pairs with the new `### Resuming sessions` rule
+ * in `buildTeamAgentsMd` which deterministically loads into the agent's
+ * context every turn — so even if the LLM ignores the in-message hint,
+ * AGENTS.md tells it the same thing.
+ *
+ * Used by:
+ *   - `groupChatSendOperation.wakeTeamAgents` (user-message-time wake)
+ *   - `useTeamOrchestration` wake-on-relay path
+ *
+ * Both call sites converged on this helper to keep behavior consistent.
+ */
+export function buildSilentResumeWakeMessage(params: {
+  agentName: string
+  teamName: string
+}): string {
+  const { agentName, teamName } = params
+  return `You are resuming a team collaboration session as ${agentName} on team "${teamName}". Stay quiet — the next message will be a [Team Update] or a user message with the real context. Continue from where you left off; do NOT introduce yourself, do NOT greet teammates, do NOT acknowledge this re-init.`
 }
 
 export function buildTeamWakeMessage(params: BuildTeamWakeMessageParams): string {

--- a/apps/web/src/stores/__tests__/chat.test.ts
+++ b/apps/web/src/stores/__tests__/chat.test.ts
@@ -4,13 +4,23 @@ import type { TranscriptEntry } from '@clawboo/protocol'
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+/**
+ * Factory uses the entryId as part of the text + slightly-staggered timestamps
+ * so distinct entries are content-distinct too. The store now dedupes by
+ * content signature in addition to entryId (Round 2, Phase A) — tests that
+ * relied on multiple `entryId`s with identical text + timestamp were
+ * exercising a degenerate case that doesn't occur in production.
+ */
+let nextTs = 1_700_000_000_000
 function makeEntry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  const id = overrides.entryId ?? `e${nextTs}`
   return {
-    entryId: 'e1',
+    entryId: id,
     kind: 'assistant',
     source: 'runtime',
-    text: 'Hello world',
-    timestamp: Date.now(),
+    text: `Hello world ${id}`,
+    timestamp: nextTs++,
+    timestampMs: nextTs,
     ...overrides,
   } as TranscriptEntry
 }

--- a/apps/web/src/stores/chat.ts
+++ b/apps/web/src/stores/chat.ts
@@ -34,9 +34,83 @@ export const useChatStore = create<ChatStore>((set) => ({
     set((state) => {
       const next = new Map(state.transcripts)
       const existing = next.get(sessionKey) ?? []
-      // Deduplicate by entryId to prevent duplicate React keys
-      const seen = new Set(existing.map((e) => e.entryId))
-      const fresh = entries.filter((e) => !seen.has(e.entryId))
+
+      // Dedup layer 1: entryId (preserves React key stability across re-fetches).
+      const seenIds = new Set(existing.map((e) => e.entryId))
+
+      // Dedup layer 2: content signature (defensive against the production
+      // triple-render bug). When the upstream pipeline fires `appendOutputLines`
+      // multiple times for the same Gateway frame, each call mints a fresh
+      // entryId via `crypto.randomUUID()` — entryId dedup misses, and the
+      // store ends up with N copies of the same message.
+      //
+      // Upstream root cause (Round 2, Phase A): the `commitChat` case in
+      // `packages/events/src/handler.ts` does NOT guard against stale
+      // terminal events for already-closed runs (the `closedRuns` guard
+      // exists only for `updateAgentStatus`). When the Gateway emits
+      // multiple `chat:final` frames for the same runId — which can happen
+      // legitimately during exec-approval flows AND happens spuriously in
+      // some Gateway configurations — every frame produces a fresh
+      // `commitChat` intent that calls `appendOutputLines` with new
+      // entryIds. We cannot add a runId-only guard at the handler layer
+      // because legitimate post-approval continuations have the SAME runId
+      // with DIFFERENT text and we want those through.
+      //
+      // The content signature collapses entries that are clearly the same
+      // logical event:
+      //
+      //   key = `${kind}|${role}|${timestampMs/1000|0}|${text.slice(0,160)}`
+      //
+      // Scoping is implicit in `sessionKey` (we only check against entries on
+      // the same session). The 1-second timestamp bucket allows real
+      // re-utterances of the same text later in the conversation through,
+      // but blocks the same-frame triplication that production exhibits.
+      // First 160 chars of text is plenty to disambiguate distinct messages
+      // while keeping the signature cheap.
+      function contentSig(e: {
+        kind?: string
+        role?: string
+        timestampMs?: number | null
+        text?: string
+      }): string {
+        const k = e.kind ?? ''
+        const r = e.role ?? ''
+        const tsBucket = Math.floor((e.timestampMs ?? 0) / 1000)
+        const t = (e.text ?? '').slice(0, 160)
+        return `${k}|${r}|${tsBucket}|${t}`
+      }
+      const seenSigs = new Set(existing.map(contentSig))
+
+      const fresh: typeof entries = []
+      const droppedByContent: { entryId: string; sig: string }[] = []
+      for (const e of entries) {
+        if (seenIds.has(e.entryId)) continue
+        const sig = contentSig(e)
+        if (seenSigs.has(sig)) {
+          droppedByContent.push({ entryId: e.entryId, sig })
+          continue
+        }
+        seenIds.add(e.entryId)
+        seenSigs.add(sig)
+        fresh.push(e)
+      }
+
+      // Optional diagnostic (Phase A4) — enable in browser DevTools with
+      //   localStorage.setItem('clawboo:debug-triple-render', 'true')
+      // to capture the actual upstream source of duplicates the next time
+      // production hits this path. Off by default.
+      if (
+        typeof window !== 'undefined' &&
+        droppedByContent.length > 0 &&
+        window.localStorage?.getItem('clawboo:debug-triple-render') === 'true'
+      ) {
+        console.warn('[clawboo:triple-render] dropped content-equivalent entries', {
+          sessionKey,
+          dropped: droppedByContent,
+          stack: new Error().stack?.split('\n').slice(1, 6).join('\n'),
+        })
+      }
+
       if (fresh.length === 0) return state
       const merged = [...existing, ...fresh]
       next.set(sessionKey, merged.length > 500 ? merged.slice(-500) : merged)

--- a/apps/web/src/stores/view.ts
+++ b/apps/web/src/stores/view.ts
@@ -4,6 +4,11 @@ import { create } from 'zustand'
 // Discriminated union replacing the old flat View type.
 // 'chat' is gone — selecting an agent opens chat via { type: 'agent' }.
 
+// The `'graph'` nav slot now renders the Atlas (global all-teams view) — a
+// canvas-wide Boo Zero hierarchy that shows every team at once. The id is
+// kept as `'graph'` for minimal churn across viewMode discriminants and
+// keyboard shortcut wiring; the team-scoped Ghost Graph still lives inside
+// `GroupChatView` and is unaffected.
 export type NavView = 'graph' | 'approvals' | 'cost' | 'marketplace' | 'scheduler' | 'system'
 
 export type ViewMode =

--- a/packages/boo-avatar/src/index.ts
+++ b/packages/boo-avatar/src/index.ts
@@ -183,9 +183,17 @@ export function generateBooAvatar(params: BooAvatarParams): string {
   // Resolve eye shape
   const eyeShape: EyeShape = params.eyeShape ?? ((Math.abs(h >> 8) % 5) as EyeShape)
 
-  // Resolve accessory
+  // Resolve accessory. Boo Zero is the iconic Clawboo mascot — the clean
+  // ghost-lobster with no accessory. Everyone running Clawboo sees the
+  // same unadorned mascot as their Boo Zero, paired with the reserved
+  // OpenClaw-red tint (TINTS[0]). Forcing `'none'` here means we never
+  // need to maintain a separate "Boo Zero" SVG: the existing avatar
+  // pipeline produces it by virtue of the tint + accessory locks. Non-
+  // Boo-Zero agents still get hash-derived accessories from the full
+  // list, so individuality remains.
   const accList: Accessory[] = ['none', 'glasses', 'hat', 'headphones', 'crown']
-  const accessory: Accessory = params.accessory ?? accList[Math.abs(h >> 16) % accList.length]
+  const accessory: Accessory =
+    params.accessory ?? (params.isBooZero ? 'none' : accList[Math.abs(h >> 16) % accList.length])
 
   // Pupil color — cyan for OpenClaw red, white for all other tints
   const pupilColor = tint === '#ff4d4d' ? '#00e5cc' : '#ffffff'

--- a/packages/db/drizzle/0003_flawless_warlock.sql
+++ b/packages/db/drizzle/0003_flawless_warlock.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `boo_zero_team_briefs` (
+	`team_id` text PRIMARY KEY NOT NULL,
+	`content` text NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `agents` ADD `exec_config` text;

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,701 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "430cabe9-fd87-4e5d-b5bb-0af20bd5e1dc",
+  "prevId": "4c8ef927-55fb-4a4a-9c2d-6fa3d85fbbfe",
+  "tables": {
+    "agents": {
+      "name": "agents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gateway_id": {
+          "name": "gateway_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "personality_config": {
+          "name": "personality_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exec_config": {
+          "name": "exec_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_agents_gateway_id": {
+          "name": "idx_agents_gateway_id",
+          "columns": ["gateway_id"],
+          "isUnique": false
+        },
+        "idx_agents_status": {
+          "name": "idx_agents_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_agents_team_id": {
+          "name": "idx_agents_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agents_team_id_teams_id_fk": {
+          "name": "agents_team_id_teams_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "approval_history": {
+      "name": "approval_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_approval_history_agent_id": {
+          "name": "idx_approval_history_agent_id",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "idx_approval_history_created_at": {
+          "name": "idx_approval_history_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "approval_history_agent_id_agents_id_fk": {
+          "name": "approval_history_agent_id_agents_id_fk",
+          "tableFrom": "approval_history",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "boo_zero_team_briefs": {
+      "name": "boo_zero_team_briefs",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boo_zero_team_briefs_team_id_teams_id_fk": {
+          "name": "boo_zero_team_briefs_team_id_teams_id_fk",
+          "tableFrom": "boo_zero_team_briefs",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "chat_messages": {
+      "name": "chat_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_chat_messages_entry_id": {
+          "name": "uniq_chat_messages_entry_id",
+          "columns": ["entry_id"],
+          "isUnique": true
+        },
+        "idx_chat_messages_session_ts": {
+          "name": "idx_chat_messages_session_ts",
+          "columns": ["session_key", "timestamp_ms"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cost_records": {
+      "name": "cost_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cost_records_agent_id": {
+          "name": "idx_cost_records_agent_id",
+          "columns": ["agent_id"],
+          "isUnique": false
+        },
+        "idx_cost_records_run_id": {
+          "name": "idx_cost_records_run_id",
+          "columns": ["run_id"],
+          "isUnique": false
+        },
+        "idx_cost_records_created_at": {
+          "name": "idx_cost_records_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cost_records_agent_id_agents_id_fk": {
+          "name": "cost_records_agent_id_agents_id_fk",
+          "tableFrom": "cost_records",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graph_layouts": {
+      "name": "graph_layouts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "gateway_url": {
+          "name": "gateway_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "layout_data": {
+          "name": "layout_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_graph_layouts_name_url": {
+          "name": "uniq_graph_layouts_name_url",
+          "columns": ["name", "gateway_url"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trust_score": {
+          "name": "trust_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skills_source": {
+          "name": "idx_skills_source",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "idx_skills_category": {
+          "name": "idx_skills_category",
+          "columns": ["category"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_profiles": {
+      "name": "team_profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agents_config": {
+          "name": "agents_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skills_config": {
+          "name": "skills_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph_layout": {
+          "name": "graph_layout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_builtin": {
+          "name": "is_builtin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "leader_agent_id": {
+          "name": "leader_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_teams_name": {
+          "name": "idx_teams_name",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773945997901,
       "tag": "0002_material_jackpot",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1778519394862,
+      "tag": "0003_flawless_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -140,6 +140,12 @@ export function createDb(dbPath: string): ClawbooDb {
       ON chat_messages (entry_id);
     CREATE INDEX IF NOT EXISTS idx_chat_messages_session_ts
       ON chat_messages (session_key, timestamp_ms);
+
+    CREATE TABLE IF NOT EXISTS boo_zero_team_briefs (
+      team_id    TEXT    PRIMARY KEY REFERENCES teams(id) ON DELETE CASCADE,
+      content    TEXT    NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
   `)
 
   // Existing-DB migrations: add columns that CREATE TABLE IF NOT EXISTS won't add.

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,6 +2,7 @@
 export {
   agents,
   approvalHistory,
+  booZeroTeamBriefs,
   chatMessages,
   costRecords,
   graphLayouts,
@@ -16,6 +17,8 @@ export type {
   DbAgentInsert,
   DbApprovalHistory,
   DbApprovalHistoryInsert,
+  DbBooZeroTeamBrief,
+  DbBooZeroTeamBriefInsert,
   DbChatMessage,
   DbChatMessageInsert,
   DbCostRecord,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -147,6 +147,26 @@ export const teamProfiles = sqliteTable('team_profiles', {
   createdAt: integer('created_at').notNull(),
 })
 
+// ─── boo_zero_team_briefs ─────────────────────────────────────────────────────
+// Per-team context briefs that Boo Zero (the universal team leader) reads
+// when operating on a team. One row per team. Content is markdown.
+//
+// Backs the SQLite-first "virtual file" model — surfaced as editable docs in
+// the UI, injected into Boo Zero's context preamble at runtime.
+//
+// FK cascades on team delete so we don't leak orphaned briefs.
+
+export const booZeroTeamBriefs = sqliteTable('boo_zero_team_briefs', {
+  teamId: text('team_id')
+    .primaryKey()
+    .references(() => teams.id, { onDelete: 'cascade' }),
+  content: text('content').notNull(),
+  updatedAt: integer('updated_at').notNull(),
+})
+
+export type DbBooZeroTeamBrief = typeof booZeroTeamBriefs.$inferSelect
+export type DbBooZeroTeamBriefInsert = typeof booZeroTeamBriefs.$inferInsert
+
 // ─── approval_history ─────────────────────────────────────────────────────────
 
 export const approvalHistory = sqliteTable(

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -514,6 +514,31 @@ export class GatewayClient {
       },
     ): Promise<SessionPatchResult> =>
       this.call<SessionPatchResult>('sessions.patch', { key, ...updates }),
+
+    /**
+     * Heavier session-level abort. Where `chat.abort` cancels a specific
+     * `runId`, `sessions.abort` aborts whatever is currently running on
+     * the session AND clears any queued/pending state.
+     *
+     * `runId` is optional: when omitted, the Gateway resolves the active
+     * run from `key`. We use this as the runId-less fallback in the Stop
+     * button path — when a user presses Stop very fast (before the first
+     * streaming event has landed and populated `agent.runId`), the
+     * surgical `chat.abort(sessionKey, runId)` is a no-op because we
+     * don't have a runId yet; `sessions.abort(key)` still does the right
+     * thing.
+     *
+     * Response shape mirrors `chat.abort` — `status: 'no-active-run'` is
+     * a benign no-op when the session is already idle.
+     */
+    abort: (
+      key: string,
+      runId?: string,
+    ): Promise<{ ok: boolean; abortedRunId?: string | null; status?: string }> =>
+      this.call<{ ok: boolean; abortedRunId?: string | null; status?: string }>(
+        'sessions.abort',
+        runId ? { key, runId } : { key },
+      ),
   }
 
   readonly config = {

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -522,4 +522,26 @@ export class GatewayClient {
     patch: (updates: Partial<GatewayConfig>): Promise<void> =>
       this.call<void>('config.patch', updates),
   }
+
+  // ── chat namespace ────────────────────────────────────────────────────────
+  // Currently only exposes `abort` (used by the chat composer's Stop button).
+  // `chat.send` is still called inline via `client.call('chat.send', …)` from
+  // `chatSendOperation.ts` / `groupChatSendOperation.ts` because those paths
+  // need to thread `displayText` overrides through the existing pipeline.
+  readonly chat = {
+    /**
+     * Cancel the in-flight LLM run on a session. The Gateway responds with
+     * `{ ok, abortedRunId, status }`. `status: 'no-active-run'` is a benign
+     * no-op when the run has already finished, so callers don't need to
+     * special-case it — local state is cleared optimistically anyway.
+     */
+    abort: (
+      sessionKey: string,
+      runId: string,
+    ): Promise<{ ok: boolean; abortedRunId?: string | null; status?: string }> =>
+      this.call<{ ok: boolean; abortedRunId?: string | null; status?: string }>('chat.abort', {
+        sessionKey,
+        runId,
+      }),
+  }
 }


### PR DESCRIPTION
## Summary

- Integrates Boo Zero into team management flows, including display name handling, team selection behavior, and Boo Zero-specific graph/orbital support.
- Enhances chat and group chat experiences with improved team mentions, embedded chat panels, stop-generation controls, and streamlined orchestration handling.
- Improves graph and layout behavior with team/atlas scoping, updated BooNode rendering, better halo rendering, re-layout controls, and smoother navigation across teams and group chat views.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed yet — app-level Boo Zero/chat/graph feature work unless this is the final release-ready package or CLI change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff