### PR TITLE
feat(chat): improve delegation, workstreams, and team rule handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,20 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build
+
+  verify-ingest:
+    name: Verify marketplace ingest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm verify:ingest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm verify:ingest
+
       - run: pnpm build
 
       - run: bash scripts/assemble-cli.sh

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,48 @@
+# clawboo
+
+> Your AI agents, visible. — The open-source AI Agent Team Studio for [OpenClaw](https://github.com/openclaw/openclaw) agent teams.
+
+## Quick start
+
+```bash
+npx clawboo
+```
+
+That's it. The first run launches an onboarding wizard that:
+
+1. Detects whether Node.js, OpenClaw, and the Gateway are installed.
+2. Guides you through any missing pieces (provider API key, gateway start).
+3. Opens the dashboard in your browser at `http://localhost:18790` (auto-fallback through `18809` if busy).
+
+If you already have OpenClaw running, the CLI auto-connects.
+
+## What you get
+
+- **Browse 304 first-class agents** across 82 prebuilt teams (workflow templates from [agency-agents](https://github.com/msitarzewski/agency-agents) + [awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases) + Clawboo's own catalog).
+- **Deploy a team in one click** — name, icon, color, then provisioned to your local OpenClaw with full per-agent `SOUL.md` / `IDENTITY.md` / `TOOLS.md` / `AGENTS.md`.
+- **Group chat with structured `<delegate>` routing** — the leader (Boo Zero) coordinates parallel workstreams and multi-step plans; teammates respond inside `DelegationCard`s with progress, completion, and synthesis cues.
+- **Ghost Graph** — live force-directed visualisation of your fleet: every Boo, every skill, every routing edge, every team.
+- **Approvals, cost tracking, cron scheduler, skill marketplace** — bundled.
+
+## Requirements
+
+- Node.js **22+**
+- An OpenClaw provider API key (Anthropic, OpenAI, Google, Ollama, or one of 11 OpenRouter-tier providers) — the wizard prompts you.
+
+## Where state lives
+
+All your state stays on your machine:
+
+- `~/.openclaw/clawboo/clawboo.db` — Clawboo's SQLite metadata (teams, settings, cost records, etc.).
+- `~/.openclaw/clawboo/settings.json` — connection + auth token.
+- `~/.openclaw/agents/<agentId>/` — each agent's own workspace (managed by the OpenClaw Gateway).
+
+The npm package ships only template content (the marketplace catalog and the orchestration generators). Nothing you do at runtime touches the package.
+
+## Full docs
+
+For the full architecture, screenshots, contributing guide, and roadmap, see the [main repo README](https://github.com/clawboo/clawboo#readme).
+
+## License
+
+MIT

--- a/apps/web/server/api/agents.ts
+++ b/apps/web/server/api/agents.ts
@@ -1,7 +1,17 @@
 import type { Request, Response } from 'express'
-import { createDb, agents, costRecords, approvalHistory } from '@clawboo/db'
+import { createDb, agents, costRecords, approvalHistory, settings } from '@clawboo/db'
 import { eq, sql, inArray } from 'drizzle-orm'
 import { getDbPath } from '../lib/db'
+
+// Per-agent `settings` keys that should be removed alongside the agent row.
+// Today the only per-agent key is `boo-zero:display-name:<agentId>` (see
+// `server/api/booZero.ts` DISPLAY_NAME_KEY_PREFIX). Add new prefixes here
+// whenever a per-agent settings key is introduced — the helper is consumed
+// by BOTH `agentsDELETE` (single agent) and `agentsCleanupPOST` (ghost
+// sweep) so adding a row stays a one-line change.
+function perAgentSettingKeys(agentId: string): string[] {
+  return [`boo-zero:display-name:${agentId}`]
+}
 
 // ─── DELETE /api/agents/:agentId ─────────────────────────────────────────────
 //
@@ -27,6 +37,11 @@ export function agentsDELETE(req: Request, res: Response): void {
     // Order matters — children before parent.
     db.delete(costRecords).where(eq(costRecords.agentId, agentId)).run()
     db.delete(approvalHistory).where(eq(approvalHistory.agentId, agentId)).run()
+    // Per-agent KV settings (display-name override etc.) don't FK to
+    // `agents` so they'd otherwise survive the agent delete and rot in
+    // SQLite. Wipe them in lock-step.
+    const settingKeys = perAgentSettingKeys(agentId)
+    db.delete(settings).where(inArray(settings.key, settingKeys)).run()
     db.delete(agents).where(eq(agents.id, agentId)).run()
     res.json({ ok: true })
   } catch (err) {
@@ -85,6 +100,11 @@ export function agentsCleanupPOST(req: Request, res: Response): void {
     // Children before parent (FK guards).
     db.delete(costRecords).where(inArray(costRecords.agentId, toDelete)).run()
     db.delete(approvalHistory).where(inArray(approvalHistory.agentId, toDelete)).run()
+    // Per-agent KV settings (no FK to `agents`) — same sweep, same scope.
+    const settingKeys = toDelete.flatMap(perAgentSettingKeys)
+    if (settingKeys.length > 0) {
+      db.delete(settings).where(inArray(settings.key, settingKeys)).run()
+    }
     db.delete(agents).where(inArray(agents.id, toDelete)).run()
 
     // Sanity-log how many remain — useful when debugging via curl.

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -29,6 +29,7 @@ import {
 } from './teams'
 import { agentsDELETE, agentsCleanupPOST } from './agents'
 import { teamOnboardingGET, teamOnboardingPATCH } from './teamOnboarding'
+import { teamRulesGET, teamRulesPUT } from './teamRules'
 import {
   teamBriefGET,
   teamBriefPUT,
@@ -100,6 +101,11 @@ router.delete('/api/teams/:id/agents/:agentId', teamAgentDELETE)
 // Team onboarding (per-team boolean flags for "Know Your Team" gate)
 router.get('/api/teams/:id/onboarding', teamOnboardingGET)
 router.patch('/api/teams/:id/onboarding', teamOnboardingPATCH)
+
+// Team rules — user-captured rules injected into every team agent's preamble.
+// Source: maintenance panel textarea OR /rule slash command in the composer.
+router.get('/api/team-rules/:teamId', teamRulesGET)
+router.put('/api/team-rules/:teamId', teamRulesPUT)
 
 // Agents — local SQLite metadata cleanup. Gateway is the source of truth for
 // agent identity, so there's no `create` or `list` here — only delete + the

--- a/apps/web/server/api/teamRules.ts
+++ b/apps/web/server/api/teamRules.ts
@@ -1,0 +1,91 @@
+// Team rules — durable per-team rules text persisted in the settings
+// key/value table. The user captures rules either via the maintenance
+// panel textarea OR via the `/rule <text>` slash command in the team
+// chat composer; either path writes here.
+//
+// The rules text is injected into the message preamble for every team
+// agent (and Boo Zero in team scope) so user corrections survive across
+// sessions. Without this, rules like "don't do work yourself, delegate
+// via <delegate>" rolled out of the last-8-messages context window
+// within an hour and agents repeated the same mistakes.
+
+import type { Request, Response } from 'express'
+import { createDb, getSetting, setSetting } from '@clawboo/db'
+import { getDbPath } from '../lib/db'
+
+interface TeamRules {
+  content: string
+}
+
+const DEFAULT_RULES: TeamRules = { content: '' }
+const MAX_RULES_CHARS = 4000
+
+function settingsKey(teamId: string): string {
+  return `team-rules:${teamId}`
+}
+
+export function readTeamRules(db: ReturnType<typeof createDb>, teamId: string): TeamRules {
+  const raw = getSetting(db, settingsKey(teamId))
+  if (!raw) return { ...DEFAULT_RULES }
+  try {
+    const parsed = JSON.parse(raw) as Partial<TeamRules>
+    return {
+      content: typeof parsed.content === 'string' ? parsed.content : '',
+    }
+  } catch {
+    return { ...DEFAULT_RULES }
+  }
+}
+
+// ─── GET /api/team-rules/:teamId ─────────────────────────────────────────────
+
+export function teamRulesGET(req: Request, res: Response): void {
+  const teamId = req.params['teamId'] as string | undefined
+  if (!teamId) {
+    res.status(400).json({ error: 'team id required' })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    const rules = readTeamRules(db, teamId)
+    res.json(rules)
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}
+
+// ─── PUT /api/team-rules/:teamId ─────────────────────────────────────────────
+// Body: { content: string }. Capped at MAX_RULES_CHARS server-side.
+
+interface PutBody {
+  content?: string
+}
+
+export function teamRulesPUT(req: Request, res: Response): void {
+  const teamId = req.params['teamId'] as string | undefined
+  if (!teamId) {
+    res.status(400).json({ error: 'team id required' })
+    return
+  }
+  const body = req.body as PutBody | undefined
+  if (!body || typeof body !== 'object') {
+    res.status(400).json({ error: 'invalid JSON' })
+    return
+  }
+  if (typeof body.content !== 'string') {
+    res.status(400).json({ error: 'content (string) required' })
+    return
+  }
+  if (body.content.length > MAX_RULES_CHARS) {
+    res.status(400).json({ error: `content exceeds ${MAX_RULES_CHARS} characters` })
+    return
+  }
+  try {
+    const db = createDb(getDbPath())
+    const next: TeamRules = { content: body.content }
+    setSetting(db, settingsKey(teamId), JSON.stringify(next))
+    res.json(next)
+  } catch (err) {
+    res.status(500).json({ error: String(err) })
+  }
+}

--- a/apps/web/server/api/teams.ts
+++ b/apps/web/server/api/teams.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto'
 import type { Request, Response } from 'express'
-import { createDb, teams, agents } from '@clawboo/db'
-import { eq, sql } from 'drizzle-orm'
+import { createDb, teams, agents, settings } from '@clawboo/db'
+import { eq, inArray, sql } from 'drizzle-orm'
 import { getDbPath } from '../lib/db'
 
 // ─── GET /api/teams ──────────────────────────────────────────────────────────
@@ -171,7 +171,13 @@ export function teamsPATCH(req: Request, res: Response): void {
 }
 
 // ─── DELETE /api/teams/:id ───────────────────────────────────────────────────
-// Deletes the team and orphans its agents (sets teamId = null).
+// Deletes the team and orphans its agents (sets teamId = null). Also cleans
+// up any team-scoped settings rows so deleted teams don't leave durable rows
+// behind in the key/value store:
+//   - `team-rules:<teamId>`     — user-captured rules
+//   - `team-onboarding:<teamId>` — onboarding flags + user intro text
+// The `boo_zero_team_briefs` table FK-cascades on team delete (see schema),
+// so that one cleans itself.
 
 export function teamsDELETE(req: Request, res: Response): void {
   const teamId = req.params['id'] as string | undefined
@@ -186,7 +192,15 @@ export function teamsDELETE(req: Request, res: Response): void {
     // Orphan agents belonging to this team
     db.update(agents).set({ teamId: null }).where(eq(agents.teamId, teamId)).run()
 
-    // Delete the team
+    // Clean up team-scoped settings rows. Drizzle's `inArray` matches the
+    // exact keys we wrote in `teamRules.ts` + `teamOnboarding.ts`. Safe to
+    // run unconditionally — `delete ... where` is a no-op when no row
+    // matches.
+    db.delete(settings)
+      .where(inArray(settings.key, [`team-rules:${teamId}`, `team-onboarding:${teamId}`]))
+      .run()
+
+    // Delete the team (boo_zero_team_briefs FK-cascades).
     db.delete(teams).where(eq(teams.id, teamId)).run()
 
     res.json({ ok: true })

--- a/apps/web/src/features/agent-detail/InlineEditor.tsx
+++ b/apps/web/src/features/agent-detail/InlineEditor.tsx
@@ -18,10 +18,15 @@ import { clawbooEditorTheme } from '@/features/editor/editorTheme'
 import { useAgentFiles, CORE_FILE_TABS, ALL_FILE_TABS } from '@/features/editor/useAgentFiles'
 import { PersonalitySliders } from '@/features/settings/PersonalitySliders'
 import { ExecSettings } from '@/features/settings/ExecSettings'
+import { useBooZeroStore } from '@/stores/booZero'
+import { useFleetStore } from '@/stores/fleet'
+import { DisplayNameEditor } from '@/features/boo-zero/DisplayNameEditor'
+import { GlobalBriefEditor } from '@/features/boo-zero/GlobalBriefEditor'
 
 // ─── Tab types ───────────────────────────────────────────────────────────────
 
-type EditorTab = 'personality' | 'permissions' | AgentFileName
+// `'brief'` is Boo-Zero-only — gated by `isBooZero` at the tab-list level.
+type EditorTab = 'personality' | 'permissions' | 'brief' | AgentFileName
 
 const FILE_TAB_LABELS: Record<AgentFileName, string> = {
   'SOUL.md': 'SOUL',
@@ -36,7 +41,13 @@ const FILE_TAB_LABELS: Record<AgentFileName, string> = {
 function getTabLabel(tab: EditorTab): string {
   if (tab === 'personality') return 'Personality'
   if (tab === 'permissions') return 'Permissions'
+  if (tab === 'brief') return 'Brief'
   return FILE_TAB_LABELS[tab] ?? tab.replace('.md', '')
+}
+
+/** Type guard: is this tab one of the file-backed CodeMirror tabs? */
+function isAgentFileTab(tab: EditorTab): tab is AgentFileName {
+  return tab !== 'personality' && tab !== 'permissions' && tab !== 'brief'
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -63,9 +74,24 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
     return [...coreTabs, ...extras]
   }, [fileExists])
 
+  // The Brief tab is Boo-Zero-only — it holds the Display Name override + the
+  // Global Brief (Boo Zero's load-bearing identity surface). Other agents
+  // don't get the tab at all, so the tab strip stays clean.
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const isBooZero = booZeroAgentId !== null && booZeroAgentId === agentId
+  // Pull the latest display name from the fleet store so the editor sees
+  // whatever override is currently applied (rather than a stale prop).
+  const liveAgent = useFleetStore((s) => s.agents.find((a) => a.id === agentId) ?? null)
+  const liveAgentName = liveAgent?.name ?? agentName
+
   const allTabs: EditorTab[] = useMemo(
-    () => ['personality', 'permissions', ...visibleFileTabs],
-    [visibleFileTabs],
+    () => [
+      'personality',
+      'permissions',
+      ...(isBooZero ? (['brief'] as const) : []),
+      ...visibleFileTabs,
+    ],
+    [visibleFileTabs, isBooZero],
   )
 
   const [activeTab, setActiveTab] = useState<EditorTab>('personality')
@@ -115,7 +141,7 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
             key: 'Mod-s',
             run: () => {
               const tab = activeTabRef.current
-              if (tab !== 'personality' && tab !== 'permissions') {
+              if (isAgentFileTab(tab)) {
                 void handleSaveRef.current(tab)
               }
               return true
@@ -127,7 +153,7 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
         EditorView.updateListener.of((update) => {
           if (update.docChanged) {
             const tab = activeTabRef.current
-            if (tab !== 'personality' && tab !== 'permissions') {
+            if (isAgentFileTab(tab)) {
               updateFileContent(tab, update.state.doc.toString())
             }
           }
@@ -150,7 +176,7 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
     const view = viewRef.current
     if (!view || loading) return
 
-    if (activeTab === 'personality' || activeTab === 'permissions') return
+    if (!isAgentFileTab(activeTab)) return
 
     const fileState = filesRef.current[activeTab]
     if (!fileState) return
@@ -163,22 +189,20 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
     }
 
     view.dispatch({
-      effects: placeholderComp.current.reconfigure(
-        placeholder(AGENT_FILE_PLACEHOLDERS[activeTab as AgentFileName]),
-      ),
+      effects: placeholderComp.current.reconfigure(placeholder(AGENT_FILE_PLACEHOLDERS[activeTab])),
     })
   }, [activeTab, loading])
 
   // ─── Active file tab data ─────────────────────────────────────────────────
 
-  const isFileTab = activeTab !== 'personality' && activeTab !== 'permissions'
-  const isFileDirty = isFileTab && isDirty(activeTab as AgentFileName)
+  const isFileTab = isAgentFileTab(activeTab)
+  const isFileDirty = isFileTab && isDirty(activeTab)
 
   const onSaveClick = useCallback(() => {
-    if (isFileTab) {
-      void handleSave(activeTab as AgentFileName)
+    if (isAgentFileTab(activeTab)) {
+      void handleSave(activeTab)
     }
-  }, [handleSave, activeTab, isFileTab])
+  }, [handleSave, activeTab])
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
@@ -206,8 +230,7 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
       >
         {allTabs.map((tab) => {
           const isActive = tab === activeTab
-          const dirty =
-            tab !== 'personality' && tab !== 'permissions' && isDirty(tab as AgentFileName)
+          const dirty = isAgentFileTab(tab) && isDirty(tab)
           return (
             <button
               key={tab}
@@ -321,12 +344,56 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
           </div>
         )}
 
-        {/* CodeMirror container — hidden (not destroyed) when personality tab active */}
+        {/* Brief tab — Boo Zero only (gated at allTabs construction).
+            Holds the Display Name override + the Global Brief — the
+            load-bearing identity surface that runs through every Boo
+            Zero turn. */}
+        {activeTab === 'brief' && isBooZero && (
+          <div
+            style={{
+              height: '100%',
+              overflowY: 'auto',
+              padding: '12px 16px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 18,
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'rgba(232,232,232,0.85)',
+                }}
+              >
+                Display name
+              </h3>
+              <DisplayNameEditor agentId={agentId} currentName={liveAgentName} />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'rgba(232,232,232,0.85)',
+                }}
+              >
+                Global brief
+              </h3>
+              <GlobalBriefEditor />
+            </div>
+          </div>
+        )}
+
+        {/* CodeMirror container — hidden (not destroyed) when a non-file tab is active */}
         <div
           ref={editorContainerRef}
           style={{
             height: '100%',
-            display: activeTab === 'personality' || activeTab === 'permissions' ? 'none' : 'block',
+            display: isAgentFileTab(activeTab) ? 'block' : 'none',
           }}
         />
       </div>
@@ -351,7 +418,9 @@ export function InlineEditor({ agentId, agentName }: { agentId: string; agentNam
             ? `${agentName} · Personality`
             : activeTab === 'permissions'
               ? `${agentName} · Permissions`
-              : AGENT_FILE_META[activeTab as AgentFileName].hint}
+              : activeTab === 'brief'
+                ? `${agentName} · Brief — display name + global brief`
+                : AGENT_FILE_META[activeTab].hint}
         </span>
         <span>
           {anyDirty ? 'Unsaved' : 'Saved'}

--- a/apps/web/src/features/boo-zero/DisplayNameEditor.tsx
+++ b/apps/web/src/features/boo-zero/DisplayNameEditor.tsx
@@ -1,0 +1,120 @@
+// DisplayNameEditor — the override that controls how Boo Zero refers to
+// itself in chat. Stored in SQLite via `/api/boo-zero/display-name/:agentId`
+// and overlaid on the fleet entry at hydration time (see GatewayBootstrap).
+//
+// Saving also fires an auto-sync to the Gateway-side SOUL.md heading
+// (best-effort) so the LLM's persisted identity aligns with the override.
+// The per-turn rules block in `lib/booZeroRules.ts` is the authoritative
+// anchor either way.
+//
+// Lives under `features/boo-zero/` because the editor is Boo-Zero-agent-
+// scoped. Rendered by the Boo Zero individual agent's `Brief` tab in
+// `InlineEditor`. (Also re-exported for the System breadcrumb to point at.)
+
+import { useCallback, useState } from 'react'
+import { Loader2, Save } from 'lucide-react'
+import { useConnectionStore } from '@/stores/connection'
+import { useToastStore } from '@/stores/toast'
+import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
+
+export function DisplayNameEditor({
+  agentId,
+  currentName,
+}: {
+  agentId: string
+  currentName: string
+}) {
+  const [value, setValue] = useState<string>(currentName)
+  const [saving, setSaving] = useState<boolean>(false)
+  const isDirty = value.trim() !== currentName.trim()
+  const client = useConnectionStore((s) => s.client)
+
+  const handleSave = useCallback(async () => {
+    const trimmed = value.trim() || 'Boo Zero'
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(agentId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: trimmed }),
+      })
+      if (!res.ok) throw new Error('Save failed')
+
+      // Auto-sync the new display name into Boo Zero's SOUL.md. The user's
+      // act of pressing Save IS the approval — they don't need a separate
+      // sync button. Best-effort (Gateway `agents.files.set('SOUL.md')` is
+      // documented unreliable); the per-turn rules block remains the
+      // authoritative identity surface either way.
+      if (client) {
+        void syncBooZeroSoulIdentity({ client, agentId, displayName: trimmed })
+      }
+      useToastStore.getState().addToast({
+        type: 'success',
+        message: `Boo Zero display name → "${trimmed}". Reload to apply across all views.`,
+      })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [agentId, client, value])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        How Boo Zero refers to itself in chats. Defaults to <code>Boo Zero</code>. Stored in
+        Clawboo&apos;s SQLite. Saving automatically syncs the heading of Boo Zero&apos;s
+        <code> SOUL.md</code> too (best-effort — the per-turn rules block stays authoritative either
+        way).
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Boo Zero"
+          maxLength={80}
+          disabled={saving}
+          style={{
+            flex: 1,
+            height: 30,
+            padding: '0 10px',
+            fontSize: 12,
+            fontFamily: 'var(--font-body, sans-serif)',
+            background: 'rgba(13,17,23,0.85)',
+            color: '#E8E8E8',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: 6,
+          }}
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || saving || value.trim().length === 0}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: isDirty && value.trim().length > 0 ? '#E94560' : 'rgba(255,255,255,0.06)',
+            color: isDirty && value.trim().length > 0 ? '#fff' : 'rgba(232,232,232,0.5)',
+            cursor: !isDirty || saving || value.trim().length === 0 ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+          Save
+        </button>
+      </div>
+      {isDirty && (
+        <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved — save and reload to apply.</span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/boo-zero/GlobalBriefEditor.tsx
+++ b/apps/web/src/features/boo-zero/GlobalBriefEditor.tsx
@@ -1,0 +1,187 @@
+// GlobalBriefEditor — Boo Zero's overall responsibilities + auto-generated
+// index of the teams it leads. Stored in SQLite via `/api/boo-zero/global-brief`
+// and injected into Boo Zero's context preamble on every interaction.
+//
+// The `## Required behavior` section inside the brief is sourced from the
+// canonical `buildBooZeroRulesBlock` so what the user sees here matches
+// what the LLM sees at runtime (see `lib/booZeroBrief.ts`).
+//
+// Lives under `features/boo-zero/` because the editor is Boo-Zero-agent-
+// scoped. Rendered by the Boo Zero individual agent's `Brief` tab in
+// `InlineEditor`.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Loader2, RefreshCw, Save } from 'lucide-react'
+import { useTeamStore } from '@/stores/team'
+import { useToastStore } from '@/stores/toast'
+import { buildGlobalBrief } from '@/lib/booZeroBrief'
+
+interface BriefResponse {
+  content?: string | null
+  updatedAt?: number | null
+}
+
+async function fetchGlobalBrief(): Promise<BriefResponse> {
+  const res = await fetch('/api/boo-zero/global-brief')
+  if (!res.ok) throw new Error('Failed to load global brief')
+  return (await res.json()) as BriefResponse
+}
+
+async function putGlobalBrief(content: string): Promise<void> {
+  const res = await fetch('/api/boo-zero/global-brief', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) throw new Error('Failed to save global brief')
+}
+
+export function GlobalBriefEditor() {
+  const teams = useTeamStore((s) => s.teams)
+  const teamsRef = useRef(teams)
+  teamsRef.current = teams
+
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+  const seededRef = useRef<boolean>(false)
+
+  useEffect(() => {
+    // Intentionally seed exactly once on mount. Subsequent team changes
+    // shouldn't blow away user edits — they can press "Regenerate" if they
+    // want a fresh draft from the current team list. `teamsRef` is read at
+    // load-time so the initial default still reflects the current state.
+    if (seededRef.current) return
+    seededRef.current = true
+    let cancelled = false
+    setLoading(true)
+    fetchGlobalBrief()
+      .then((r) => {
+        if (cancelled) return
+        const value =
+          r.content && r.content.length > 0
+            ? r.content
+            : buildGlobalBrief({
+                teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
+              })
+        setContent(value)
+        setClean(value)
+      })
+      .catch(() => {
+        if (cancelled) return
+        const fallback = buildGlobalBrief({
+          teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
+        })
+        setContent(fallback)
+        setClean(fallback)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      await putGlobalBrief(content)
+      setClean(content)
+      useToastStore.getState().addToast({ type: 'success', message: 'Global brief saved' })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [content])
+
+  const handleRegenerate = useCallback(() => {
+    const fresh = buildGlobalBrief({
+      teams: teams.map((t) => ({ name: t.name, icon: t.icon })),
+    })
+    setContent(fresh)
+  }, [teams])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        Boo Zero&apos;s overall responsibilities + the list of teams it leads. Injected into Boo
+        Zero&apos;s context preamble on every interaction.
+      </p>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={loading || saving}
+        spellCheck={false}
+        style={{
+          width: '100%',
+          minHeight: 240,
+          maxHeight: 480,
+          padding: 12,
+          fontSize: 12,
+          fontFamily: 'var(--font-geist-mono, monospace)',
+          lineHeight: 1.55,
+          background: 'rgba(13,17,23,0.85)',
+          color: '#E8E8E8',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 8,
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || saving || loading}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+            color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+            cursor: !isDirty || saving || loading ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleRegenerate}
+          disabled={loading || saving}
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'rgba(255,255,255,0.04)',
+            color: 'rgba(232,232,232,0.7)',
+            cursor: loading || saving ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+          title="Regenerate from current team list (does not save yet)"
+        >
+          <RefreshCw size={12} />
+          Regenerate from teams
+        </button>
+        {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { InlineApprovalTray } from '@/features/approvals/InlineApprovalTray'
 import { parseTeamOrAgentMention } from '@/lib/parseTeamOrAgentMention'
 import { buildTeamContextPreamble } from '@/lib/teamProtocol'
+import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
 import { getMergedTeamEntries } from '@/features/group-chat/groupChatSendOperation'
 import { TeamChips } from './TeamChips'
 
@@ -111,14 +112,17 @@ export function ChatPanel({ agentId: propAgentId }: { agentId?: string } = {}) {
     async (message: string) => {
       if (!client || !agent || !sessionKey) return
 
-      // In Boo Zero's individual chat, inject the identity anchor + (when
-      // the user `@TeamName`-mentions) the matching team brief. The
-      // identity anchor fires on EVERY message so the LLM stays consistent
-      // about its name. Outside Boo Zero's chat (regular agent 1:1), this
-      // path is bypassed — team agents have their own AGENTS.md / SOUL.md
-      // identity.
+      // In Boo Zero's individual chat, inject the rules block + (when the
+      // user `@TeamName`-mentions) the matching team brief. The rules block
+      // carries identity + load-bearing behavioral rules (delegate first,
+      // don't do work yourself, no Task tool, no resume greetings) and
+      // fires on EVERY message so the LLM stays consistent. Outside Boo
+      // Zero's chat (regular agent 1:1), this path is bypassed — team
+      // agents have their own AGENTS.md / SOUL.md identity.
       if (isBooZeroChat) {
-        const identityBlock = `[Your Identity]\nYou are ${agent.name}. This is your name — the only name you should use to refer to yourself. Do NOT invent alternative names mid-response.\n[End Your Identity]`
+        // No teamName in the 1:1 chat path — Boo Zero coordinates across
+        // every team here, not within any single team's scope.
+        const identityBlock = buildBooZeroRulesBlock({ displayName: agent.name })
 
         const teamCandidates = teams.map((t) => ({ id: t.id, name: t.name }))
         const mention = parseTeamOrAgentMention(message, teamCandidates)

--- a/apps/web/src/features/chat/__tests__/splitAssistantText.test.ts
+++ b/apps/web/src/features/chat/__tests__/splitAssistantText.test.ts
@@ -14,9 +14,16 @@ describe('splitAssistantText', () => {
 
   it('returns a single delegation segment when text is just a delegate block', () => {
     const result = splitAssistantText('<delegate to="@Bug Fixer Boo">fix the parser</delegate>')
-    expect(result).toEqual([
-      { kind: 'delegation', targetName: 'Bug Fixer Boo', task: 'fix the parser' },
-    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      kind: 'delegation',
+      targetName: 'Bug Fixer Boo',
+      task: 'fix the parser',
+    })
+    // blockStart/blockEnd carried through from findDelegationBlocks
+    const seg = result[0] as { blockStart: number; blockEnd: number }
+    expect(seg.blockStart).toBe(0)
+    expect(seg.blockEnd).toBeGreaterThan(0)
   })
 
   it('preserves order: prose, delegation, prose', () => {
@@ -29,7 +36,7 @@ Let me know what you find.`
     expect(result).toHaveLength(3)
     expect(result[0]).toMatchObject({ kind: 'prose' })
     expect((result[0] as { text: string }).text).toContain("Here's the plan")
-    expect(result[1]).toEqual({
+    expect(result[1]).toMatchObject({
       kind: 'delegation',
       targetName: 'Bug Fixer Boo',
       task: 'fix the parser',
@@ -98,5 +105,23 @@ Check JWT signing for null safety.
     const text = '<delegate to="Bug Fixer Boo">fix the parser</delegate>'
     const result = splitAssistantText(text)
     expect((result[0] as { targetName: string }).targetName).toBe('Bug Fixer Boo')
+  })
+
+  it('preserves distinct blockStart offsets for multiple delegations in same text', () => {
+    const text = `Plan:
+<delegate to="@A">first</delegate>
+mid prose
+<delegate to="@B">second</delegate>`
+    const result = splitAssistantText(text)
+    const dels = result.filter(
+      (s): s is Extract<typeof s, { kind: 'delegation' }> => s.kind === 'delegation',
+    )
+    expect(dels).toHaveLength(2)
+    expect(dels[0]!.blockStart).toBeLessThan(dels[1]!.blockStart)
+    expect(dels[0]!.blockEnd).toBeLessThan(dels[1]!.blockStart)
+    // The blockStart for each delegation matches the actual character index
+    // of '<delegate' in the source text.
+    expect(text.slice(dels[0]!.blockStart, dels[0]!.blockStart + 9)).toBe('<delegate')
+    expect(text.slice(dels[1]!.blockStart, dels[1]!.blockStart + 9)).toBe('<delegate')
   })
 })

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -25,6 +25,8 @@ import {
   buildDelegationLinkages,
   type DelegationLinkage,
 } from '@/features/group-chat/buildDelegationLinkages'
+import { shouldDropAssistantTurn } from '@/lib/teamProtocol'
+import { parseToolEntry } from './parseToolEntry'
 import { splitAssistantText } from './splitAssistantText'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -42,20 +44,11 @@ export const formatDuration = (ms: number) => {
   return s < 10 ? `${s.toFixed(1)}s` : `${Math.round(s)}s`
 }
 
-/** Parse [[tool]] / [[tool-result]] lines from the protocol. */
-export function parseToolEntry(
-  text: string,
-): { kind: 'call' | 'result'; name: string; body: string } | null {
-  const isCall = text.startsWith('[[tool]]')
-  const isResult = text.startsWith('[[tool-result]]')
-  if (!isCall && !isResult) return null
-  const prefix = isCall ? '[[tool]]' : '[[tool-result]]'
-  const rest = text.slice(prefix.length)
-  const nl = rest.indexOf('\n')
-  const name = (nl === -1 ? rest : rest.slice(0, nl)).trim()
-  const body = nl === -1 ? '' : rest.slice(nl + 1).trim()
-  return { kind: isCall ? 'call' : 'result', name, body }
-}
+// `parseToolEntry` lives in its own module so `buildDelegationLinkages` can
+// import it without a circular reference through chatComponents (which itself
+// imports `buildDelegationLinkages`). Re-exported here so existing consumers
+// keep working.
+export { parseToolEntry } from './parseToolEntry'
 
 /**
  * Inline @mention highlighting for group chat messages.
@@ -147,10 +140,14 @@ export function groupEntriesToBlocks(entries: TranscriptEntry[]): RenderBlock[] 
   for (const entry of entries) {
     // Skip injected context preamble entries (should not appear in UI)
     if (entry.text.startsWith('[Team Context')) continue
-    // Skip the resume-ack token — the wake message asks the agent to reply
-    // with EXACTLY `__resumed__` to confirm session warmup. The literal
-    // token is a protocol artifact, not chat content the user should see.
-    if (entry.text.trim() === '__resumed__') continue
+    // Drop broken-shape assistant turns: OpenClaw protocol control tokens
+    // (ANNOUNCE_SKIP / NO_REPLY / NO), Clawboo control tokens (__resumed__,
+    // __skipped__), and short refusal-shape leaks. See `shouldDropAssistantTurn`
+    // in `lib/teamProtocol.ts` for the canonical filter (extracted as a
+    // shared utility so the delegation source scanner uses the same gate).
+    // Meta and user entries pass through — the filter only catches assistant
+    // turns whose entire body is a broken-shape signal.
+    if (entry.role === 'assistant' && shouldDropAssistantTurn(entry.text)) continue
 
     if (entry.kind === 'meta') {
       commitTurn()
@@ -488,13 +485,50 @@ export const DelegationCard = memo(function DelegationCard({
       <div className="flex items-center gap-2">
         <BooAvatar seed={avatarSeed} size={20} />
         <ArrowRight size={11} style={{ color: `${tint}b3` }} />
-        <span
-          className="font-mono text-[10px] font-semibold uppercase tracking-widest"
-          style={{ color: tint }}
-        >
-          Delegated to
-        </span>
+        {(() => {
+          // Round 7: verb + badge differ by routing source so the user can
+          // tell apart "the LLM explicitly delegated" vs. "Clawboo
+          // routed this on the LLM's behalf".
+          const src = linkage?.source ?? 'delegate-tag'
+          const verb = src === 'clawboo-relay' ? 'Routed to' : 'Delegated to'
+          return (
+            <span
+              className="font-mono text-[10px] font-semibold uppercase tracking-widest"
+              style={{ color: tint }}
+            >
+              {verb}
+            </span>
+          )
+        })()}
         <span className="font-mono text-[10px] font-medium text-text">@{targetName}</span>
+        {(() => {
+          // Show an origin badge for the non-canonical paths so the user
+          // sees the routing wasn't an explicit `<delegate>` tag.
+          const src = linkage?.source ?? 'delegate-tag'
+          if (src === 'clawboo-dispatch') {
+            return (
+              <span
+                className="ml-1 rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
+                style={{ color: tint, background: `${tint}1a` }}
+                title="Clawboo dispatched this to the target on the LLM's behalf (fallback regex match)"
+              >
+                via clawboo
+              </span>
+            )
+          }
+          if (src === 'clawboo-relay') {
+            return (
+              <span
+                className="ml-1 rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
+                style={{ color: 'rgba(232,232,232,0.55)', background: 'rgba(255,255,255,0.06)' }}
+                title="Clawboo forwarded the source's response to this teammate as a [Team Update]"
+              >
+                routed
+              </span>
+            )
+          }
+          return null
+        })()}
         {canCollapse && (
           <button
             type="button"
@@ -736,6 +770,7 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
   agentName,
   streaming,
   linkagesBySourceEntry,
+  claimedEntries,
   teamId,
   latestSourceEntryId,
   isFollowup = false,
@@ -746,6 +781,14 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
   streaming?: boolean
   /** Group-chat-only: pass-through so DelegationCard segments can nest target replies. */
   linkagesBySourceEntry?: Map<string, DelegationLinkage[]>
+  /**
+   * Group-chat-only: ids of tool entries claimed by Round 6's
+   * `sessions_send` linkage scan. Those entries already render as
+   * DelegationCards inside the prose region — the raw `[[tool]]`
+   * `ToolCallCard` is suppressed so the same routing event doesn't appear
+   * twice. Defaults to an empty set when omitted (1:1 chat path).
+   */
+  claimedEntries?: Set<string>
   /** Group-chat-only: needed by nested DelegationCards to resolve target session keys. */
   teamId?: string
   /** Group-chat-only: source entryId whose delegations default-expand (newest exposed). */
@@ -760,7 +803,14 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
 }) {
   const isRelay = isTeamUpdateEntry(block.assistant)
   const hasThinking = block.thinking.length > 0
-  const hasTools = block.tools.length > 0
+  // Round 6: filter tool entries claimed by `sessions_send` linkages — those
+  // render as DelegationCards inside the prose region below; rendering the
+  // raw `[[tool]] sessions_send` ToolCallCard would duplicate the routing
+  // event visually.
+  const visibleTools = claimedEntries
+    ? block.tools.filter((entry) => !claimedEntries.has(entry.entryId))
+    : block.tools
+  const hasTools = visibleTools.length > 0
   const hasText = Boolean(block.assistant?.text)
   const charCount = block.assistant?.text?.length ?? 0
   const runId = block.assistant?.runId ?? null
@@ -816,62 +866,103 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
         />
       )}
 
-      {/* Tool calls */}
+      {/* Tool calls (after filtering out Round 6's `sessions_send` entries
+          that already render as DelegationCards in the prose region below). */}
       {hasTools && (
         <div className="flex flex-col gap-1">
-          {block.tools.map((entry) => (
+          {visibleTools.map((entry) => (
             <ToolCallCard key={entry.entryId} entry={entry} />
           ))}
         </div>
       )}
 
-      {/* Assistant text — strip prefix for relay messages, split structured
-          delegation blocks out into their own cards. Relay messages don't
-          contain `<delegate>` blocks (they're condensed summaries), so the
-          split returns a single prose segment for them.
+      {/* Assistant text — strip relay prefix, split structured `<delegate>`
+          blocks into their own cards. Round 6 also injects DelegationCards
+          for `sessions_send` tool calls between the leader's intro prose
+          and any post-`\n---\n` summary prose, restoring the natural
+          "intro → cards → summary" flow within the leader's card.
           `max-w-prose` (~65ch) caps line length to the optimal reading
-          measure regardless of window width — without this, body lines
-          stretched 150-200+ chars and the eye lost track of which line
-          it was on returning to the left margin. */}
-      {hasText && (
-        <div className="flex max-w-prose flex-col gap-2 text-[13px] leading-relaxed text-text">
-          {splitAssistantText(
-            isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text,
-          ).map((segment, idx) => {
-            if (segment.kind === 'delegation') {
-              const matchedLinkage =
-                block.assistant && linkagesBySourceEntry
-                  ? linkagesBySourceEntry
-                      .get(block.assistant.entryId)
-                      ?.find((l) => l.blockStart === segment.blockStart)
-                  : undefined
-              const expandedDefault = block.assistant
-                ? block.assistant.entryId === latestSourceEntryId
-                : true
+          measure regardless of window width. */}
+      {hasText &&
+        (() => {
+          const rawText = isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text
+          // Pull `sessions_send` linkages for this source — they go BETWEEN
+          // the intro prose and the post-`\n---\n` summary prose so the
+          // leader's response reads in narrative order.
+          const allLinkagesForSource =
+            block.assistant && linkagesBySourceEntry
+              ? (linkagesBySourceEntry.get(block.assistant.entryId) ?? [])
+              : []
+          const sessionsSendLinkages = allLinkagesForSource.filter(
+            (l) => l.source === 'sessions-send',
+          )
+
+          // Split the prose at the first `\n---\n` markdown horizontal rule
+          // when we have `sessions_send` cards to inject. Without cards the
+          // whole prose renders as one segment (no behavioral regression for
+          // turns that don't use sessions_send routing).
+          const splitMatch = sessionsSendLinkages.length > 0 ? rawText.match(/\n---\n/) : null
+          const splitIdx = splitMatch?.index ?? -1
+          const introText = splitIdx >= 0 ? rawText.slice(0, splitIdx) : rawText
+          const summaryText =
+            splitIdx >= 0 && splitMatch ? rawText.slice(splitIdx + splitMatch[0].length) : ''
+
+          const expandedDefault = block.assistant
+            ? block.assistant.entryId === latestSourceEntryId
+            : true
+
+          const renderProseSegments = (proseText: string, keyBase: string) =>
+            splitAssistantText(proseText).map((segment, idx) => {
+              if (segment.kind === 'delegation') {
+                const matchedLinkage =
+                  block.assistant && linkagesBySourceEntry
+                    ? linkagesBySourceEntry
+                        .get(block.assistant.entryId)
+                        ?.find(
+                          (l) => l.source === 'delegate-tag' && l.blockStart === segment.blockStart,
+                        )
+                    : undefined
+                return (
+                  <DelegationCard
+                    key={`${keyBase}-delegation-${idx}`}
+                    targetName={segment.targetName}
+                    task={segment.task}
+                    linkage={matchedLinkage}
+                    teamId={teamId}
+                    defaultExpanded={expandedDefault}
+                    latestSourceEntryId={latestSourceEntryId}
+                  />
+                )
+              }
               return (
+                <ReactMarkdown
+                  key={`${keyBase}-prose-${idx}`}
+                  remarkPlugins={[remarkGfm]}
+                  components={MD_COMPONENTS}
+                >
+                  {segment.text}
+                </ReactMarkdown>
+              )
+            })
+
+          return (
+            <div className="flex max-w-prose flex-col gap-2 text-[13px] leading-relaxed text-text">
+              {renderProseSegments(introText, 'intro')}
+              {sessionsSendLinkages.map((linkage) => (
                 <DelegationCard
-                  key={`delegation-${idx}`}
-                  targetName={segment.targetName}
-                  task={segment.task}
-                  linkage={matchedLinkage}
+                  key={linkage.delegationId}
+                  targetName={`@${linkage.targetAgentName}`}
+                  task={linkage.task}
+                  linkage={linkage}
                   teamId={teamId}
                   defaultExpanded={expandedDefault}
                   latestSourceEntryId={latestSourceEntryId}
                 />
-              )
-            }
-            return (
-              <ReactMarkdown
-                key={`prose-${idx}`}
-                remarkPlugins={[remarkGfm]}
-                components={MD_COMPONENTS}
-              >
-                {segment.text}
-              </ReactMarkdown>
-            )
-          })}
-        </div>
-      )}
+              ))}
+              {summaryText && renderProseSegments(summaryText, 'summary')}
+            </div>
+          )
+        })()}
 
       {/* Streaming text */}
       {streaming && !hasText && !hasThinking && <TypingIndicator />}
@@ -926,8 +1017,20 @@ export const StreamingCard = memo(function StreamingCard({
                 task={segment.task}
               />
             ) : (
-              <div key={`stream-prose-${idx}`} className="whitespace-pre-wrap">
-                {segment.text}
+              // Round 6 (Layer 6B): render streaming prose with the same
+              // ReactMarkdown pipeline used by `AssistantTurnCard` so bold /
+              // lists / code blocks / links format progressively as text
+              // streams in — instead of staying as raw text until commit.
+              // ReactMarkdown's parser is tolerant of partial markdown
+              // (unfinished `**bold`, partial `[link](`, unclosed fences):
+              // it renders what's parseable and leaves the rest as text.
+              // `splitAssistantText` (above) already excludes partial
+              // `<delegate>` tags from the prose, so the markdown parser
+              // never sees them.
+              <div key={`stream-prose-${idx}`}>
+                <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
+                  {segment.text}
+                </ReactMarkdown>
               </div>
             ),
           )}

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -14,12 +14,17 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowRight, ChevronRight, Clock, SendHorizontal, Square, Wrench } from 'lucide-react'
-import { BooAvatar } from '@clawboo/ui'
+import { BooAvatar, resolveBooTint } from '@clawboo/ui'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { useFleetStore } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
+import { useBooZeroStore } from '@/stores/booZero'
 import { calculateCostUsd, formatCost } from '@/features/cost/costUtils'
+import {
+  buildDelegationLinkages,
+  type DelegationLinkage,
+} from '@/features/group-chat/buildDelegationLinkages'
 import { splitAssistantText } from './splitAssistantText'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -410,42 +415,311 @@ export const UserMessageCard = memo(function UserMessageCard({
 
 // ─── DelegationCard ───────────────────────────────────────────────────────────
 // Renders a `<delegate to="@Name">task</delegate>` block as a styled card
-// inside the assistant turn. The structured delegation protocol replaces
-// natural-language @-mentions with this explicit, machine-parseable form;
-// we visualize it so the user has a clear breadcrumb for who picked up
-// what work.
+// inside the assistant turn. When a `linkage` is supplied (group-chat path),
+// the target's reply nests inside the card via a collapsible body. Without
+// a linkage (1:1 chat path), the card renders header-only, matching the
+// pre-nesting behaviour.
+
+const MAX_NEST_DEPTH = 4
 
 export const DelegationCard = memo(function DelegationCard({
   targetName,
   task,
+  linkage,
+  teamId,
+  defaultExpanded = true,
+  depth = 0,
+  latestSourceEntryId,
 }: {
   targetName: string
   task: string
+  linkage?: DelegationLinkage
+  teamId?: string
+  defaultExpanded?: boolean
+  depth?: number
+  latestSourceEntryId?: string | null
 }) {
-  // Resolve the agent so we can render their boo avatar (if they're in the
-  // fleet store). For unknown agents, fall back to a deterministic seed
-  // based on the name so the avatar is at least consistent across renders.
-  const targetAgentId = useFleetStore(
+  // Resolve target agent — prefer the linkage's resolved id (covers cases
+  // where the LLM wrote a partial / case-mismatched name and we already
+  // mapped it to the canonical roster entry).
+  const targetAgentIdFromStore = useFleetStore(
     (s) => s.agents.find((a) => a.name === targetName)?.id ?? null,
   )
+  const targetAgentId = linkage?.targetAgentId ?? targetAgentIdFromStore
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  const isBooZero = targetAgentId !== null && targetAgentId === booZeroAgentId
   const avatarSeed = targetAgentId ?? targetName
+
+  // Target tint — same hex the avatar paints with, lifted from boo-avatar.
+  // Fall back to the existing emerald when we can't resolve a target.
+  const tint = targetAgentId ? resolveBooTint(targetAgentId, isBooZero) : '#10b981'
+
+  // Streaming text for the target — only the FIRST pending delegation per
+  // target session owns the live stream. Subsequent pending delegations
+  // wait their turn (queued by the Gateway anyway).
+  const ownsStreaming = Boolean(linkage?.isPending && linkage?.targetSessionKey && teamId)
+  const streamingText = useChatStore((s) =>
+    ownsStreaming && linkage?.targetSessionKey
+      ? (s.streamingText.get(linkage.targetSessionKey) ?? null)
+      : null,
+  )
+
+  const hasLinkedBody = Boolean(
+    linkage && (linkage.linkedEntries.length > 0 || streamingText !== null || linkage.isPending),
+  )
+  const canCollapse = hasLinkedBody && depth < MAX_NEST_DEPTH
+
+  const [expanded, setExpanded] = useState(defaultExpanded)
 
   return (
     <div
-      className="flex flex-col gap-1.5 rounded-lg border-l-2 border-emerald-500/40 bg-emerald-500/[0.04] py-2 pr-3 pl-3"
+      className="flex flex-col gap-1.5 rounded-lg py-2 pr-3 pl-3"
+      style={{
+        borderLeft: `2px solid ${tint}66`,
+        background: `${tint}0a`,
+      }}
       data-testid="delegation-card"
+      data-delegation-id={linkage?.delegationId}
     >
       <div className="flex items-center gap-2">
         <BooAvatar seed={avatarSeed} size={20} />
-        <ArrowRight size={11} className="text-emerald-500/70" />
-        <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-emerald-400">
+        <ArrowRight size={11} style={{ color: `${tint}b3` }} />
+        <span
+          className="font-mono text-[10px] font-semibold uppercase tracking-widest"
+          style={{ color: tint }}
+        >
           Delegated to
         </span>
         <span className="font-mono text-[10px] font-medium text-text">@{targetName}</span>
+        {canCollapse && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="ml-auto flex h-5 w-5 items-center justify-center rounded hover:bg-white/5"
+            aria-label={expanded ? 'Collapse delegation' : 'Expand delegation'}
+            data-testid="delegation-toggle"
+          >
+            <ChevronRight
+              size={12}
+              style={{ color: tint }}
+              className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+            />
+          </button>
+        )}
       </div>
       <div className="text-[12px] leading-relaxed whitespace-pre-wrap text-secondary/80">
         {task}
       </div>
+      <AnimatePresence initial={false}>
+        {expanded && hasLinkedBody && linkage && (
+          <motion.div
+            key="body"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="overflow-hidden"
+            data-testid="delegation-card-body"
+          >
+            <div
+              className="mt-1.5 flex flex-col gap-2 border-t pt-2 text-[13px] leading-relaxed text-text/95"
+              style={{ borderColor: `${tint}1a` }}
+            >
+              <NestedDelegationBody
+                entries={linkage.linkedEntries}
+                streamingText={streamingText}
+                teamId={teamId}
+                depth={depth + 1}
+                latestSourceEntryId={latestSourceEntryId}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+})
+
+// ─── NestedDelegationBody ─────────────────────────────────────────────────────
+// Renders the target's reply chunk inside a DelegationCard: thinking section,
+// tool calls, assistant prose (with recursive nested DelegationCards for any
+// `<delegate>` blocks the target itself emitted), and the live streaming
+// text when the target is still typing.
+
+const NestedDelegationBody = memo(function NestedDelegationBody({
+  entries,
+  streamingText,
+  teamId,
+  depth,
+  latestSourceEntryId,
+}: {
+  entries: TranscriptEntry[]
+  streamingText: string | null
+  teamId?: string
+  depth: number
+  latestSourceEntryId?: string | null
+}) {
+  // Group entries into the same Thinking / Tool / Assistant buckets the
+  // top-level renderer uses, so the nested body mirrors the visual rhythm.
+  const grouped = useMemo(() => groupEntriesToBlocks(entries), [entries])
+  // Linkages for any nested `<delegate>` blocks inside the target's reply.
+  // Built per-source so we don't need to re-derive across the whole
+  // conversation here — the parent computation already covers ancestors
+  // and the deeper levels are scoped to this body.
+  const nestedLinkages = useNestedLinkages(entries, teamId)
+
+  const hasContent = entries.length > 0 || (streamingText !== null && streamingText.length > 0)
+  if (!hasContent) {
+    return <TypingIndicator />
+  }
+
+  return (
+    <>
+      {grouped.map((block, i) => {
+        if (block.kind === 'meta') {
+          return <MetaMessageCard key={block.entry.entryId} entry={block.entry} />
+        }
+        if (block.kind === 'user') {
+          return <UserMessageCard key={block.entry.entryId} entry={block.entry} />
+        }
+        return (
+          <NestedAssistantContent
+            key={`nested-${i}`}
+            block={block}
+            linkagesBySourceEntry={nestedLinkages}
+            teamId={teamId}
+            depth={depth}
+            latestSourceEntryId={latestSourceEntryId}
+          />
+        )
+      })}
+      {streamingText !== null && streamingText.length > 0 && (
+        <div className="whitespace-pre-wrap text-text/80" data-testid="delegation-streaming">
+          {streamingText}
+        </div>
+      )}
+      {streamingText !== null && streamingText.length === 0 && <TypingIndicator />}
+    </>
+  )
+})
+
+// Build linkages for delegations that appear INSIDE the target's reply,
+// scoped to those entries only. Pure derivation; no Zustand subscription.
+function useNestedLinkages(
+  entries: TranscriptEntry[],
+  teamId: string | undefined,
+): Map<string, DelegationLinkage[]> {
+  // Pull participants from the fleet store ONCE — the team-id filter is
+  // applied inside the helper. We include Boo Zero (teamless) too so its
+  // delegations from nested replies resolve.
+  const agents = useFleetStore((s) => s.agents)
+  const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
+  return useMemo(() => {
+    if (!teamId || entries.length === 0) return new Map()
+    const teamAgents = agents
+      .filter((a) => a.teamId === teamId)
+      .map((a) => ({ id: a.id, name: a.name }))
+    const booZero = booZeroAgentId ? agents.find((a) => a.id === booZeroAgentId) : null
+    const participants = booZero
+      ? [...teamAgents, { id: booZero.id, name: booZero.name }]
+      : teamAgents
+    // Defensive dedup (same shape as GroupChatPanel.participants).
+    const seen = new Set<string>()
+    const deduped = participants.filter((p) => {
+      if (seen.has(p.id)) return false
+      seen.add(p.id)
+      return true
+    })
+    const blocks = groupEntriesToBlocks(entries)
+    const result = buildDelegationLinkages({
+      blocks,
+      mergedEntries: entries,
+      teamId,
+      participants: deduped,
+    })
+    return result.linkagesBySourceEntry
+  }, [agents, booZeroAgentId, entries, teamId])
+}
+
+// ─── NestedAssistantContent ───────────────────────────────────────────────────
+// Compact assistant renderer used INSIDE a DelegationCard body. Skips the
+// outer agent-identity header/footer (the parent card already conveys who
+// is replying) and recurses into nested DelegationCards for any `<delegate>`
+// blocks inside.
+
+const NestedAssistantContent = memo(function NestedAssistantContent({
+  block,
+  linkagesBySourceEntry,
+  teamId,
+  depth,
+  latestSourceEntryId,
+}: {
+  block: AssistantBlock
+  linkagesBySourceEntry: Map<string, DelegationLinkage[]>
+  teamId?: string
+  depth: number
+  latestSourceEntryId?: string | null
+}) {
+  const isRelay = isTeamUpdateEntry(block.assistant)
+  const hasThinking = block.thinking.length > 0
+  const hasTools = block.tools.length > 0
+  const hasText = Boolean(block.assistant?.text)
+  const linkagesForBlock = block.assistant
+    ? (linkagesBySourceEntry.get(block.assistant.entryId) ?? [])
+    : []
+  const linkageByBlockStart = useMemo(() => {
+    const map = new Map<number, DelegationLinkage>()
+    for (const l of linkagesForBlock) map.set(l.blockStart, l)
+    return map
+  }, [linkagesForBlock])
+
+  return (
+    <div className="flex flex-col gap-2">
+      {hasThinking && (
+        <ThinkingSection entries={block.thinking} thinkingDurationMs={block.thinkingDurationMs} />
+      )}
+      {hasTools && (
+        <div className="flex flex-col gap-1">
+          {block.tools.map((entry) => (
+            <ToolCallCard key={entry.entryId} entry={entry} />
+          ))}
+        </div>
+      )}
+      {hasText && (
+        <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-text/95">
+          {splitAssistantText(
+            isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text,
+          ).map((segment, idx) => {
+            if (segment.kind === 'delegation') {
+              const nestedLinkage = linkageByBlockStart.get(segment.blockStart)
+              const expandedDefault = block.assistant
+                ? block.assistant.entryId === latestSourceEntryId
+                : true
+              return (
+                <DelegationCard
+                  key={`nested-delegation-${idx}`}
+                  targetName={segment.targetName}
+                  task={segment.task}
+                  linkage={nestedLinkage}
+                  teamId={teamId}
+                  defaultExpanded={expandedDefault}
+                  depth={depth}
+                  latestSourceEntryId={latestSourceEntryId}
+                />
+              )
+            }
+            return (
+              <ReactMarkdown
+                key={`nested-prose-${idx}`}
+                remarkPlugins={[remarkGfm]}
+                components={MD_COMPONENTS}
+              >
+                {segment.text}
+              </ReactMarkdown>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 })
@@ -457,11 +731,20 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
   agentId,
   agentName,
   streaming,
+  linkagesBySourceEntry,
+  teamId,
+  latestSourceEntryId,
 }: {
   block: AssistantBlock
   agentId: string
   agentName: string
   streaming?: boolean
+  /** Group-chat-only: pass-through so DelegationCard segments can nest target replies. */
+  linkagesBySourceEntry?: Map<string, DelegationLinkage[]>
+  /** Group-chat-only: needed by nested DelegationCards to resolve target session keys. */
+  teamId?: string
+  /** Group-chat-only: source entryId whose delegations default-expand (newest exposed). */
+  latestSourceEntryId?: string | null
 }) {
   const isRelay = isTeamUpdateEntry(block.assistant)
   const hasThinking = block.thinking.length > 0
@@ -526,14 +809,30 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
         <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-text">
           {splitAssistantText(
             isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text,
-          ).map((segment, idx) =>
-            segment.kind === 'delegation' ? (
-              <DelegationCard
-                key={`delegation-${idx}`}
-                targetName={segment.targetName}
-                task={segment.task}
-              />
-            ) : (
+          ).map((segment, idx) => {
+            if (segment.kind === 'delegation') {
+              const matchedLinkage =
+                block.assistant && linkagesBySourceEntry
+                  ? linkagesBySourceEntry
+                      .get(block.assistant.entryId)
+                      ?.find((l) => l.blockStart === segment.blockStart)
+                  : undefined
+              const expandedDefault = block.assistant
+                ? block.assistant.entryId === latestSourceEntryId
+                : true
+              return (
+                <DelegationCard
+                  key={`delegation-${idx}`}
+                  targetName={segment.targetName}
+                  task={segment.task}
+                  linkage={matchedLinkage}
+                  teamId={teamId}
+                  defaultExpanded={expandedDefault}
+                  latestSourceEntryId={latestSourceEntryId}
+                />
+              )
+            }
+            return (
               <ReactMarkdown
                 key={`prose-${idx}`}
                 remarkPlugins={[remarkGfm]}
@@ -541,8 +840,8 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
               >
                 {segment.text}
               </ReactMarkdown>
-            ),
-          )}
+            )
+          })}
         </div>
       )}
 

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -738,6 +738,7 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
   linkagesBySourceEntry,
   teamId,
   latestSourceEntryId,
+  isFollowup = false,
 }: {
   block: AssistantBlock
   agentId: string
@@ -749,6 +750,13 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
   teamId?: string
   /** Group-chat-only: source entryId whose delegations default-expand (newest exposed). */
   latestSourceEntryId?: string | null
+  /**
+   * When true, hide the avatar/name/timestamp header. Set by the parent
+   * renderer when this block is a continuation of the same author's
+   * previous block within a short window — drops the repeated chrome so
+   * a burst of messages from one agent reads as a single section.
+   */
+  isFollowup?: boolean
 }) {
   const isRelay = isTeamUpdateEntry(block.assistant)
   const hasThinking = block.thinking.length > 0
@@ -767,25 +775,37 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
     <div
       className={`flex flex-col gap-2${isRelay ? ' border-l-2 border-emerald-500/40 pl-3 opacity-80' : ''}`}
     >
-      {/* Header */}
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <AgentBooAvatar agentId={agentId} size={22} />
-          <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary/70">
-            {agentName}
-          </span>
-          {isRelay && (
-            <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 font-mono text-[9px] font-medium text-emerald-400">
-              Team Update
+      {/* Header — avatar bumped to 28px and name lifted to 11.5px / full
+          secondary opacity so the agent identity is legible at a glance
+          (the previous 22px avatar + 10px name @ 70% opacity made the
+          header feel like a footnote under the body).
+          Suppressed when `isFollowup` — the parent renderer sets that flag
+          for consecutive same-author messages so the repeated chrome
+          doesn't double-render. The body still aligns under where the
+          header would be, so the burst reads as one continuous section. */}
+      {!isFollowup && (
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2.5">
+            <AgentBooAvatar agentId={agentId} size={28} />
+            <span
+              className="font-mono font-semibold uppercase tracking-widest text-secondary"
+              style={{ fontSize: 11.5 }}
+            >
+              {agentName}
             </span>
+            {isRelay && (
+              <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 font-mono text-[9px] font-medium text-emerald-400">
+                Team Update
+              </span>
+            )}
+          </div>
+          {block.timestampMs && (
+            <time className="font-mono text-[10px] text-secondary/50">
+              {formatTimestamp(block.timestampMs)}
+            </time>
           )}
         </div>
-        {block.timestampMs && (
-          <time className="font-mono text-[10px] text-secondary/50">
-            {formatTimestamp(block.timestampMs)}
-          </time>
-        )}
-      </div>
+      )}
 
       {/* Thinking trace */}
       {(hasThinking || (streaming && !hasText)) && (
@@ -808,9 +828,13 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
       {/* Assistant text — strip prefix for relay messages, split structured
           delegation blocks out into their own cards. Relay messages don't
           contain `<delegate>` blocks (they're condensed summaries), so the
-          split returns a single prose segment for them. */}
+          split returns a single prose segment for them.
+          `max-w-prose` (~65ch) caps line length to the optimal reading
+          measure regardless of window width — without this, body lines
+          stretched 150-200+ chars and the eye lost track of which line
+          it was on returning to the left margin. */}
       {hasText && (
-        <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-text">
+        <div className="flex max-w-prose flex-col gap-2 text-[13px] leading-relaxed text-text">
           {splitAssistantText(
             isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text,
           ).map((segment, idx) => {
@@ -883,14 +907,17 @@ export const StreamingCard = memo(function StreamingCard({
   const segments = useMemo(() => splitAssistantText(text), [text])
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <AgentBooAvatar agentId={agentId} size={22} />
-        <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary/70">
+      <div className="flex items-center gap-2.5">
+        <AgentBooAvatar agentId={agentId} size={28} />
+        <span
+          className="font-mono font-semibold uppercase tracking-widest text-secondary"
+          style={{ fontSize: 11.5 }}
+        >
           {agentName}
         </span>
       </div>
       {hasText ? (
-        <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-text opacity-80">
+        <div className="flex max-w-prose flex-col gap-2 text-[13px] leading-relaxed text-text opacity-80">
           {segments.map((segment, idx) =>
             segment.kind === 'delegation' ? (
               <DelegationCard
@@ -911,6 +938,65 @@ export const StreamingCard = memo(function StreamingCard({
     </div>
   )
 })
+
+// ─── Author-grouping + spacing helpers ───────────────────────────────────────
+//
+// Slack / Discord / iMessage pattern: when consecutive assistant turns come
+// from the SAME agent inside a short window, drop the repeated avatar+name
+// chrome on the follow-ups so the burst reads as one continuous section.
+//
+// `FOLLOWUP_WINDOW_MS` — anything beyond this is treated as a new "section"
+// and gets a full header. 5 minutes is the sweet spot: long pauses (lunch,
+// next morning) read as a fresh thread; back-to-back streaming bursts read
+// as one author speaking continuously.
+
+const FOLLOWUP_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * True when `current` is a continuation of `prev`: both are assistant-turn
+ * blocks owned by the same agent, with timestamps within 5 min. User and
+ * meta blocks always break the streak (returning false).
+ */
+export function isFollowupBlock(
+  prev: RenderBlock | null,
+  current: RenderBlock,
+  prevOwnerAgentId: string | null,
+  currentOwnerAgentId: string | null,
+): boolean {
+  if (!prev || prev.kind !== 'assistant-turn' || current.kind !== 'assistant-turn') return false
+  if (!currentOwnerAgentId || prevOwnerAgentId !== currentOwnerAgentId) return false
+  const prevTs = prev.timestampMs
+  const currTs = current.timestampMs
+  if (prevTs === null || currTs === null) return false
+  return currTs - prevTs <= FOLLOWUP_WINDOW_MS
+}
+
+/**
+ * Tailwind margin class for a block based on whether it's the first block,
+ * a same-author continuation (tight), or a new author group (generous).
+ * Replaces uniform `gap-5` on the parent so spacing reads as grouping.
+ */
+export function blockMarginClass(index: number, isFollowup: boolean): string {
+  if (index === 0) return ''
+  return isFollowup ? 'mt-2' : 'mt-7'
+}
+
+/**
+ * Per-block hover affordance — Slack pattern. The `-mx-4 px-4` matches the
+ * parent scroll container's `px-4`, so the highlight extends edge-to-edge
+ * within the column (no awkward 4px gap on either side). Near-imperceptible
+ * bg tint on hover so each message becomes a discoverable interactive
+ * surface without adding chrome at rest.
+ *
+ * Applied uniformly to assistant turns AND user messages — Slack hovers
+ * user rows too, and at 1.8% opacity the stripe behind a right-aligned
+ * bubble reads as "this row is interactive" rather than as a misaligned
+ * background.
+ *
+ * Future per-message actions (copy, react, react bar) attach here.
+ */
+export const BLOCK_ROW_HOVER_CLASS =
+  '-mx-4 rounded-md px-4 transition-colors duration-150 hover:bg-white/[0.028]'
 
 // ─── MessageList ──────────────────────────────────────────────────────────────
 
@@ -978,29 +1064,68 @@ export const MessageList = memo(function MessageList({
           <p className="font-mono text-[12px] text-secondary/40">No messages yet.</p>
         </div>
       ) : (
-        <div className="flex flex-col gap-5 pb-2">
+        <div className="flex flex-col pb-2">
           {blocks.map((block, i) => {
+            const prev = i > 0 ? (blocks[i - 1] ?? null) : null
+            // 1:1 chat: every assistant turn is from the same agent (the
+            // `agentId` prop), so the owner check collapses to "is the
+            // previous block also an assistant-turn?" — handled by
+            // `isFollowupBlock` against equal owner ids.
+            const isFollowup = isFollowupBlock(prev, block, agentId, agentId)
+            const margin = blockMarginClass(i, isFollowup)
+
             if (block.kind === 'meta') {
-              return <MetaMessageCard key={block.entry.entryId} entry={block.entry} />
+              return (
+                <div key={block.entry.entryId} className={margin}>
+                  <MetaMessageCard entry={block.entry} />
+                </div>
+              )
             }
             if (block.kind === 'user') {
-              return <UserMessageCard key={block.entry.entryId} entry={block.entry} />
+              return (
+                <div
+                  key={block.entry.entryId}
+                  className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}
+                >
+                  <UserMessageCard entry={block.entry} />
+                </div>
+              )
             }
             return (
-              <AssistantTurnCard
-                key={`turn-${i}`}
-                block={block}
-                agentId={agentId}
-                agentName={agentName}
-                streaming={isRunning && i === blocks.length - 1 && !showLive}
-              />
+              <div key={`turn-${i}`} className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}>
+                <AssistantTurnCard
+                  block={block}
+                  agentId={agentId}
+                  agentName={agentName}
+                  streaming={isRunning && i === blocks.length - 1 && !showLive}
+                  isFollowup={isFollowup}
+                />
+              </div>
             )
           })}
 
-          {/* Live uncommitted stream */}
-          {showLive && (
-            <StreamingCard text={streamingText ?? ''} agentId={agentId} agentName={agentName} />
-          )}
+          {/* Live uncommitted stream — applies the same follow-up rule
+              against the last committed block so a streaming continuation
+              of the agent's own burst stays tight. */}
+          {showLive &&
+            (() => {
+              const last = blocks.length > 0 ? (blocks[blocks.length - 1] ?? null) : null
+              const streamIsFollowup =
+                last !== null &&
+                last.kind === 'assistant-turn' &&
+                last.timestampMs !== null &&
+                Date.now() - last.timestampMs <= FOLLOWUP_WINDOW_MS
+              const margin = blocks.length === 0 ? '' : streamIsFollowup ? 'mt-2' : 'mt-7'
+              return (
+                <div className={margin}>
+                  <StreamingCard
+                    text={streamingText ?? ''}
+                    agentId={agentId}
+                    agentName={agentName}
+                  />
+                </div>
+              )
+            })()}
 
           <div ref={bottomRef} aria-hidden />
         </div>

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -981,23 +981,6 @@ export function blockMarginClass(index: number, isFollowup: boolean): string {
   return isFollowup ? 'mt-2' : 'mt-7'
 }
 
-/**
- * Per-block hover affordance — Slack pattern. The `-mx-4 px-4` matches the
- * parent scroll container's `px-4`, so the highlight extends edge-to-edge
- * within the column (no awkward 4px gap on either side). Near-imperceptible
- * bg tint on hover so each message becomes a discoverable interactive
- * surface without adding chrome at rest.
- *
- * Applied uniformly to assistant turns AND user messages — Slack hovers
- * user rows too, and at 1.8% opacity the stripe behind a right-aligned
- * bubble reads as "this row is interactive" rather than as a misaligned
- * background.
- *
- * Future per-message actions (copy, react, react bar) attach here.
- */
-export const BLOCK_ROW_HOVER_CLASS =
-  '-mx-4 rounded-md px-4 transition-colors duration-150 hover:bg-white/[0.028]'
-
 // ─── MessageList ──────────────────────────────────────────────────────────────
 
 export const NEAR_BOTTOM_PX = 80
@@ -1083,16 +1066,13 @@ export const MessageList = memo(function MessageList({
             }
             if (block.kind === 'user') {
               return (
-                <div
-                  key={block.entry.entryId}
-                  className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}
-                >
+                <div key={block.entry.entryId} className={margin}>
                   <UserMessageCard entry={block.entry} />
                 </div>
               )
             }
             return (
-              <div key={`turn-${i}`} className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}>
+              <div key={`turn-${i}`} className={margin}>
                 <AssistantTurnCard
                   block={block}
                   agentId={agentId}

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -13,7 +13,7 @@ import {
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { AnimatePresence, motion } from 'framer-motion'
-import { ArrowRight, ChevronRight, Clock, SendHorizontal, Square, Wrench } from 'lucide-react'
+import { ChevronRight, Clock, SendHorizontal, Square, Wrench } from 'lucide-react'
 import { BooAvatar, resolveBooTint } from '@clawboo/ui'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
@@ -28,6 +28,8 @@ import {
 import { shouldDropAssistantTurn } from '@/lib/teamProtocol'
 import { parseToolEntry } from './parseToolEntry'
 import { splitAssistantText } from './splitAssistantText'
+import { stripPlanBlocks } from '@/features/group-chat/planDetector'
+import { pickLatestActivity } from '@/features/graph/nodes/pickLatestActivity'
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -414,6 +416,176 @@ export const UserMessageCard = memo(function UserMessageCard({
   )
 })
 
+// ─── firstSentencePreview ─────────────────────────────────────────────────────
+//
+// Round 12B: derive a single-line preview from an agent's reply body. Used
+// by `DelegationCard` when the card is collapsed so the user gets a gist
+// of "what the agent said" without expanding. Pure prose extraction — no
+// markdown parsing, no API call. The first sentence (or first newline /
+// truncated tail) of the reply, trimmed of leading markdown punctuation.
+//
+// Examples:
+//   "**Fall** — the crisp air, rich colors..." →  "Fall — the crisp air, rich colors..."
+//   "Hi! Quick answer: react.\n\nLonger..."     →  "Hi!"
+//   one long unbroken sentence > 90 chars       →  truncated with "…"
+
+function firstSentencePreview(text: string, maxChars = 90): string {
+  // Strip leading markdown noise (bold/italic/heading/quote/code markers)
+  // so the preview starts with the first real word.
+  const cleaned = text
+    .trim()
+    .replace(/^[\s>#`*_~-]+/, '')
+    .trim()
+  if (!cleaned) return ''
+  // First sentence end or first newline — whichever comes first.
+  const sentenceMatch = cleaned.match(/^[\s\S]+?[.!?](\s|$)/)
+  const firstLine = cleaned.split('\n')[0] ?? cleaned
+  let raw = (sentenceMatch?.[0] ?? firstLine).trim()
+  // Strip trailing punctuation-only artifacts then truncate.
+  if (raw.length > maxChars) raw = `${raw.slice(0, maxChars - 1).trimEnd()}…`
+  return raw
+}
+
+// ─── LiveActivityFeed ─────────────────────────────────────────────────────────
+//
+// What the target agent is doing RIGHT NOW — replaces the previous generic
+// "Thinking..." spinner inside a pending DelegationCard. Mirrors how Claude
+// Code surfaces tool calls / streamed prose: subscribe to the target's
+// session, ask `pickLatestActivity` what the most-recent activity is, and
+// render it with kind-specific affordances (mint pulse for streaming, 🔧
+// for tool calls, prose markdown for final responses).
+//
+// When `isRunning` is true but no signal has landed yet, falls back to the
+// `TypingIndicator` (animated dots). When the agent is idle and we have
+// nothing to show, renders a muted "Awaiting response" line — better than
+// a lingering "Thinking..." that the user reads as "the system is stuck".
+
+const LiveActivityFeed = memo(function LiveActivityFeed({
+  targetAgentId,
+  targetSessionKey,
+  tint,
+}: {
+  targetAgentId: string | null
+  targetSessionKey?: string
+  tint: string
+}) {
+  // Subscribe by primitive lookups so unrelated agents' updates don't
+  // re-render this card.
+  const agentStatus = useFleetStore((s) =>
+    targetAgentId ? (s.agents.find((a) => a.id === targetAgentId)?.status ?? null) : null,
+  )
+  const isRunning = agentStatus === 'running'
+
+  const streamingText = useChatStore((s) =>
+    targetSessionKey ? (s.streamingText.get(targetSessionKey) ?? null) : null,
+  )
+  // Pull a small tail of the target's transcript — last 6 entries is enough
+  // to find the most recent assistant turn / tool call. Using a wider
+  // window would only matter for very chatty agents, which isn't typical.
+  const recentEntries = useChatStore((s) =>
+    targetSessionKey ? (s.transcripts.get(targetSessionKey) ?? null) : null,
+  )
+  const tail = useMemo(
+    () => (recentEntries && recentEntries.length > 0 ? recentEntries.slice(-6) : null),
+    [recentEntries],
+  )
+  const picked = pickLatestActivity(streamingText, tail)
+
+  if (!picked) {
+    if (isRunning) return <TypingIndicator />
+    return (
+      <div className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-wider text-text/35">
+        <motion.span
+          aria-hidden
+          className="h-1.5 w-1.5 rounded-full"
+          style={{ background: tint }}
+          initial={{ opacity: 0.25 }}
+          animate={{ opacity: [0.25, 0.55, 0.25] }}
+          transition={{ duration: 2.4, repeat: Infinity, ease: 'easeInOut' }}
+        />
+        <span>Awaiting response</span>
+      </div>
+    )
+  }
+
+  if (picked.kind === 'streaming') {
+    // Streaming text with a blinking cursor at the tail — mirrors Claude
+    // Code's typewriter feel so the user can SEE the agent thinking
+    // word-by-word in real time.
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="text-[13px] leading-relaxed text-text/95">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
+            {picked.text}
+          </ReactMarkdown>
+          {/* Blinking cursor — sits inline at the tail of the streamed
+              text so the eye anchors on the live edge. */}
+          <motion.span
+            aria-hidden
+            className="ml-0.5 inline-block h-[1em] w-[2px] translate-y-[2px] rounded-sm align-middle"
+            style={{ background: tint }}
+            animate={{ opacity: [1, 0, 1] }}
+            transition={{ duration: 0.9, repeat: Infinity, ease: 'easeInOut' }}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  if (picked.kind === 'tool') {
+    // Format `[[tool: <label>]]` → extract label, render as a styled chip
+    // (matches Claude Code's tool-call pill). The label may contain a
+    // primary name + dimmed argument (e.g. `read package.json`); we split
+    // on the first space to render that distinction.
+    const label = picked.text.match(/\[\[tool:\s*(.+?)\]\]/)?.[1]?.trim() ?? 'tool'
+    const spaceIdx = label.indexOf(' ')
+    const toolName = spaceIdx >= 0 ? label.slice(0, spaceIdx) : label
+    const toolArg = spaceIdx >= 0 ? label.slice(spaceIdx + 1) : null
+    return (
+      <motion.div
+        className="inline-flex items-center gap-2 self-start rounded-md border px-2 py-1"
+        style={{
+          borderColor: `${tint}33`,
+          background: `${tint}10`,
+        }}
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={isRunning ? { opacity: 1, scale: [1, 1.02, 1] } : { opacity: 1, scale: 1 }}
+        transition={
+          isRunning
+            ? { scale: { duration: 1.4, repeat: Infinity, ease: 'easeInOut' } }
+            : { duration: 0.2 }
+        }
+      >
+        <Wrench size={11} style={{ color: tint }} />
+        <span
+          className="font-mono text-[10px] font-semibold uppercase tracking-wider"
+          style={{ color: tint }}
+        >
+          {isRunning ? 'Calling' : 'Last called'}
+        </span>
+        <span className="font-mono text-[11px] text-text">{toolName}</span>
+        {toolArg && <span className="truncate font-mono text-[11px] text-text/60">{toolArg}</span>}
+        {isRunning && (
+          <span
+            aria-hidden
+            className="h-1.5 w-1.5 animate-pulse rounded-full"
+            style={{ background: tint }}
+          />
+        )}
+      </motion.div>
+    )
+  }
+
+  // picked.kind === 'assistant' — committed response, render in full.
+  return (
+    <div className="text-[13px] leading-relaxed text-text/95">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
+        {picked.text}
+      </ReactMarkdown>
+    </div>
+  )
+})
+
 // ─── DelegationCard ───────────────────────────────────────────────────────────
 // Renders a `<delegate to="@Name">task</delegate>` block as a styled card
 // inside the assistant turn. When a `linkage` is supplied (group-chat path),
@@ -431,6 +603,7 @@ export const DelegationCard = memo(function DelegationCard({
   defaultExpanded = true,
   depth = 0,
   latestSourceEntryId,
+  animationIndex = 0,
 }: {
   targetName: string
   task: string
@@ -439,6 +612,13 @@ export const DelegationCard = memo(function DelegationCard({
   defaultExpanded?: boolean
   depth?: number
   latestSourceEntryId?: string | null
+  /**
+   * Round 11: per-card index inside a WorkstreamCard / PlanCard grid. Used
+   * to stagger entry animations (delay = idx * 40 ms) so a batch of cards
+   * fades in as a wave, not all at once. Defaults to 0 for standalone
+   * inline cards (no stagger needed).
+   */
+  animationIndex?: number
 }) {
   // Resolve target agent — prefer the linkage's resolved id (covers cases
   // where the LLM wrote a partial / case-mismatched name and we already
@@ -455,6 +635,13 @@ export const DelegationCard = memo(function DelegationCard({
   // Fall back to the existing emerald when we can't resolve a target.
   const tint = targetAgentId ? resolveBooTint(targetAgentId, isBooZero) : '#10b981'
 
+  // Round 11: target agent live status (running / idle) drives the
+  // pulse-glow on the card border and the small status dot in the header.
+  const targetAgentStatus = useFleetStore((s) =>
+    targetAgentId ? (s.agents.find((a) => a.id === targetAgentId)?.status ?? null) : null,
+  )
+  const targetIsRunning = targetAgentStatus === 'running'
+
   // Streaming text for the target — only the FIRST pending delegation per
   // target session owns the live stream. Subsequent pending delegations
   // wait their turn (queued by the Gateway anyway).
@@ -465,116 +652,401 @@ export const DelegationCard = memo(function DelegationCard({
       : null,
   )
 
-  const hasLinkedBody = Boolean(
-    linkage && (linkage.linkedEntries.length > 0 || streamingText !== null || linkage.isPending),
-  )
-  const canCollapse = hasLinkedBody && depth < MAX_NEST_DEPTH
+  const hasLinkedEntries = Boolean(linkage && linkage.linkedEntries.length > 0)
+  const hasStreaming = streamingText !== null && streamingText.length > 0
+  // The card has SOMETHING to show in its body when ANY of these hold:
+  // claimed reply entries, live streaming, or pending state (which falls
+  // through to the LiveActivityFeed for the target).
+  const hasBody = Boolean(linkage) && depth < MAX_NEST_DEPTH
 
-  const [expanded, setExpanded] = useState(defaultExpanded)
+  // Round 12: subscribe to the full transcripts map ONCE — same pattern as
+  // Round 11A's WorkstreamCard counter heuristic. Used for two derivations:
+  //   (a) `sourceTimestampMs` — when did this card's source entry commit?
+  //       Filters the fallback peek to replies AFTER the source so stale
+  //       responses from prior batches don't count.
+  //   (b) `hasFallbackReply` / `previewText` — both look at the target's
+  //       last ~6 entries for a fresh non-control-token assistant reply.
+  const transcripts = useChatStore((s) => s.transcripts)
+
+  // Anchor: when did the source commit? We resolve the source entry by id
+  // across every session's bucket. O(N total entries) but bounded by the
+  // chat's last-500-entry cap per session, called once per card mount/dep
+  // change. Fall back to 0 (matches any timestamp) when not found.
+  const sourceTimestampMs = useMemo(() => {
+    if (!linkage?.sourceEntryId) return 0
+    for (const bucket of transcripts.values()) {
+      for (let i = bucket.length - 1; i >= 0; i--) {
+        const e = bucket[i]
+        if (e?.entryId === linkage.sourceEntryId) return e.timestampMs ?? 0
+      }
+    }
+    return 0
+  }, [transcripts, linkage?.sourceEntryId])
+
+  // Round 12A: "has the agent's reply landed anywhere?" — same fallback
+  // heuristic Round 11A uses for the WorkstreamCard counter. When true,
+  // the card stops glowing regardless of whether the linkage claim path
+  // succeeded.
+  const hasFallbackReply = useMemo(() => {
+    if (!linkage?.targetSessionKey) return false
+    const bucket = transcripts.get(linkage.targetSessionKey)
+    if (!bucket || bucket.length === 0) return false
+    const tail = bucket.slice(-6)
+    for (let i = tail.length - 1; i >= 0; i--) {
+      const e = tail[i]
+      if (!e || !e.text) continue
+      if (e.kind !== 'assistant') continue
+      if (shouldDropAssistantTurn(e.text)) continue
+      if ((e.timestampMs ?? 0) <= sourceTimestampMs) continue
+      return true
+    }
+    return false
+  }, [linkage?.targetSessionKey, transcripts, sourceTimestampMs])
+
+  // Round 12B: preview text for the collapsed card. First sentence (or
+  // ~90 chars) of the agent's reply, extracted from the same sources
+  // LiveActivityFeed peeks at — claimed linkedEntries first, then bucket.
+  const previewText = useMemo(() => {
+    if (linkage) {
+      for (const e of linkage.linkedEntries) {
+        if (e.kind === 'assistant' && e.text && !shouldDropAssistantTurn(e.text)) {
+          return firstSentencePreview(e.text)
+        }
+      }
+    }
+    if (!linkage?.targetSessionKey) return null
+    const bucket = transcripts.get(linkage.targetSessionKey)
+    if (!bucket || bucket.length === 0) return null
+    const tail = bucket.slice(-6)
+    for (let i = tail.length - 1; i >= 0; i--) {
+      const e = tail[i]
+      if (!e || !e.text) continue
+      if (e.kind !== 'assistant') continue
+      if (shouldDropAssistantTurn(e.text)) continue
+      if ((e.timestampMs ?? 0) <= sourceTimestampMs) continue
+      return firstSentencePreview(e.text)
+    }
+    return null
+  }, [linkage, transcripts, sourceTimestampMs])
+
+  // The unified "this card has visible content" signal — feeds the glow
+  // gate (12A), the DONE pill (12C), and the just-completed flash (12D).
+  const hasContent = hasLinkedEntries || hasStreaming || hasFallbackReply
+
+  // Accordion topology — when this card's source isn't the latest
+  // delegation in the leader's turn, default-collapse the response body so
+  // the visible chat stays focused on the newest work. A user manual
+  // toggle wins until `latestSourceEntryId` changes again (a new
+  // delegation lands → old user override resets → newest auto-opens, old
+  // auto-collapses).
+  const isLatest = Boolean(
+    linkage && latestSourceEntryId !== null && linkage.sourceEntryId === latestSourceEntryId,
+  )
+  // No linkage (1:1 chat path) → fall back to caller's `defaultExpanded`.
+  const wantExpanded = linkage
+    ? linkage.sourceEntryId === latestSourceEntryId ||
+      (latestSourceEntryId === null && defaultExpanded)
+    : defaultExpanded
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(null)
+  const expanded = expandedOverride !== null ? expandedOverride : wantExpanded
+  // Reset the manual override whenever the latest-source pointer moves —
+  // a new delegation just landed, so this card's accordion state should
+  // re-align with the "is this the newest one?" signal.
+  useEffect(() => {
+    setExpandedOverride(null)
+  }, [latestSourceEntryId])
+
+  // Task body — moved into the body top per Round 11B. Hidden by default
+  // because the user wants the AGENT'S RESPONSE to be the primary visible
+  // content; the instruction body is a debug detail.
+  const [taskExpanded, setTaskExpanded] = useState(false)
+
+  // Round 12A: glow gated by the visible-content signal (NOT the linkage's
+  // raw `isPending`). When `LiveActivityFeed`'s fallback peek surfaces the
+  // agent's reply, the body LOOKS done — the glow needs to match.
+  const showPulseGlow = targetIsRunning && !hasContent
+
+  // Round 12D: one-shot completion flash. When `hasContent` transitions
+  // from false to true (the agent's reply just landed), fire a bright
+  // mint glow that pulses up + fades for 1.5s, then settles to no glow.
+  // After this, the card stays calm (no infinite pulse).
+  const [justCompleted, setJustCompleted] = useState(false)
+  const prevHadContent = useRef(hasContent)
+  useEffect(() => {
+    if (!prevHadContent.current && hasContent) {
+      setJustCompleted(true)
+      prevHadContent.current = hasContent
+      const t = setTimeout(() => setJustCompleted(false), 1500)
+      return () => clearTimeout(t)
+    }
+    prevHadContent.current = hasContent
+  }, [hasContent])
 
   return (
-    <div
-      className="flex flex-col gap-1.5 rounded-lg py-2 pr-3 pl-3"
+    <motion.div
+      className="flex flex-col gap-2 rounded-xl px-4 py-3"
       style={{
-        borderLeft: `2px solid ${tint}66`,
-        background: `${tint}0a`,
+        border: `1px solid ${tint}33`,
+        background: `linear-gradient(180deg, ${tint}10 0%, ${tint}06 55%, ${tint}03 100%)`,
+        // Inset highlight keeps a subtle "lit edge" along the top so the
+        // gradient reads as depth, not a flat panel.
+        boxShadow: `inset 0 1px 0 ${tint}20`,
       }}
+      initial={{ opacity: 0, y: 6 }}
+      animate={
+        showPulseGlow
+          ? {
+              // Working — infinite breathing glow in the agent's tint.
+              opacity: 1,
+              y: 0,
+              boxShadow: [
+                `inset 0 1px 0 ${tint}20, 0 0 0 0 ${tint}00`,
+                `inset 0 1px 0 ${tint}20, 0 0 26px -8px ${tint}66`,
+                `inset 0 1px 0 ${tint}20, 0 0 0 0 ${tint}00`,
+              ],
+            }
+          : justCompleted
+            ? {
+                // Just landed — one-shot bright mint flash that fades to
+                // nothing. Signals "reply delivered" without lingering.
+                opacity: 1,
+                y: 0,
+                boxShadow: [
+                  `inset 0 1px 0 ${tint}20, 0 0 0 0 #34d39900`,
+                  `inset 0 1px 0 ${tint}20, 0 0 32px -6px #34d399cc`,
+                  `inset 0 1px 0 ${tint}20, 0 0 16px -8px #34d39966`,
+                  `inset 0 1px 0 ${tint}20, 0 0 0 0 #34d39900`,
+                ],
+              }
+            : { opacity: 1, y: 0 }
+      }
+      transition={
+        showPulseGlow
+          ? {
+              opacity: {
+                duration: 0.28,
+                delay: animationIndex * 0.04,
+                ease: [0.22, 0.61, 0.36, 1],
+              },
+              y: { duration: 0.28, delay: animationIndex * 0.04, ease: [0.22, 0.61, 0.36, 1] },
+              boxShadow: { duration: 2.4, repeat: Infinity, ease: 'easeInOut' },
+            }
+          : justCompleted
+            ? {
+                opacity: { duration: 0.2 },
+                y: { duration: 0.2 },
+                boxShadow: { duration: 1.4, repeat: 0, ease: [0.22, 0.61, 0.36, 1] },
+              }
+            : { duration: 0.28, delay: animationIndex * 0.04, ease: [0.22, 0.61, 0.36, 1] }
+      }
       data-testid="delegation-card"
       data-delegation-id={linkage?.delegationId}
+      data-is-latest={isLatest ? 'true' : 'false'}
     >
-      <div className="flex items-center gap-2">
-        <BooAvatar seed={avatarSeed} size={20} />
-        <ArrowRight size={11} style={{ color: `${tint}b3` }} />
-        {(() => {
-          // Round 7: verb + badge differ by routing source so the user can
-          // tell apart "the LLM explicitly delegated" vs. "Clawboo
-          // routed this on the LLM's behalf".
-          const src = linkage?.source ?? 'delegate-tag'
-          const verb = src === 'clawboo-relay' ? 'Routed to' : 'Delegated to'
-          return (
+      <div className="flex items-center gap-2.5">
+        <BooAvatar seed={avatarSeed} size={28} />
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex items-center gap-1.5">
+            {(() => {
+              // Round 7: verb + badge differ by routing source so the user can
+              // tell apart "the LLM explicitly delegated" vs. "Clawboo
+              // routed this on the LLM's behalf".
+              const src = linkage?.source ?? 'delegate-tag'
+              const verb = src === 'clawboo-relay' ? 'Routed to' : 'Delegated to'
+              return (
+                <span
+                  className="font-mono text-[10px] font-semibold uppercase tracking-widest"
+                  style={{ color: tint }}
+                >
+                  {verb}
+                </span>
+              )
+            })()}
+            {(() => {
+              // Origin badge for non-canonical paths.
+              const src = linkage?.source ?? 'delegate-tag'
+              if (src === 'clawboo-dispatch') {
+                return (
+                  <span
+                    className="rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
+                    style={{ color: tint, background: `${tint}1a` }}
+                    title="Clawboo dispatched this to the target on the LLM's behalf (fallback regex match)"
+                  >
+                    via clawboo
+                  </span>
+                )
+              }
+              if (src === 'clawboo-relay') {
+                return (
+                  <span
+                    className="rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
+                    style={{
+                      color: 'rgba(232,232,232,0.55)',
+                      background: 'rgba(255,255,255,0.06)',
+                    }}
+                    title="Clawboo forwarded the source's response to this teammate as a [Team Update]"
+                  >
+                    routed
+                  </span>
+                )
+              }
+              return null
+            })()}
+          </div>
+          <span className="truncate font-mono text-[11.5px] font-semibold text-text">
+            @{targetName}
+          </span>
+          {/* Round 12B/E: preview line — single muted sentence of the
+              agent's reply, shown ONLY when the card is collapsed. When
+              expanded, the full reply renders below and the preview would
+              be redundant. */}
+          {!expanded && previewText && (
             <span
-              className="font-mono text-[10px] font-semibold uppercase tracking-widest"
-              style={{ color: tint }}
+              className="truncate text-[11px] leading-snug text-text/55 italic"
+              data-testid="delegation-card-preview"
+              title={previewText}
             >
-              {verb}
+              {previewText}
             </span>
-          )
-        })()}
-        <span className="font-mono text-[10px] font-medium text-text">@{targetName}</span>
-        {(() => {
-          // Show an origin badge for the non-canonical paths so the user
-          // sees the routing wasn't an explicit `<delegate>` tag.
-          const src = linkage?.source ?? 'delegate-tag'
-          if (src === 'clawboo-dispatch') {
-            return (
+          )}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          {/* Round 12C: status indicator — three states.
+              - Working (running + no content yet): animated mint pulse-ring
+              - Done (content visible — linked OR fallback): mint DONE pill
+              - Idle / waiting: dim gray dot */}
+          {showPulseGlow ? (
+            <span className="relative flex h-2 w-2" title="Working…">
               <span
-                className="ml-1 rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
-                style={{ color: tint, background: `${tint}1a` }}
-                title="Clawboo dispatched this to the target on the LLM's behalf (fallback regex match)"
-              >
-                via clawboo
-              </span>
-            )
-          }
-          if (src === 'clawboo-relay') {
-            return (
+                aria-hidden
+                className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-60"
+                style={{ background: tint }}
+              />
               <span
-                className="ml-1 rounded-full px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider"
-                style={{ color: 'rgba(232,232,232,0.55)', background: 'rgba(255,255,255,0.06)' }}
-                title="Clawboo forwarded the source's response to this teammate as a [Team Update]"
-              >
-                routed
-              </span>
-            )
-          }
-          return null
-        })()}
-        {canCollapse && (
-          <button
-            type="button"
-            onClick={() => setExpanded((v) => !v)}
-            className="ml-auto flex h-5 w-5 items-center justify-center rounded hover:bg-white/5"
-            aria-label={expanded ? 'Collapse delegation' : 'Expand delegation'}
-            data-testid="delegation-toggle"
-          >
-            <ChevronRight
-              size={12}
-              style={{ color: tint }}
-              className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+                aria-hidden
+                className="relative inline-flex h-2 w-2 rounded-full"
+                style={{ background: tint }}
+              />
+            </span>
+          ) : hasContent ? (
+            <span
+              className="rounded-full bg-emerald-500/20 px-1.5 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wider text-emerald-300"
+              title="Reply delivered"
+            >
+              Done
+            </span>
+          ) : (
+            <span
+              aria-hidden
+              className="h-2 w-2 rounded-full"
+              style={{ background: 'rgba(255,255,255,0.15)' }}
+              title="Awaiting response"
             />
-          </button>
-        )}
+          )}
+          {hasBody && (
+            <button
+              type="button"
+              onClick={() => setExpandedOverride(expanded ? false : true)}
+              className="flex h-6 w-6 items-center justify-center rounded-md hover:bg-white/5"
+              aria-label={expanded ? 'Collapse response' : 'Expand response'}
+              data-testid="delegation-toggle"
+            >
+              <ChevronRight
+                size={14}
+                style={{ color: tint }}
+                className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+              />
+            </button>
+          )}
+        </div>
       </div>
-      <div className="text-[12px] leading-relaxed whitespace-pre-wrap text-secondary/80">
-        {task}
-      </div>
+
+      {/* Response body — primary visible content. The TASK toggle moved
+          here per Round 11B (was in the header, was cluttered). */}
       <AnimatePresence initial={false}>
-        {expanded && hasLinkedBody && linkage && (
+        {expanded && hasBody && linkage && (
           <motion.div
             key="body"
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.18 }}
+            transition={{ duration: 0.22, ease: [0.22, 0.61, 0.36, 1] }}
             className="overflow-hidden"
             data-testid="delegation-card-body"
           >
             <div
-              className="mt-1.5 flex flex-col gap-2 border-t pt-2 text-[13px] leading-relaxed text-text/95"
-              style={{ borderColor: `${tint}1a` }}
+              className="mt-1 flex flex-col gap-2 border-t border-dashed pt-2.5 text-[13px] leading-relaxed text-text/95"
+              style={{ borderColor: `${tint}20` }}
             >
-              <NestedDelegationBody
-                entries={linkage.linkedEntries}
-                streamingText={streamingText}
-                teamId={teamId}
-                depth={depth + 1}
-                latestSourceEntryId={latestSourceEntryId}
-              />
+              {/* Round 11B: task toggle lives at the top of the body. */}
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-mono text-[9px] font-semibold uppercase tracking-wider text-text/45">
+                  Response
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setTaskExpanded((v) => !v)}
+                  className={`flex items-center gap-1 rounded font-mono text-[9px] uppercase tracking-wider transition-opacity hover:text-text/80 ${
+                    taskExpanded ? 'text-text/70' : 'text-text/40'
+                  }`}
+                  aria-label={taskExpanded ? 'Hide task' : 'Show task'}
+                  data-testid="delegation-task-toggle"
+                  title="Show the task body Clawboo sent to the agent"
+                >
+                  <span className="underline decoration-dotted underline-offset-4">
+                    {taskExpanded ? 'Hide task' : 'Show task'}
+                  </span>
+                  <ChevronRight
+                    size={9}
+                    className={`shrink-0 transition-transform ${taskExpanded ? 'rotate-90' : ''}`}
+                  />
+                </button>
+              </div>
+
+              <AnimatePresence>
+                {taskExpanded && (
+                  <motion.div
+                    key="task"
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: 0.18, ease: [0.22, 0.61, 0.36, 1] }}
+                    className="overflow-hidden"
+                    data-testid="delegation-card-task"
+                  >
+                    <div
+                      className="rounded-md border border-dashed px-3 py-2 text-[12px] leading-relaxed whitespace-pre-wrap text-text/75"
+                      style={{ borderColor: `${tint}33`, background: `${tint}08` }}
+                    >
+                      <div className="mb-1 font-mono text-[8px] font-semibold uppercase tracking-widest text-text/45">
+                        Task from Clawboo
+                      </div>
+                      {task}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+
+              {hasLinkedEntries || hasStreaming ? (
+                <NestedDelegationBody
+                  entries={linkage.linkedEntries}
+                  streamingText={streamingText}
+                  teamId={teamId}
+                  depth={depth + 1}
+                  latestSourceEntryId={latestSourceEntryId}
+                />
+              ) : (
+                <LiveActivityFeed
+                  targetAgentId={targetAgentId}
+                  targetSessionKey={linkage.targetSessionKey}
+                  tint={tint}
+                />
+              )}
             </div>
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </motion.div>
   )
 })
 
@@ -632,8 +1104,13 @@ const NestedDelegationBody = memo(function NestedDelegationBody({
         )
       })}
       {streamingText !== null && streamingText.length > 0 && (
-        <div className="whitespace-pre-wrap text-text/80" data-testid="delegation-streaming">
-          {streamingText}
+        <div
+          className="max-w-prose text-[13px] leading-relaxed text-text/90"
+          data-testid="delegation-streaming"
+        >
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD_COMPONENTS}>
+            {streamingText}
+          </ReactMarkdown>
         </div>
       )}
       {streamingText !== null && streamingText.length === 0 && <TypingIndicator />}
@@ -762,6 +1239,266 @@ const NestedAssistantContent = memo(function NestedAssistantContent({
   )
 })
 
+// ─── PlanCard (Round 9) ──────────────────────────────────────────────────────
+//
+// Visual container for a `<plan>` block's step-DelegationCards. Renders a
+// header with the step count + progress, then each step card under a
+// numbered "Step N" label. The individual step cards are still
+// `DelegationCard`s — PlanCard is purely the visual grouping wrapper.
+//
+// Progress signal comes from `pendingPlans` in the chat store: the plan's
+// `currentStepIndex` tells the renderer how many steps have completed.
+// `currentStepIndex >= steps.length` ⇒ "Complete" badge replaces the
+// in-progress indicator.
+
+export const PlanCard = memo(function PlanCard({
+  planId,
+  linkages,
+  teamId,
+  defaultExpanded = true,
+  latestSourceEntryId,
+}: {
+  planId: string
+  /** Plan-step linkages, in stepIndex order. Pre-sorted by the caller. */
+  linkages: DelegationLinkage[]
+  teamId?: string
+  defaultExpanded?: boolean
+  latestSourceEntryId?: string | null
+}) {
+  // Subscribe to the plan's progress state. The pendingPlan may not exist
+  // (e.g., after a page reload — the store doesn't persist plans). In that
+  // case we derive progress from the linkages themselves: a step is
+  // "complete" if its linkage has linkedEntries.
+  const pendingPlan = useChatStore((s) => s.pendingPlans.get(planId) ?? null)
+  const totalSteps = pendingPlan?.steps.length ?? linkages.length
+  const completedFromStore = pendingPlan?.currentStepIndex ?? 0
+  const completedFromLinkages = linkages.filter((l) => !l.isPending).length
+  // Use whichever is more up-to-date — store advances reactively during the
+  // active session, linkages capture historical state after reload.
+  const completedSteps = Math.max(completedFromStore, completedFromLinkages)
+  const isComplete = completedSteps >= totalSteps && totalSteps > 0
+
+  return (
+    <div
+      className="@container flex flex-col gap-3 rounded-xl border border-white/8 bg-gradient-to-b from-white/[0.025] to-white/[0.005] p-4"
+      data-testid="plan-card"
+      data-plan-id={planId}
+    >
+      <div className="flex items-center gap-2 border-b border-white/5 pb-2.5">
+        <span aria-hidden className="text-[15px]">
+          📋
+        </span>
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary">
+          Plan
+        </span>
+        <span className="font-mono text-[10px] text-text/70">
+          {totalSteps} {totalSteps === 1 ? 'step' : 'steps'}
+        </span>
+        <span className="ml-auto flex items-center gap-1.5">
+          {isComplete ? (
+            <span
+              className="rounded-full bg-emerald-500/15 px-2 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-wider text-emerald-400"
+              title="All plan steps complete — the leader has received a [Plan Complete] envelope and should now synthesize."
+            >
+              Complete
+            </span>
+          ) : (
+            <>
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400/80"
+              />
+              <span className="font-mono text-[10px] text-text/70">
+                {completedSteps} / {totalSteps} done
+              </span>
+            </>
+          )}
+        </span>
+      </div>
+      {/* Plans are SEQUENTIAL (Round 8) but the grid still gives them
+          breathing room at wide widths — cards stack 1-col on narrow
+          screens and pair to 2-col at >=640px container width. */}
+      <div className="grid grid-cols-1 gap-3 @[640px]:grid-cols-2">
+        {linkages.map((linkage, idx) => {
+          // Step index — prefer the stored planStepIndex; fall back to
+          // render order so layout is stable even when the field is missing.
+          const stepNum = (linkage.planStepIndex ?? idx) + 1
+          return (
+            <div
+              key={linkage.delegationId}
+              className="flex flex-col gap-1"
+              data-plan-step-index={linkage.planStepIndex ?? idx}
+            >
+              <span className="font-mono text-[9px] font-semibold uppercase tracking-wider text-secondary/70">
+                Step {stepNum}
+              </span>
+              <DelegationCard
+                // DelegationCard renders `@{targetName}` itself; pass bare
+                // name (no leading `@`) to avoid `@@` double-prefix.
+                targetName={linkage.targetAgentName}
+                task={linkage.task}
+                linkage={linkage}
+                teamId={teamId}
+                defaultExpanded={defaultExpanded}
+                latestSourceEntryId={latestSourceEntryId}
+                animationIndex={idx}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+})
+
+// ─── WorkstreamCard (Round 10) ────────────────────────────────────────────────
+//
+// Visual container for a parallel-workstream batch (≥2 sibling `<delegate>`
+// tags emitted in one leader turn, no `<plan>` wrapper). Mirrors PlanCard's
+// structure but with parallel semantics — no step ordering, just an
+// in-flight set with X / N done progress.
+//
+// Progress signal comes from two sources:
+//   1. `pendingWorkstreams` in the chat store — reactive during the active
+//      session, drives the in-flight indicator.
+//   2. The linkages themselves — `linkages.filter(l => !l.isPending).length`.
+//      Survives page reload (the in-memory `pendingWorkstreams` map resets,
+//      but linkages re-derive from committed transcript on every render).
+// `Math.max(storeCount, linkageCount)` keeps the card accurate in both
+// active and post-reload contexts.
+
+export const WorkstreamCard = memo(function WorkstreamCard({
+  workstreamId,
+  linkages,
+  teamId,
+  defaultExpanded = true,
+  latestSourceEntryId,
+}: {
+  workstreamId: string
+  /** Workstream-step linkages, in target-index order. Pre-sorted by the caller. */
+  linkages: DelegationLinkage[]
+  teamId?: string
+  defaultExpanded?: boolean
+  latestSourceEntryId?: string | null
+}) {
+  const pendingWs = useChatStore((s) => s.pendingWorkstreams.get(workstreamId) ?? null)
+  const totalTargets = pendingWs?.targets.length ?? linkages.length
+  const completedFromStore =
+    pendingWs?.targets.filter((t) => t.resolvedEntryId !== null).length ?? 0
+
+  // Round 11A: count cards as "done" if either the linkage was claimed OR
+  // the LiveActivityFeed would render a substantive assistant reply (the
+  // user sees content → it's "done" from their perspective). Mirrors
+  // `pickLatestActivity`'s heuristic but skips streaming-state (that's
+  // in-progress, not done) and skips control tokens via
+  // `shouldDropAssistantTurn`.
+  const transcripts = useChatStore((s) => s.transcripts)
+  const wsTimestamp = pendingWs?.timestampMs ?? 0
+  const completedFromContent = useMemo(() => {
+    let count = 0
+    for (const l of linkages) {
+      if (!l.isPending) {
+        count++
+        continue
+      }
+      // Pending linkage — peek at the target's bucket for a fresh
+      // substantive reply (mirror of `LiveActivityFeed`'s fallback).
+      const bucket = transcripts.get(l.targetSessionKey)
+      if (!bucket || bucket.length === 0) continue
+      const tail = bucket.slice(-6)
+      let found = false
+      for (let i = tail.length - 1; i >= 0; i--) {
+        const e = tail[i]
+        if (!e || !e.text) continue
+        if (e.kind !== 'assistant') continue
+        if (shouldDropAssistantTurn(e.text)) continue
+        if ((e.timestampMs ?? 0) <= wsTimestamp) continue
+        found = true
+        break
+      }
+      if (found) count++
+    }
+    return count
+  }, [linkages, transcripts, wsTimestamp])
+
+  const completedTargets = Math.max(completedFromStore, completedFromContent)
+  const isComplete = completedTargets >= totalTargets && totalTargets > 0
+
+  return (
+    <div
+      className="@container flex flex-col gap-3 rounded-xl border border-white/8 bg-gradient-to-b from-white/[0.025] to-white/[0.005] p-4"
+      data-testid="workstream-card"
+      data-workstream-id={workstreamId}
+    >
+      <div className="flex items-center gap-2 border-b border-white/5 pb-2.5">
+        <span aria-hidden className="text-[15px]">
+          📡
+        </span>
+        <span className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary">
+          Workstreams
+        </span>
+        <span className="font-mono text-[10px] text-text/70">
+          {totalTargets} {totalTargets === 1 ? 'workstream' : 'workstreams'}
+        </span>
+        <span className="ml-auto flex items-center gap-1.5">
+          {isComplete ? (
+            <span
+              className="rounded-full bg-emerald-500/15 px-2 py-0.5 font-mono text-[9px] font-semibold uppercase tracking-wider text-emerald-400"
+              title="All parallel workstreams complete — the leader has received a [Workstreams Complete] envelope and should now synthesize across them."
+            >
+              Complete
+            </span>
+          ) : (
+            <>
+              <span
+                aria-hidden
+                className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400/80"
+              />
+              <span className="font-mono text-[10px] text-text/70">
+                {completedTargets} / {totalTargets} done
+              </span>
+            </>
+          )}
+        </span>
+      </div>
+      {/* Round 11D: responsive 2-col grid. Tailwind 4 container queries —
+          the grid adapts to the WorkstreamCard's OWN width (not the
+          viewport's), so a narrow chat panel collapses to 1-col cleanly
+          and a wide panel uses the previously-unused horizontal space. */}
+      <div className="grid grid-cols-1 gap-3 @[640px]:grid-cols-2">
+        {linkages.map((linkage, idx) => {
+          // Workstream index — prefer the stored workstreamTargetIndex; fall
+          // back to render order so layout is stable even when the field is
+          // missing.
+          const wsNum = (linkage.workstreamTargetIndex ?? idx) + 1
+          return (
+            <div
+              key={linkage.delegationId}
+              className="flex flex-col gap-1"
+              data-workstream-target-index={linkage.workstreamTargetIndex ?? idx}
+            >
+              <span className="font-mono text-[9px] font-semibold uppercase tracking-wider text-secondary/70">
+                Workstream {wsNum}
+              </span>
+              <DelegationCard
+                // DelegationCard renders `@{targetName}` itself; pass bare
+                // name (no leading `@`) to avoid `@@` double-prefix.
+                targetName={linkage.targetAgentName}
+                task={linkage.task}
+                linkage={linkage}
+                teamId={teamId}
+                defaultExpanded={defaultExpanded}
+                latestSourceEntryId={latestSourceEntryId}
+                animationIndex={idx}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+})
+
 // ─── AssistantTurnCard ────────────────────────────────────────────────────────
 
 export const AssistantTurnCard = memo(function AssistantTurnCard({
@@ -881,14 +1618,16 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
           for `sessions_send` tool calls between the leader's intro prose
           and any post-`\n---\n` summary prose, restoring the natural
           "intro → cards → summary" flow within the leader's card.
+          Round 9 adds the PlanCard rendering: linkages with the same
+          `planId` get grouped under one `<PlanCard>` (rendered alongside
+          sessions_send cards between intro + outro prose). Raw `<plan>`
+          markdown is stripped so it doesn't show as text.
           `max-w-prose` (~65ch) caps line length to the optimal reading
           measure regardless of window width. */}
       {hasText &&
         (() => {
-          const rawText = isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text
-          // Pull `sessions_send` linkages for this source — they go BETWEEN
-          // the intro prose and the post-`\n---\n` summary prose so the
-          // leader's response reads in narrative order.
+          let rawText = isRelay ? stripRelayPrefix(block.assistant!.text) : block.assistant!.text
+          // Pull linkages for this source and split them by source kind.
           const allLinkagesForSource =
             block.assistant && linkagesBySourceEntry
               ? (linkagesBySourceEntry.get(block.assistant.entryId) ?? [])
@@ -896,12 +1635,60 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
           const sessionsSendLinkages = allLinkagesForSource.filter(
             (l) => l.source === 'sessions-send',
           )
+          // Round 9: group plan-step linkages by `planId`. Each plan
+          // becomes one `<PlanCard>` containing its step DelegationCards.
+          const planGroups = new Map<string, DelegationLinkage[]>()
+          for (const linkage of allLinkagesForSource) {
+            if (!linkage.planId) continue
+            const group = planGroups.get(linkage.planId)
+            if (group) group.push(linkage)
+            else planGroups.set(linkage.planId, [linkage])
+          }
+          // Sort each group's linkages by step index for stable display.
+          for (const group of planGroups.values()) {
+            group.sort((a, b) => (a.planStepIndex ?? 0) - (b.planStepIndex ?? 0))
+          }
+          // Round 9: strip raw `<plan>…</plan>` markdown when we'll render
+          // PlanCards in its place. Without this the leader's prose would
+          // show the unrendered tags as text alongside the visual cards.
+          if (planGroups.size > 0) {
+            rawText = stripPlanBlocks(rawText)
+          }
+
+          // Round 10: group parallel-workstream linkages by `workstreamId`.
+          // Each group becomes one `<WorkstreamCard>` containing its
+          // sibling DelegationCards under a "📡 WORKSTREAMS" header with
+          // progress indicator. Workstream linkages always have
+          // `source: 'delegate-tag'` (they're Path 1 linkages with the
+          // `workstreamId` field attributed by `buildDelegationLinkages`
+          // when N≥2 valid `<delegate>` blocks exist on a non-plan source).
+          const workstreamGroups = new Map<string, DelegationLinkage[]>()
+          for (const linkage of allLinkagesForSource) {
+            if (!linkage.workstreamId) continue
+            const group = workstreamGroups.get(linkage.workstreamId)
+            if (group) group.push(linkage)
+            else workstreamGroups.set(linkage.workstreamId, [linkage])
+          }
+          for (const group of workstreamGroups.values()) {
+            group.sort((a, b) => (a.workstreamTargetIndex ?? 0) - (b.workstreamTargetIndex ?? 0))
+          }
+          // Round 10: build a set of `blockStart` offsets that belong to a
+          // workstream so the inline-delegation renderer can skip them (they
+          // render inside the WorkstreamCard instead, and rendering them
+          // twice would clutter the leader's card).
+          const workstreamBlockStarts = new Set<number>()
+          for (const group of workstreamGroups.values()) {
+            for (const l of group) workstreamBlockStarts.add(l.blockStart)
+          }
 
           // Split the prose at the first `\n---\n` markdown horizontal rule
-          // when we have `sessions_send` cards to inject. Without cards the
-          // whole prose renders as one segment (no behavioral regression for
-          // turns that don't use sessions_send routing).
-          const splitMatch = sessionsSendLinkages.length > 0 ? rawText.match(/\n---\n/) : null
+          // when we have `sessions_send`, PlanCards, OR WorkstreamCards to
+          // inject. Without any, the whole prose renders as one segment (no
+          // behavioral regression for turns that don't use any path).
+          const splitMatch =
+            sessionsSendLinkages.length > 0 || planGroups.size > 0 || workstreamGroups.size > 0
+              ? rawText.match(/\n---\n/)
+              : null
           const splitIdx = splitMatch?.index ?? -1
           const introText = splitIdx >= 0 ? rawText.slice(0, splitIdx) : rawText
           const summaryText =
@@ -914,6 +1701,11 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
           const renderProseSegments = (proseText: string, keyBase: string) =>
             splitAssistantText(proseText).map((segment, idx) => {
               if (segment.kind === 'delegation') {
+                // Round 10: when this delegation is part of a workstream
+                // batch, skip the inline render — it'll appear inside the
+                // WorkstreamCard below. Rendering it both inline AND in the
+                // card would duplicate the routing event visually.
+                if (workstreamBlockStarts.has(segment.blockStart)) return null
                 const matchedLinkage =
                   block.assistant && linkagesBySourceEntry
                     ? linkagesBySourceEntry
@@ -945,21 +1737,60 @@ export const AssistantTurnCard = memo(function AssistantTurnCard({
               )
             })
 
+          // Round 11D — break PlanCards / WorkstreamCards OUT of the
+          // `max-w-prose` cap so they can use the full chat-panel width
+          // (the previously-empty horizontal space the user pointed at).
+          // Intro / outro PROSE segments stay capped at the ~65ch reading
+          // measure; `sessions_send` cards sit inside the prose flow
+          // because they're typically one-off (not a parallel batch).
+          const hasFullWidthCards = planGroups.size > 0 || workstreamGroups.size > 0
           return (
-            <div className="flex max-w-prose flex-col gap-2 text-[13px] leading-relaxed text-text">
-              {renderProseSegments(introText, 'intro')}
-              {sessionsSendLinkages.map((linkage) => (
-                <DelegationCard
-                  key={linkage.delegationId}
-                  targetName={`@${linkage.targetAgentName}`}
-                  task={linkage.task}
-                  linkage={linkage}
-                  teamId={teamId}
-                  defaultExpanded={expandedDefault}
-                  latestSourceEntryId={latestSourceEntryId}
-                />
-              ))}
-              {summaryText && renderProseSegments(summaryText, 'summary')}
+            <div className="flex flex-col gap-2 text-[13px] leading-relaxed text-text">
+              <div className="max-w-prose">{renderProseSegments(introText, 'intro')}</div>
+              {hasFullWidthCards && (
+                <div className="flex w-full flex-col gap-3">
+                  {/* Round 9: PlanCards (one per `planId`). Each contains
+                      its step DelegationCards under a "📋 Plan" header
+                      with progress indicator. */}
+                  {Array.from(planGroups.entries()).map(([planId, group]) => (
+                    <PlanCard
+                      key={`plan-${planId}`}
+                      planId={planId}
+                      linkages={group}
+                      teamId={teamId}
+                      defaultExpanded={expandedDefault}
+                      latestSourceEntryId={latestSourceEntryId}
+                    />
+                  ))}
+                  {/* Round 10: WorkstreamCards (one per `workstreamId`). */}
+                  {Array.from(workstreamGroups.entries()).map(([wsId, group]) => (
+                    <WorkstreamCard
+                      key={`workstream-${wsId}`}
+                      workstreamId={wsId}
+                      linkages={group}
+                      teamId={teamId}
+                      defaultExpanded={expandedDefault}
+                      latestSourceEntryId={latestSourceEntryId}
+                    />
+                  ))}
+                </div>
+              )}
+              <div className="flex max-w-prose flex-col gap-2">
+                {sessionsSendLinkages.map((linkage) => (
+                  <DelegationCard
+                    key={linkage.delegationId}
+                    // DelegationCard renders `@{targetName}` itself; pass
+                    // bare name to avoid `@@` double-prefix.
+                    targetName={linkage.targetAgentName}
+                    task={linkage.task}
+                    linkage={linkage}
+                    teamId={teamId}
+                    defaultExpanded={expandedDefault}
+                    latestSourceEntryId={latestSourceEntryId}
+                  />
+                ))}
+                {summaryText && renderProseSegments(summaryText, 'summary')}
+              </div>
             </div>
           )
         })()}

--- a/apps/web/src/features/chat/chatComponents.tsx
+++ b/apps/web/src/features/chat/chatComponents.tsx
@@ -147,6 +147,10 @@ export function groupEntriesToBlocks(entries: TranscriptEntry[]): RenderBlock[] 
   for (const entry of entries) {
     // Skip injected context preamble entries (should not appear in UI)
     if (entry.text.startsWith('[Team Context')) continue
+    // Skip the resume-ack token — the wake message asks the agent to reply
+    // with EXACTLY `__resumed__` to confirm session warmup. The literal
+    // token is a protocol artifact, not chat content the user should see.
+    if (entry.text.trim() === '__resumed__') continue
 
     if (entry.kind === 'meta') {
       commitTurn()
@@ -1264,7 +1268,8 @@ export const MessageComposer = memo(
           )}
         </div>
         <p className="mt-1.5 text-right font-mono text-[10px] text-secondary/30">
-          Enter to send · Shift+Enter for newline · /reset for new session
+          Enter to send · Shift+Enter for newline · /reset for new session · /rule &lt;text&gt; to
+          save a team rule
         </p>
       </div>
     )

--- a/apps/web/src/features/chat/parseToolEntry.ts
+++ b/apps/web/src/features/chat/parseToolEntry.ts
@@ -1,0 +1,39 @@
+// Pure parser for `[[tool]]` / `[[tool-result]]` markdown lines emitted by
+// `@clawboo/protocol`'s `formatToolCallMarkdown` / `formatToolResultMarkdown`.
+//
+// Extracted to its own module so non-renderer modules
+// (`buildDelegationLinkages.ts`) can parse tool calls without pulling in the
+// React component tree from `chatComponents.tsx` (which would create a
+// circular import: chatComponents imports `buildDelegationLinkages`, and
+// `buildDelegationLinkages` needs `parseToolEntry` for the Round 6
+// `sessions_send` tool-call → DelegationCard pipeline).
+
+export interface ParsedToolEntry {
+  kind: 'call' | 'result'
+  /**
+   * The tool identifier emitted by the protocol — typically `"<tool_name>"`
+   * or `"<tool_name> (<call_id>)"`. Callers that need just the tool name
+   * should `name.split(' ')[0]` (e.g. `sessions_send` from
+   * `"sessions_send (call_abc)"`).
+   */
+  name: string
+  /**
+   * Everything after the tool-name line. For `kind === 'call'` this is the
+   * fenced JSON params block. For `kind === 'result'` this is the tool's
+   * stringified return value.
+   */
+  body: string
+}
+
+/** Parse [[tool]] / [[tool-result]] lines from the protocol. */
+export function parseToolEntry(text: string): ParsedToolEntry | null {
+  const isCall = text.startsWith('[[tool]]')
+  const isResult = text.startsWith('[[tool-result]]')
+  if (!isCall && !isResult) return null
+  const prefix = isCall ? '[[tool]]' : '[[tool-result]]'
+  const rest = text.slice(prefix.length)
+  const nl = rest.indexOf('\n')
+  const name = (nl === -1 ? rest : rest.slice(0, nl)).trim()
+  const body = nl === -1 ? '' : rest.slice(nl + 1).trim()
+  return { kind: isCall ? 'call' : 'result', name, body }
+}

--- a/apps/web/src/features/chat/splitAssistantText.ts
+++ b/apps/web/src/features/chat/splitAssistantText.ts
@@ -7,7 +7,7 @@ import { findDelegationBlocks } from '@/features/group-chat/delegationDetector'
 
 export type AssistantSegment =
   | { kind: 'prose'; text: string }
-  | { kind: 'delegation'; targetName: string; task: string }
+  | { kind: 'delegation'; targetName: string; task: string; blockStart: number; blockEnd: number }
 
 /**
  * Walk the assistant text and produce an ordered list of segments. Empty
@@ -39,6 +39,8 @@ export function splitAssistantText(text: string): AssistantSegment[] {
       kind: 'delegation',
       targetName: cleanedName,
       task: block.task,
+      blockStart: block.blockStart,
+      blockEnd: block.blockEnd,
     })
     cursor = block.blockEnd
   }

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2, RotateCcw } from 'lucide-react'
 import { GatewayClient, resolveProxyGatewayUrl } from '@clawboo/gateway-client'
+import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
 import type { DbApprovalHistory } from '@clawboo/db'
 import { GatewayConnectScreen } from './GatewayConnectScreen'
 import { OnboardingWizard } from '@/features/onboarding/OnboardingWizard'
@@ -293,6 +294,16 @@ export function GatewayBootstrap() {
             for (const a of mapped) {
               if (a.id === booZeroId) a.name = override
             }
+            // Auto-sync the display name into Boo Zero's SOUL.md. Idempotent
+            // (no-op when the SOUL.md heading already matches). Best-effort —
+            // the per-turn rules block in `lib/booZeroRules.ts` is the
+            // authoritative anchor regardless of whether the sync sticks.
+            // Fire-and-forget so a slow Gateway doesn't delay fleet hydration.
+            void syncBooZeroSoulIdentity({
+              client: liveClient,
+              agentId: booZeroId,
+              displayName: override,
+            })
           }
         }
 

--- a/apps/web/src/features/connection/useGatewayEvents.ts
+++ b/apps/web/src/features/connection/useGatewayEvents.ts
@@ -144,6 +144,16 @@ export function useGatewayEvents(client: GatewayClient | null): void {
           (agentId ? getTeamChatOverride(agentId, runId) : undefined) ?? sessionKey
         if (resolvedKey && patch.streamText !== undefined) {
           useChatStore.getState().setStreamingText(resolvedKey, patch.streamText)
+          // Anchor the stream-start timestamp for this session in the chat
+          // store. First chunk wins (the store action is no-op when already
+          // set). Skipped when `streamText` is null (end-of-stream marker)
+          // so we don't re-anchor right before commit. The renderer reads
+          // this timestamp to position the live StreamingCard at its
+          // chronological slot — no more "bottom-of-list during stream,
+          // jump to top on commit" re-arrangement.
+          if (patch.streamText !== null) {
+            useChatStore.getState().setStreamStart(resolvedKey, Date.now())
+          }
         }
       },
 
@@ -167,7 +177,17 @@ export function useGatewayEvents(client: GatewayClient | null): void {
         const sessionKey = teamOverride ?? eventSessionKey ?? agent?.sessionKey
         if (!sessionKey) return
 
-        const now = Date.now()
+        // Anchor the commit batch to when streaming STARTED for this session,
+        // not when it commits. Without this, a long-streaming leader's commit
+        // lands AFTER fast specialists' commits even though the leader's
+        // response began first. Stream-start lives in the chat store so
+        // renderers can subscribe AND `appendOutputLines` can read it here.
+        // Falls back to commit time for tool-only batches that never streamed.
+        const streamStart = useChatStore.getState().streamStartedAt.get(sessionKey) ?? null
+        if (streamStart !== null) {
+          useChatStore.getState().clearStreamStart(sessionKey)
+        }
+        const timestamp = streamStart ?? Date.now()
         const entries: TranscriptEntry[] = lines.map((text) => ({
           entryId: crypto.randomUUID(),
           runId: agent?.runId ?? null,
@@ -179,10 +199,10 @@ export function useGatewayEvents(client: GatewayClient | null): void {
           role: 'assistant' as const,
           text,
           source: 'runtime-chat' as const,
-          timestampMs: now,
+          timestampMs: timestamp,
           // Each line in the batch gets a unique strictly-increasing
           // sequenceKey so the merged-view sort can break ties even when
-          // every line shares `now`.
+          // every line shares the same timestamp.
           sequenceKey: nextSeq(),
           confirmed: true,
           fingerprint: crypto.randomUUID(),
@@ -401,6 +421,10 @@ export function useGatewayEvents(client: GatewayClient | null): void {
       patchQueue.dispose()
       handler.dispose()
       clearAllWakeRecords()
+      // Stream-start anchors live in the chat store (Round 5) — they're
+      // already wiped per-session via `clearStreamStart` at commit time
+      // and via `clearTranscript` for session resets. No global cleanup
+      // needed here.
     }
   }, [client])
 }

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -750,84 +750,12 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
           doesn't leak into other views. */}
       {scope === 'atlas' && showTeamHalos && <TeamHaloLayer nodes={nodes} />}
 
-      {/* Re-layout — bumps the layout key and saves new positions. Shown
-          on the canvas (instead of the now-suppressed panel toolbar) so
-          both Atlas and the embedded Group Chat graph have it in the
-          same place. Gated by `hasRunLayout` — there's nothing to
-          re-layout before the first ELK pass completes. Position 224px
-          from the right keeps a stable column order regardless of which
-          scope is active: [Re-layout] [Team halos] [Connect]. Team halos
-          is hidden in team scope, leaving a small empty band — preferred
-          over conditional offsets that would jitter as scope changes. */}
-      {hasRunLayout && (
-        <button
-          onClick={resetLayout}
-          title="Re-layout"
-          style={{
-            position: 'absolute',
-            top: 12,
-            right: 224,
-            zIndex: 20,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            padding: '6px 12px',
-            borderRadius: 8,
-            fontSize: 12,
-            fontWeight: 600,
-            cursor: 'pointer',
-            border: '1px solid rgba(255,255,255,0.1)',
-            background: '#111827',
-            color: 'rgba(232,232,232,0.5)',
-            transition: 'all 0.15s',
-          }}
-          onMouseOver={(e) =>
-            ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.85)')
-          }
-          onMouseOut={(e) =>
-            ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.5)')
-          }
-        >
-          <RefreshCw size={14} />
-          Re-layout
-        </button>
-      )}
-
-      {/* Team halos toggle — Atlas-only control. Hidden in team scope so
-          the toolbar doesn't carry irrelevant chrome. */}
-      {scope === 'atlas' && (
-        <button
-          onClick={() => setShowTeamHalos(!showTeamHalos)}
-          title="Toggle colored team hulls behind agents"
-          style={{
-            position: 'absolute',
-            top: 12,
-            right: 112,
-            zIndex: 20,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 6,
-            padding: '6px 12px',
-            borderRadius: 8,
-            fontSize: 12,
-            fontWeight: 600,
-            cursor: 'pointer',
-            border: showTeamHalos
-              ? '1px solid rgba(52,211,153,0.4)'
-              : '1px solid rgba(255,255,255,0.1)',
-            background: showTeamHalos ? 'rgba(52,211,153,0.18)' : '#111827',
-            color: showTeamHalos ? '#34D399' : 'rgba(232,232,232,0.5)',
-            transition: 'all 0.15s',
-          }}
-        >
-          <Pin size={14} />
-          Team halos
-        </button>
-      )}
-
-      {/* Connect mode toggle */}
-      <button
-        onClick={() => setConnectMode(!connectMode)}
+      {/* Floating top-right toolbar — Re-layout / Team halos (Atlas only) /
+          Connect. Wrapped in a single flex row so the buttons always sit
+          adjacent regardless of which subset is visible. The previous
+          layout pinned each button to a fixed `right:` offset, which left
+          a visible gap in team scope where Team halos was hidden. */}
+      <div
         style={{
           position: 'absolute',
           top: 12,
@@ -835,21 +763,95 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
           zIndex: 20,
           display: 'flex',
           alignItems: 'center',
-          gap: 6,
-          padding: '6px 12px',
-          borderRadius: 8,
-          fontSize: 12,
-          fontWeight: 600,
-          cursor: 'pointer',
-          border: connectMode ? '1px solid rgba(233,69,96,0.4)' : '1px solid rgba(255,255,255,0.1)',
-          background: connectMode ? 'rgba(233,69,96,0.2)' : '#111827',
-          color: connectMode ? '#E94560' : 'rgba(232,232,232,0.5)',
-          transition: 'all 0.15s',
+          gap: 8,
         }}
       >
-        <GitBranch size={14} />
-        {connectMode ? 'Drawing Edges' : 'Connect'}
-      </button>
+        {/* Re-layout — bumps the layout key and saves new positions.
+            Gated by `hasRunLayout` — there's nothing to re-layout
+            before the first ELK pass completes. */}
+        {hasRunLayout && (
+          <button
+            onClick={resetLayout}
+            title="Re-layout"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 12px',
+              borderRadius: 8,
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+              border: '1px solid rgba(255,255,255,0.1)',
+              background: '#111827',
+              color: 'rgba(232,232,232,0.5)',
+              transition: 'all 0.15s',
+            }}
+            onMouseOver={(e) =>
+              ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.85)')
+            }
+            onMouseOut={(e) =>
+              ((e.currentTarget as HTMLButtonElement).style.color = 'rgba(232,232,232,0.5)')
+            }
+          >
+            <RefreshCw size={14} />
+            Re-layout
+          </button>
+        )}
+
+        {/* Team halos toggle — Atlas-only. Hidden in team scope so the
+            toolbar doesn't carry irrelevant chrome; with flex layout,
+            removing it leaves no gap. */}
+        {scope === 'atlas' && (
+          <button
+            onClick={() => setShowTeamHalos(!showTeamHalos)}
+            title="Toggle colored team hulls behind agents"
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '6px 12px',
+              borderRadius: 8,
+              fontSize: 12,
+              fontWeight: 600,
+              cursor: 'pointer',
+              border: showTeamHalos
+                ? '1px solid rgba(52,211,153,0.4)'
+                : '1px solid rgba(255,255,255,0.1)',
+              background: showTeamHalos ? 'rgba(52,211,153,0.18)' : '#111827',
+              color: showTeamHalos ? '#34D399' : 'rgba(232,232,232,0.5)',
+              transition: 'all 0.15s',
+            }}
+          >
+            <Pin size={14} />
+            Team halos
+          </button>
+        )}
+
+        {/* Connect mode toggle */}
+        <button
+          onClick={() => setConnectMode(!connectMode)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            padding: '6px 12px',
+            borderRadius: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            cursor: 'pointer',
+            border: connectMode
+              ? '1px solid rgba(233,69,96,0.4)'
+              : '1px solid rgba(255,255,255,0.1)',
+            background: connectMode ? 'rgba(233,69,96,0.2)' : '#111827',
+            color: connectMode ? '#E94560' : 'rgba(232,232,232,0.5)',
+            transition: 'all 0.15s',
+          }}
+        >
+          <GitBranch size={14} />
+          {connectMode ? 'Drawing Edges' : 'Connect'}
+        </button>
+      </div>
 
       {/* MiniMap minimize/maximize toggle. Sits at the bottom-right corner —
           where the MiniMap itself lives — so the relationship between the

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -24,6 +24,9 @@ import {
   MetaMessageCard,
   MessageComposer,
   NEAR_BOTTOM_PX,
+  isFollowupBlock,
+  blockMarginClass,
+  BLOCK_ROW_HOVER_CLASS,
   type MessageComposerHandle,
 } from '@/features/chat/chatComponents'
 import { AgentChips } from './AgentChips'
@@ -481,51 +484,88 @@ export function GroupChatPanel({
             </p>
           </div>
         ) : (
-          <div className="flex flex-col gap-5 pb-2">
-            {topLevelBlocks.map((block, i) => {
-              if (block.kind === 'meta') {
-                return <MetaMessageCard key={block.entry.entryId} entry={block.entry} />
-              }
-              if (block.kind === 'user') {
-                const targetId = agentIdFromSessionKey(block.entry.sessionKey)
-                const targetAgent = targetId ? agentLookup.get(targetId) : null
-                return (
-                  <UserMessageCard
-                    key={block.entry.entryId}
-                    entry={block.entry}
-                    targetAgentName={targetAgent?.name}
-                    knownAgentNames={knownAgentNames}
-                  />
+          <div className="flex flex-col pb-2">
+            {(() => {
+              // Track the previous block + its owner across the loop so the
+              // follow-up check has both pieces of context. Same author +
+              // assistant-turn + within 5 min → drop the repeated header
+              // and tighten the top margin (the Slack/Discord/iMessage
+              // grouping pattern).
+              let prevBlock: (typeof topLevelBlocks)[number] | null = null
+              let prevOwnerAgentId: string | null = null
+              return topLevelBlocks.map((block, i) => {
+                let currentOwnerAgentId: string | null = null
+                if (block.kind === 'assistant-turn') {
+                  const firstEntry = block.assistant ?? block.thinking[0] ?? block.tools[0] ?? null
+                  currentOwnerAgentId = firstEntry
+                    ? agentIdFromSessionKey(firstEntry.sessionKey)
+                    : null
+                }
+                const isFollowup = isFollowupBlock(
+                  prevBlock,
+                  block,
+                  prevOwnerAgentId,
+                  currentOwnerAgentId,
                 )
-              }
-              // assistant-turn: determine owning agent from first entry
-              const firstEntry = block.assistant ?? block.thinking[0] ?? block.tools[0] ?? null
-              const ownerAgentId = firstEntry ? agentIdFromSessionKey(firstEntry.sessionKey) : null
-              const ownerAgent = ownerAgentId ? agentLookup.get(ownerAgentId) : null
-              return (
-                <AssistantTurnCard
-                  key={`turn-${i}`}
-                  block={block}
-                  agentId={ownerAgent?.id ?? 'unknown'}
-                  agentName={ownerAgent?.name ?? 'Agent'}
-                  streaming={
-                    anyRunning && i === topLevelBlocks.length - 1 && activeStreams.length === 0
-                  }
-                  linkagesBySourceEntry={linkages.linkagesBySourceEntry}
-                  teamId={teamId}
-                  latestSourceEntryId={latestSourceEntryIdWithDelegations}
-                />
-              )
-            })}
+                const margin = blockMarginClass(i, isFollowup)
+                prevBlock = block
+                prevOwnerAgentId = currentOwnerAgentId
 
-            {/* Live streaming — one card per actively streaming agent */}
+                if (block.kind === 'meta') {
+                  return (
+                    <div key={block.entry.entryId} className={margin}>
+                      <MetaMessageCard entry={block.entry} />
+                    </div>
+                  )
+                }
+                if (block.kind === 'user') {
+                  const targetId = agentIdFromSessionKey(block.entry.sessionKey)
+                  const targetAgent = targetId ? agentLookup.get(targetId) : null
+                  return (
+                    <div
+                      key={block.entry.entryId}
+                      className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}
+                    >
+                      <UserMessageCard
+                        entry={block.entry}
+                        targetAgentName={targetAgent?.name}
+                        knownAgentNames={knownAgentNames}
+                      />
+                    </div>
+                  )
+                }
+                const ownerAgent = currentOwnerAgentId ? agentLookup.get(currentOwnerAgentId) : null
+                return (
+                  <div key={`turn-${i}`} className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}>
+                    <AssistantTurnCard
+                      block={block}
+                      agentId={ownerAgent?.id ?? 'unknown'}
+                      agentName={ownerAgent?.name ?? 'Agent'}
+                      streaming={
+                        anyRunning && i === topLevelBlocks.length - 1 && activeStreams.length === 0
+                      }
+                      linkagesBySourceEntry={linkages.linkagesBySourceEntry}
+                      teamId={teamId}
+                      latestSourceEntryId={latestSourceEntryIdWithDelegations}
+                      isFollowup={isFollowup}
+                    />
+                  </div>
+                )
+              })
+            })()}
+
+            {/* Live streaming — one card per actively streaming agent.
+                Always gets the "new section" margin since we can't know
+                whether the streaming agent matches the chronologically-
+                last committed block's owner without extra bookkeeping. */}
             {activeStreams.map((stream) => (
-              <StreamingCard
-                key={`stream-${stream.agentId}`}
-                text={stream.text}
-                agentId={stream.agentId}
-                agentName={stream.agentName}
-              />
+              <div key={`stream-wrap-${stream.agentId}`} className="mt-7">
+                <StreamingCard
+                  text={stream.text}
+                  agentId={stream.agentId}
+                  agentName={stream.agentName}
+                />
+              </div>
             ))}
 
             <div ref={bottomRef} aria-hidden />

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -11,6 +11,7 @@ import { useBooZeroStore } from '@/stores/booZero'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
 import { sendGroupChatMessage } from './groupChatSendOperation'
 import { useTeamOrchestration } from './useTeamOrchestration'
+import { buildDelegationLinkages } from './buildDelegationLinkages'
 import { stopAllInTeam } from '@/features/chat/stopChatOperation'
 import {
   groupEntriesToBlocks,
@@ -168,6 +169,52 @@ export function GroupChatPanel({
 
   const blocks = useMemo(() => groupEntriesToBlocks(mergedEntries), [mergedEntries])
 
+  // ── Delegation linkages ──────────────────────────────────────────────────
+  // Pure scan of the merged transcript: pairs each `<delegate>` block in a
+  // source agent's reply with the next eligible target reply. Used by the
+  // renderer to (1) hide claimed target replies from the top-level stream
+  // and (2) nest those replies inside the source's DelegationCard.
+  const linkages = useMemo(
+    () =>
+      buildDelegationLinkages({
+        blocks,
+        mergedEntries,
+        teamId,
+        participants: participants.map((a) => ({ id: a.id, name: a.name })),
+      }),
+    [blocks, mergedEntries, teamId, participants],
+  )
+
+  // Pick the entryId of the chronologically-latest source-turn that contains
+  // delegations. All delegations on THAT source default-expand; older ones
+  // collapse (per the user's "newest expanded, older collapsed" choice).
+  const latestSourceEntryIdWithDelegations = useMemo(() => {
+    let latestSeq = -1
+    let latestId: string | null = null
+    for (const linkage of linkages.linkagesByDelegationId.values()) {
+      const sourceEntry = mergedEntries.find((e) => e.entryId === linkage.sourceEntryId)
+      if (!sourceEntry) continue
+      if (sourceEntry.sequenceKey > latestSeq) {
+        latestSeq = sourceEntry.sequenceKey
+        latestId = sourceEntry.entryId
+      }
+    }
+    return latestId
+  }, [linkages, mergedEntries])
+
+  // Filter assistant-turn blocks whose owning entry is claimed by some
+  // delegation — those render INSIDE a DelegationCard, not at the top level.
+  const topLevelBlocks = useMemo(
+    () =>
+      blocks.filter((b) => {
+        if (b.kind !== 'assistant-turn') return true
+        const owner = b.assistant ?? b.thinking[0] ?? b.tools[0] ?? null
+        if (!owner) return true
+        return !linkages.claimedEntries.has(owner.entryId)
+      }),
+    [blocks, linkages.claimedEntries],
+  )
+
   // ── Load persisted history for all participants (team-scoped sessionKeys) ──
   useEffect(() => {
     for (const agent of participants) {
@@ -207,18 +254,24 @@ export function GroupChatPanel({
 
   // Collect all streaming texts for participants (using team-scoped sessionKeys).
   // Boo Zero's stream lands in the merged transcript with its own avatar/name.
+  //
+  // Streams whose target sessionKey is OWNED by a pending DelegationCard are
+  // filtered out — that card subscribes to the same stream itself and renders
+  // it inline. Without this filter the stream would appear both inside the
+  // card AND as a duplicate top-level StreamingCard.
   const activeStreams = useMemo(() => {
     const streams: { agentId: string; agentName: string; text: string }[] = []
     for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
+      if (linkages.streamingOwnerByTargetSessionKey.has(teamSk)) continue
       const text = streamingTextMap.get(teamSk)
       if (text != null) {
         streams.push({ agentId: agent.id, agentName: agent.name, text })
       }
     }
     return streams
-  }, [participants, teamSessionKeys, streamingTextMap])
+  }, [participants, teamSessionKeys, streamingTextMap, linkages.streamingOwnerByTargetSessionKey])
 
   const anyRunning = teamAgents.some((a) => a.status === 'running')
 
@@ -230,7 +283,7 @@ export function GroupChatPanel({
         rafRef.current = null
       }
     }
-  }, [blocks.length, activeStreams.length, scheduleScroll])
+  }, [topLevelBlocks.length, activeStreams.length, scheduleScroll])
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current
@@ -268,7 +321,7 @@ export function GroupChatPanel({
   const canSend = Boolean(
     client && connectionStatus === 'connected' && teamAgents.length > 0 && !anyRunning,
   )
-  const isEmpty = blocks.length === 0 && activeStreams.length === 0
+  const isEmpty = topLevelBlocks.length === 0 && activeStreams.length === 0
 
   // ── Render ────────────────────────────────────────────────────────────────
   return (
@@ -311,7 +364,7 @@ export function GroupChatPanel({
           </div>
         ) : (
           <div className="flex flex-col gap-5 pb-2">
-            {blocks.map((block, i) => {
+            {topLevelBlocks.map((block, i) => {
               if (block.kind === 'meta') {
                 return <MetaMessageCard key={block.entry.entryId} entry={block.entry} />
               }
@@ -337,7 +390,12 @@ export function GroupChatPanel({
                   block={block}
                   agentId={ownerAgent?.id ?? 'unknown'}
                   agentName={ownerAgent?.name ?? 'Agent'}
-                  streaming={anyRunning && i === blocks.length - 1 && activeStreams.length === 0}
+                  streaming={
+                    anyRunning && i === topLevelBlocks.length - 1 && activeStreams.length === 0
+                  }
+                  linkagesBySourceEntry={linkages.linkagesBySourceEntry}
+                  teamId={teamId}
+                  latestSourceEntryId={latestSourceEntryIdWithDelegations}
                 />
               )
             })}

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -26,7 +26,6 @@ import {
   NEAR_BOTTOM_PX,
   isFollowupBlock,
   blockMarginClass,
-  BLOCK_ROW_HOVER_CLASS,
   type MessageComposerHandle,
 } from '@/features/chat/chatComponents'
 import { AgentChips } from './AgentChips'
@@ -522,10 +521,7 @@ export function GroupChatPanel({
                   const targetId = agentIdFromSessionKey(block.entry.sessionKey)
                   const targetAgent = targetId ? agentLookup.get(targetId) : null
                   return (
-                    <div
-                      key={block.entry.entryId}
-                      className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}
-                    >
+                    <div key={block.entry.entryId} className={margin}>
                       <UserMessageCard
                         entry={block.entry}
                         targetAgentName={targetAgent?.name}
@@ -536,7 +532,7 @@ export function GroupChatPanel({
                 }
                 const ownerAgent = currentOwnerAgentId ? agentLookup.get(currentOwnerAgentId) : null
                 return (
-                  <div key={`turn-${i}`} className={`${margin} ${BLOCK_ROW_HOVER_CLASS}`.trim()}>
+                  <div key={`turn-${i}`} className={margin}>
                     <AssistantTurnCard
                       block={block}
                       agentId={ownerAgent?.id ?? 'unknown'}

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -60,6 +60,16 @@ export function GroupChatPanel({
   const connectionStatus = useConnectionStore((s) => s.status)
   const transcripts = useChatStore((s) => s.transcripts)
   const streamingTextMap = useChatStore((s) => s.streamingText)
+  // Round 5: subscribe to stream-start timestamps so live StreamingCards
+  // can position themselves at their chronological slot in the merged
+  // timeline (not always-at-the-end). After commit, the committed entry
+  // takes the same `timestampMs` value — zero visible re-arrangement.
+  const streamStartedAtMap = useChatStore((s) => s.streamStartedAt)
+  // Round 7: Clawboo's recorded outgoing routing events for this team.
+  // Threaded into `buildDelegationLinkages` Path 3 so DelegationCards
+  // surface ACTUAL Clawboo routing — `dispatchDelegation` + relay batches
+  // — independent of whatever the LLM emits in prose.
+  const clawbooDispatchesMap = useChatStore((s) => s.clawbooDispatches)
 
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
@@ -210,8 +220,9 @@ export function GroupChatPanel({
         mergedEntries,
         teamId,
         participants: participants.map((a) => ({ id: a.id, name: a.name })),
+        clawbooDispatches: clawbooDispatchesMap,
       }),
-    [blocks, mergedEntries, teamId, participants],
+    [blocks, mergedEntries, teamId, participants, clawbooDispatchesMap],
   )
 
   // Pick the entryId of the chronologically-latest source-turn that contains
@@ -317,18 +328,83 @@ export function GroupChatPanel({
   // it inline. Without this filter the stream would appear both inside the
   // card AND as a duplicate top-level StreamingCard.
   const activeStreams = useMemo(() => {
-    const streams: { agentId: string; agentName: string; text: string }[] = []
+    const streams: {
+      agentId: string
+      agentName: string
+      text: string
+      sessionKey: string
+      streamStartedAt: number
+    }[] = []
     for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
       if (linkages.streamingOwnerByTargetSessionKey.has(teamSk)) continue
       const text = streamingTextMap.get(teamSk)
       if (text != null) {
-        streams.push({ agentId: agent.id, agentName: agent.name, text })
+        // Stream-start anchors the live card's chronological position in
+        // the timeline. Falls back to "now" on the first render after a
+        // chunk lands but before the store update commits (vanishingly
+        // rare in practice — Zustand updates are synchronous).
+        const streamStartedAt = streamStartedAtMap.get(teamSk) ?? Date.now()
+        streams.push({
+          agentId: agent.id,
+          agentName: agent.name,
+          text,
+          sessionKey: teamSk,
+          streamStartedAt,
+        })
       }
     }
     return streams
-  }, [participants, teamSessionKeys, streamingTextMap, linkages.streamingOwnerByTargetSessionKey])
+  }, [
+    participants,
+    teamSessionKeys,
+    streamingTextMap,
+    streamStartedAtMap,
+    linkages.streamingOwnerByTargetSessionKey,
+  ])
+
+  // ── Interleaved render timeline ───────────────────────────────────────────
+  // Committed blocks and active streaming cards merged into ONE chronologically-
+  // sorted list. Each item carries the timestamp at which the leader's
+  // response BEGAN — committed entries from `appendOutputLines` use the same
+  // stream-start anchor, so a streaming card and its eventual committed entry
+  // occupy the same chronological slot. No visible re-arrangement on commit.
+  type RenderItem =
+    | { kind: 'block'; block: (typeof topLevelBlocks)[number]; ts: number; tieKey: number }
+    | { kind: 'stream'; stream: (typeof activeStreams)[number]; ts: number; tieKey: number }
+  const renderItems = useMemo<RenderItem[]>(() => {
+    const blockTs = (block: (typeof topLevelBlocks)[number]): number => {
+      // AssistantBlock carries its own `timestampMs`; meta/user blocks
+      // anchor on their underlying entry. Fall back to 0 only as a defensive
+      // last resort.
+      if (block.kind === 'assistant-turn') return block.timestampMs ?? 0
+      return block.entry.timestampMs ?? 0
+    }
+    const items: RenderItem[] = []
+    for (let i = 0; i < topLevelBlocks.length; i++) {
+      const block = topLevelBlocks[i]!
+      items.push({ kind: 'block', block, ts: blockTs(block), tieKey: i })
+    }
+    for (const stream of activeStreams) {
+      // Streams sort AFTER committed blocks with the same timestamp because
+      // the committed entry IS what the stream produced — once it commits,
+      // the stream disappears and the committed block takes the slot. While
+      // streaming, the slight tieKey bump keeps the live card visually below
+      // any same-timestamp tool/thinking block that already committed.
+      items.push({
+        kind: 'stream',
+        stream,
+        ts: stream.streamStartedAt,
+        tieKey: Number.MAX_SAFE_INTEGER,
+      })
+    }
+    items.sort((a, b) => {
+      if (a.ts !== b.ts) return a.ts - b.ts
+      return a.tieKey - b.tieKey
+    })
+    return items
+  }, [topLevelBlocks, activeStreams])
 
   const anyRunning = teamAgents.some((a) => a.status === 'running')
 
@@ -485,14 +561,34 @@ export function GroupChatPanel({
         ) : (
           <div className="flex flex-col pb-2">
             {(() => {
-              // Track the previous block + its owner across the loop so the
-              // follow-up check has both pieces of context. Same author +
-              // assistant-turn + within 5 min → drop the repeated header
-              // and tighten the top margin (the Slack/Discord/iMessage
-              // grouping pattern).
+              // Track previous BLOCK across the loop (not previous stream)
+              // so the same-author follow-up grouping survives stream
+              // interruptions. Streams are always rendered with the
+              // "new section" margin — they don't participate in the
+              // Slack/Discord/iMessage author-grouping rhythm.
               let prevBlock: (typeof topLevelBlocks)[number] | null = null
               let prevOwnerAgentId: string | null = null
-              return topLevelBlocks.map((block, i) => {
+              let blockIdx = -1
+              const lastBlockSeenIdx = topLevelBlocks.length - 1
+
+              return renderItems.map((item, i) => {
+                if (item.kind === 'stream') {
+                  const stream = item.stream
+                  return (
+                    <div
+                      key={`stream-wrap-${stream.agentId}-${stream.sessionKey}`}
+                      className={i === 0 ? '' : 'mt-7'}
+                    >
+                      <StreamingCard
+                        text={stream.text}
+                        agentId={stream.agentId}
+                        agentName={stream.agentName}
+                      />
+                    </div>
+                  )
+                }
+                blockIdx += 1
+                const block = item.block
                 let currentOwnerAgentId: string | null = null
                 if (block.kind === 'assistant-turn') {
                   const firstEntry = block.assistant ?? block.thinking[0] ?? block.tools[0] ?? null
@@ -506,7 +602,10 @@ export function GroupChatPanel({
                   prevOwnerAgentId,
                   currentOwnerAgentId,
                 )
-                const margin = blockMarginClass(i, isFollowup)
+                // Use `i === 0` (timeline position) for the "first item
+                // has no top margin" check; `blockIdx` only matters for
+                // the followup-vs-new-author choice.
+                const margin = i === 0 ? '' : blockMarginClass(blockIdx, isFollowup)
                 prevBlock = block
                 prevOwnerAgentId = currentOwnerAgentId
 
@@ -532,15 +631,16 @@ export function GroupChatPanel({
                 }
                 const ownerAgent = currentOwnerAgentId ? agentLookup.get(currentOwnerAgentId) : null
                 return (
-                  <div key={`turn-${i}`} className={margin}>
+                  <div key={`turn-${blockIdx}`} className={margin}>
                     <AssistantTurnCard
                       block={block}
                       agentId={ownerAgent?.id ?? 'unknown'}
                       agentName={ownerAgent?.name ?? 'Agent'}
                       streaming={
-                        anyRunning && i === topLevelBlocks.length - 1 && activeStreams.length === 0
+                        anyRunning && blockIdx === lastBlockSeenIdx && activeStreams.length === 0
                       }
                       linkagesBySourceEntry={linkages.linkagesBySourceEntry}
+                      claimedEntries={linkages.claimedEntries}
                       teamId={teamId}
                       latestSourceEntryId={latestSourceEntryIdWithDelegations}
                       isFollowup={isFollowup}
@@ -549,20 +649,6 @@ export function GroupChatPanel({
                 )
               })
             })()}
-
-            {/* Live streaming — one card per actively streaming agent.
-                Always gets the "new section" margin since we can't know
-                whether the streaming agent matches the chronologically-
-                last committed block's owner without extra bookkeeping. */}
-            {activeStreams.map((stream) => (
-              <div key={`stream-wrap-${stream.agentId}`} className="mt-7">
-                <StreamingCard
-                  text={stream.text}
-                  agentId={stream.agentId}
-                  agentName={stream.agentName}
-                />
-              </div>
-            ))}
 
             <div ref={bottomRef} aria-hidden />
           </div>

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -70,6 +70,14 @@ export function GroupChatPanel({
   // surface ACTUAL Clawboo routing — `dispatchDelegation` + relay batches
   // — independent of whatever the LLM emits in prose.
   const clawbooDispatchesMap = useChatStore((s) => s.clawbooDispatches)
+  // Round 13: implicit fan-out workstreams. When the leader emits pure
+  // prose like "I'll ask all teammates" without structured tags,
+  // `useTeamOrchestration` mints a `pendingWorkstreams` record with
+  // `:implicit-fanout` suffix. Threaded into `buildDelegationLinkages`
+  // Path 4 so the WorkstreamCard renders the implicit batch with the
+  // same DONE pills / preview lines / grid as an explicit `<delegate>`
+  // batch.
+  const pendingWorkstreamsMap = useChatStore((s) => s.pendingWorkstreams)
 
   const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
@@ -221,26 +229,66 @@ export function GroupChatPanel({
         teamId,
         participants: participants.map((a) => ({ id: a.id, name: a.name })),
         clawbooDispatches: clawbooDispatchesMap,
+        pendingWorkstreams: pendingWorkstreamsMap,
+        // Round 15: feed live streaming text + stream-start anchors into the
+        // linkage scan so closed `<delegate>` blocks emitted mid-stream
+        // (before the leader's source entry commits) claim their target's
+        // streaming/committed reply. Without this, the target's reply
+        // appears at top level during the gap and "jumps inside" the card
+        // only once the leader commits.
+        streamingTexts: streamingTextMap,
+        streamStartedAt: streamStartedAtMap,
       }),
-    [blocks, mergedEntries, teamId, participants, clawbooDispatchesMap],
+    [
+      blocks,
+      mergedEntries,
+      teamId,
+      participants,
+      clawbooDispatchesMap,
+      pendingWorkstreamsMap,
+      streamingTextMap,
+      streamStartedAtMap,
+    ],
   )
 
-  // Pick the entryId of the chronologically-latest source-turn that contains
-  // delegations. All delegations on THAT source default-expand; older ones
-  // collapse (per the user's "newest expanded, older collapsed" choice).
+  // Pick the entryId of the chronologically-latest LEADER source-turn that
+  // contains visible delegations. All delegations on THAT source default-
+  // expand; older ones collapse (per the user's "newest expanded, older
+  // collapsed" accordion topology).
+  //
+  // Restrict to leader = Boo Zero. A specialist agent occasionally emits
+  // its own `<delegate>` tag in a response — those linkages have higher
+  // timestamps than Boo Zero's last delegation turn and would otherwise
+  // win the "latest" comparison, but their cards render NESTED inside the
+  // parent DelegationCard (not at top level), so they never receive the
+  // auto-expand signal. Net effect of including them: ALL visible top-
+  // level cards stay collapsed forever. Filtering to leader-source
+  // linkages restores the "newest top-level workstream auto-opens"
+  // behavior the user expects.
+  //
+  // Sort by `timestampMs` (wall-clock, stable across reloads) NOT
+  // `sequenceKey` (process-local, resets to 0 on reload) — same lesson as
+  // Round 7B's `findTargetResponse` fix.
   const latestSourceEntryIdWithDelegations = useMemo(() => {
+    let latestTs = -1
     let latestSeq = -1
     let latestId: string | null = null
     for (const linkage of linkages.linkagesByDelegationId.values()) {
+      // Only consider linkages whose source is the leader (Boo Zero). A
+      // specialist's rogue `<delegate>` shouldn't move the accordion
+      // pointer because its cards aren't visible top-level.
+      if (booZeroAgent && linkage.sourceAgentId !== booZeroAgent.id) continue
       const sourceEntry = mergedEntries.find((e) => e.entryId === linkage.sourceEntryId)
       if (!sourceEntry) continue
-      if (sourceEntry.sequenceKey > latestSeq) {
+      const ts = sourceEntry.timestampMs ?? 0
+      if (ts > latestTs || (ts === latestTs && sourceEntry.sequenceKey > latestSeq)) {
+        latestTs = ts
         latestSeq = sourceEntry.sequenceKey
         latestId = sourceEntry.entryId
       }
     }
     return latestId
-  }, [linkages, mergedEntries])
+  }, [linkages, mergedEntries, booZeroAgent])
 
   // Filter assistant-turn blocks whose owning entry is claimed by some
   // delegation — those render INSIDE a DelegationCard, not at the top level.
@@ -261,13 +309,55 @@ export function GroupChatPanel({
   // entries and replay stale wake/relay messages (the 7-hour-cascade bug).
   // The 5s safety timeout is a fallback — if a fetch hangs forever we still
   // want orchestration to come online eventually.
+  //
+  // **CRITICAL — stable dep signature**: depend on a STRING derived from
+  // participant ids, not the participants array reference. `participants`
+  // is a `useMemo` over `[teamAgents, booZeroAgent]`, both of which are
+  // Zustand selector results — the array reference REALLOCATES on every
+  // fleet store update (every agent status patch during streaming). With
+  // the array as a dep, this effect re-fired on every chat tick, resetting
+  // `historyHydrated` to `false` → disabling orchestration → the
+  // `useTeamOrchestration` subscription kept unmounting and remounting,
+  // its `processNewEntries` never running. That broke Round 7's dispatch
+  // recording, Round 8's plan state machine, AND Round 10's workstream
+  // auto-synthesis. The string signature only changes when the set of
+  // participant IDs actually changes (e.g., team switch, agent deleted).
+  const participantSignature = useMemo(
+    () =>
+      participants
+        .map((a) => a.id)
+        .sort()
+        .join('|'),
+    [participants],
+  )
+  // Stash the latest array/map refs so the effect can read them at fire
+  // time without participating in the dependency list. We DELIBERATELY do
+  // NOT include `participants` / `teamSessionKeys` in the effect's deps —
+  // see the multi-line rationale in the effect body below.
+  const participantsRef = useRef(participants)
+  participantsRef.current = participants
+  const teamSessionKeysRef = useRef(teamSessionKeys)
+  teamSessionKeysRef.current = teamSessionKeys
   useEffect(() => {
     setHistoryHydrated(false)
     let cancelled = false
 
+    // Read the latest participants/teamSessionKeys via refs (not deps). The
+    // `participants` array reference reallocates whenever the fleet-store
+    // agents array reallocates (which happens on EVERY agent status patch
+    // during streaming — a chat tick can fire 10+ patches per second), and
+    // `teamSessionKeys` is downstream of that. If we put them in the deps,
+    // this effect re-fires on every chat tick, resets `historyHydrated` to
+    // `false`, and the `useTeamOrchestration` subscription gated on it
+    // unmounts/remounts in a tight loop — breaking Round 7 dispatch
+    // recording, Round 8 plan state machines, AND Round 10 workstream
+    // auto-synthesis. The `participantSignature` string only changes when
+    // the set of participant IDs actually changes (team switch, agent
+    // added/removed), which is the right granularity for "re-hydrate
+    // history".
     const fetches: Promise<unknown>[] = []
-    for (const agent of participants) {
-      const teamSk = teamSessionKeys.get(agent.id)
+    for (const agent of participantsRef.current) {
+      const teamSk = teamSessionKeysRef.current.get(agent.id)
       if (!teamSk) continue
       const existing = useChatStore.getState().transcripts.get(teamSk)
       if (existing && existing.length > 0) continue
@@ -300,7 +390,7 @@ export function GroupChatPanel({
       cancelled = true
       clearTimeout(timer)
     }
-  }, [participants, teamSessionKeys])
+  }, [participantSignature])
 
   // ── Auto-scroll ───────────────────────────────────────────────────────────
   const scrollRef = useRef<HTMLDivElement>(null)

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -13,6 +13,9 @@ import { sendGroupChatMessage } from './groupChatSendOperation'
 import { useTeamOrchestration } from './useTeamOrchestration'
 import { buildDelegationLinkages } from './buildDelegationLinkages'
 import { stopAllInTeam } from '@/features/chat/stopChatOperation'
+import { appendRule, fetchTeamRules, parseRuleCommand, saveTeamRules } from '@/lib/teamRules'
+import { nextSeq } from '@/lib/sequenceKey'
+import { useToastStore } from '@/stores/toast'
 import {
   groupEntriesToBlocks,
   UserMessageCard,
@@ -76,6 +79,24 @@ export function GroupChatPanel({
   // orchestration-side cleanup.
   const [stopSignal, setStopSignal] = useState(0)
 
+  // ── History-hydration gate ──────────────────────────────────────────────
+  // `useTeamOrchestration` must NOT process historical entries that arrive
+  // via `/api/chat-history` hydration as if they were new — that's the root
+  // cause of the "7-hour-later cascade of intros / wake messages" we saw in
+  // production. The hook seeds `lastCountsRef` on mount; if it mounts before
+  // hydration completes, the seed reads `0` and every hydrated entry trips
+  // the subscription's "new entries" branch.
+  //
+  // We flip this flag to `true` AFTER `Promise.allSettled` over all per-
+  // participant history fetches resolves. The hook is gated on `enabled =
+  // connected && historyHydrated` so it only mounts (and thus only seeds)
+  // when the transcript is in its final settled shape.
+  //
+  // Resets on `teamId` change so reopening a different team waits for THAT
+  // team's hydration cycle. Falls open after a 5s timeout as a safety net —
+  // a hung fetch shouldn't lock the team chat orchestration forever.
+  const [historyHydrated, setHistoryHydrated] = useState(false)
+
   // ── Team orchestration (delegation detection + context relay) ───────────
   //
   // Always on — relay + delegation routing is the whole point of a team
@@ -94,7 +115,13 @@ export function GroupChatPanel({
     leaderAgentId: teamInternalLeadId,
     booZeroAgent,
     client,
-    enabled: connectionStatus === 'connected',
+    // Hold orchestration until history has fully hydrated. This is the
+    // load-bearing fix for the "rehydrate cascade" — see `historyHydrated`
+    // declaration above. While `false`, the hook returns early without
+    // subscribing, so the hydration-time `appendTranscript` calls don't
+    // trip the "new entries" branch and fire stale wake/relay messages
+    // for entries that landed hours ago.
+    enabled: connectionStatus === 'connected' && historyHydrated,
     userIntroText,
     stopSignal,
   })
@@ -216,21 +243,49 @@ export function GroupChatPanel({
   )
 
   // ── Load persisted history for all participants (team-scoped sessionKeys) ──
+  // Tracks completion via `historyHydrated`: `useTeamOrchestration` is gated
+  // on this flag so it doesn't see the hydration-time appends as "new"
+  // entries and replay stale wake/relay messages (the 7-hour-cascade bug).
+  // The 5s safety timeout is a fallback — if a fetch hangs forever we still
+  // want orchestration to come online eventually.
   useEffect(() => {
+    setHistoryHydrated(false)
+    let cancelled = false
+
+    const fetches: Promise<unknown>[] = []
     for (const agent of participants) {
       const teamSk = teamSessionKeys.get(agent.id)
       if (!teamSk) continue
       const existing = useChatStore.getState().transcripts.get(teamSk)
       if (existing && existing.length > 0) continue
 
-      fetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
-        .then((r) => r.json())
-        .then(({ entries: historical }: { entries?: TranscriptEntry[] }) => {
-          if (historical && historical.length > 0) {
-            useChatStore.getState().appendTranscript(teamSk, historical)
-          }
-        })
-        .catch(() => {})
+      fetches.push(
+        fetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
+          .then((r) => r.json())
+          .then(({ entries: historical }: { entries?: TranscriptEntry[] }) => {
+            if (cancelled) return
+            if (historical && historical.length > 0) {
+              useChatStore.getState().appendTranscript(teamSk, historical)
+            }
+          })
+          .catch(() => {}),
+      )
+    }
+
+    // Safety timeout — if a fetch hangs we still want orchestration online.
+    const timer = setTimeout(() => {
+      if (!cancelled) setHistoryHydrated(true)
+    }, 5000)
+
+    void Promise.allSettled(fetches).then(() => {
+      if (cancelled) return
+      clearTimeout(timer)
+      setHistoryHydrated(true)
+    })
+
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
     }
   }, [participants, teamSessionKeys])
 
@@ -294,6 +349,59 @@ export function GroupChatPanel({
   // ── Send handler ──────────────────────────────────────────────────────────
   const handleSend = useCallback(
     async (message: string) => {
+      // `/rule <text>` — intercept BEFORE routing to any agent. Appends the
+      // text to the team's durable rules in SQLite, drops a meta entry in
+      // every team session's transcript so the user gets visible
+      // confirmation, and short-circuits without sending to the Gateway.
+      const ruleText = parseRuleCommand(message)
+      if (ruleText !== null) {
+        try {
+          const existing = await fetchTeamRules(teamId)
+          const updated = appendRule(existing, ruleText)
+          const ok = await saveTeamRules(teamId, updated)
+          if (!ok) {
+            useToastStore.getState().addToast({
+              message: 'Could not save team rule. Try again?',
+              type: 'error',
+            })
+            return
+          }
+          // Drop a single meta confirmation into the first participant's
+          // session so the merged team view shows ONE entry, not N
+          // duplicates. The rule itself is global to the team (in SQLite),
+          // so the per-session anchor is just a visual breadcrumb.
+          const firstAgent = participants[0]
+          const firstSk = firstAgent ? teamSessionKeys.get(firstAgent.id) : null
+          if (firstSk) {
+            useChatStore.getState().appendTranscript(firstSk, [
+              {
+                entryId: crypto.randomUUID(),
+                runId: null,
+                sessionKey: firstSk,
+                kind: 'meta',
+                role: 'system',
+                text: `Rule saved for team: ${ruleText}`,
+                source: 'local-send',
+                timestampMs: Date.now(),
+                sequenceKey: nextSeq(),
+                confirmed: true,
+                fingerprint: crypto.randomUUID(),
+              },
+            ])
+          }
+          useToastStore.getState().addToast({
+            message: 'Team rule saved.',
+            type: 'success',
+          })
+        } catch {
+          useToastStore.getState().addToast({
+            message: 'Could not save team rule. Try again?',
+            type: 'error',
+          })
+        }
+        return
+      }
+
       if (!client) return
       await sendGroupChatMessage({
         client,
@@ -310,7 +418,17 @@ export function GroupChatPanel({
         userIntroText,
       })
     },
-    [client, teamId, team?.name, teamInternalLeadId, teamAgents, booZeroAgent, userIntroText],
+    [
+      client,
+      teamId,
+      team?.name,
+      teamInternalLeadId,
+      teamAgents,
+      booZeroAgent,
+      userIntroText,
+      participants,
+      teamSessionKeys,
+    ],
   )
 
   // ── Chip tag handler ───────────────────────────────────────────────────────

--- a/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
+++ b/apps/web/src/features/group-chat/GroupChatViewHeader.tsx
@@ -11,8 +11,11 @@
 // is sourced from the graph store directly so it stays in sync with the
 // canvas without GroupChatView having to plumb it through.
 
+import { useState } from 'react'
+import { Settings } from 'lucide-react'
 import { useGraphStore } from '@/features/graph/store'
 import type { Team } from '@/stores/team'
+import { TeamSettingsSheet } from './TeamSettingsSheet'
 
 interface GroupChatViewHeaderProps {
   team: Team | null
@@ -24,64 +27,92 @@ export function GroupChatViewHeader({ team }: GroupChatViewHeaderProps) {
   const booCount = useGraphStore((s) => s.nodes.filter((n) => n.type === 'boo').length)
   const skillCount = useGraphStore((s) => s.nodes.filter((n) => n.type === 'skill').length)
 
+  // Open-state for the team-settings sheet — holds the brief + rules
+  // editors that used to live in the System panel. Local-state because
+  // it doesn't outlive the team-chat view.
+  const [settingsOpen, setSettingsOpen] = useState(false)
+
   // Don't flash "0 Boos · 0 skills" before the graph hydrates — render an
   // ellipsis placeholder until the structural rebuild lands its first node.
   const hasGraph = booCount > 0
   return (
-    <div className="flex shrink-0 items-center gap-3 border-b border-white/8 px-4 py-3">
-      {team && (
-        <span
-          className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
-          style={{ background: `${team.color}22` }}
-        >
-          {team.icon}
-        </span>
-      )}
-      <div className="min-w-0 flex-1">
-        <h2
-          className="truncate text-[14px] font-semibold text-text"
-          style={{ fontFamily: 'var(--font-body)' }}
-        >
-          {team?.name ?? 'Group Chat'}
-        </h2>
-        {/* Accent-red pill badge — same style as the old Ghost Graph
-            toolbar badge, so the boo/skill count keeps the same visual
-            prominence after being folded into the team header. While the
-            graph hydrates we render a dimmer placeholder pill instead of
-            "0 Boos · 0 skills" flashing in. */}
-        <div className="mt-1.5 flex">
-          {hasGraph ? (
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 500,
-                color: '#E94560',
-                background: 'rgba(233,69,96,0.12)',
-                borderRadius: 20,
-                padding: '2px 10px',
-                lineHeight: '16px',
-              }}
-            >
-              {booCount} Boo{booCount !== 1 ? 's' : ''}
-              {skillCount > 0 && ` · ${skillCount} skill${skillCount !== 1 ? 's' : ''}`}
-            </span>
-          ) : (
-            <span
-              style={{
-                fontSize: 11,
-                fontWeight: 500,
-                color: 'rgba(232,232,232,0.35)',
-                background: 'rgba(255,255,255,0.04)',
-                borderRadius: 20,
-                padding: '2px 10px',
-                lineHeight: '16px',
-              }}
-            >
-              …
-            </span>
-          )}
+    <>
+      <div className="flex shrink-0 items-center gap-3 border-b border-white/8 px-4 py-3">
+        {team && (
+          <span
+            className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg text-[16px]"
+            style={{ background: `${team.color}22` }}
+          >
+            {team.icon}
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <h2
+            className="truncate text-[14px] font-semibold text-text"
+            style={{ fontFamily: 'var(--font-body)' }}
+          >
+            {team?.name ?? 'Group Chat'}
+          </h2>
+          {/* Accent-red pill badge — same style as the old Ghost Graph
+              toolbar badge, so the boo/skill count keeps the same visual
+              prominence after being folded into the team header. While the
+              graph hydrates we render a dimmer placeholder pill instead of
+              "0 Boos · 0 skills" flashing in. */}
+          <div className="mt-1.5 flex">
+            {hasGraph ? (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: '#E94560',
+                  background: 'rgba(233,69,96,0.12)',
+                  borderRadius: 20,
+                  padding: '2px 10px',
+                  lineHeight: '16px',
+                }}
+              >
+                {booCount} Boo{booCount !== 1 ? 's' : ''}
+                {skillCount > 0 && ` · ${skillCount} skill${skillCount !== 1 ? 's' : ''}`}
+              </span>
+            ) : (
+              <span
+                style={{
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: 'rgba(232,232,232,0.35)',
+                  background: 'rgba(255,255,255,0.04)',
+                  borderRadius: 20,
+                  padding: '2px 10px',
+                  lineHeight: '16px',
+                }}
+              >
+                …
+              </span>
+            )}
+          </div>
         </div>
+        {/* Team-settings entry point — opens TeamSettingsSheet (brief +
+            rules). Icon + text label mirrors the canvas toolbar buttons
+            (Re-layout / Connect) so the affordance reads consistently.
+            Hidden when no team is active (the "Group Chat" fallback is a
+            non-team-scoped view, so there's nothing to configure). */}
+        {team && (
+          <button
+            type="button"
+            onClick={() => setSettingsOpen(true)}
+            aria-label={`${team.name} — brief & rules`}
+            title="Team brief & rules"
+            data-testid="team-settings-button"
+            className="flex h-8 shrink-0 items-center gap-1.5 rounded-lg border border-white/8 bg-surface/40 px-2.5 text-[11px] font-medium text-text/70 transition hover:bg-surface/70 hover:text-text"
+          >
+            <Settings size={13} strokeWidth={1.75} />
+            Brief &amp; Rules
+          </button>
+        )}
       </div>
-    </div>
+      {settingsOpen && team && (
+        <TeamSettingsSheet team={team} onClose={() => setSettingsOpen(false)} />
+      )}
+    </>
   )
 }

--- a/apps/web/src/features/group-chat/TeamBriefForm.tsx
+++ b/apps/web/src/features/group-chat/TeamBriefForm.tsx
@@ -1,0 +1,210 @@
+// TeamBriefForm — flat (non-collapsible) editor for a single team's brief.
+// Replaces the collapsible TeamBriefEditor used in the old maintenance panel:
+// here we manage ONE team at a time (the one whose chat the user has open),
+// so the collapse chrome would be wasted.
+//
+// Used by `TeamSettingsSheet` — opened from the team header gear icon.
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, RefreshCw, Save } from 'lucide-react'
+import { useFleetStore } from '@/stores/fleet'
+import { useToastStore } from '@/stores/toast'
+import { buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
+import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
+
+interface BriefResponse {
+  content?: string | null
+  updatedAt?: number | null
+}
+
+async function fetchTeamBrief(teamId: string): Promise<BriefResponse> {
+  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
+  if (!res.ok) throw new Error('Failed to load team brief')
+  return (await res.json()) as BriefResponse
+}
+
+async function putTeamBrief(teamId: string, content: string): Promise<void> {
+  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  })
+  if (!res.ok) throw new Error('Failed to save team brief')
+}
+
+export function TeamBriefForm({
+  teamId,
+  teamName,
+  teamIcon,
+  templateId,
+}: {
+  teamId: string
+  teamName: string
+  teamIcon: string
+  templateId: string | null
+}) {
+  const agents = useFleetStore((s) => s.agents)
+  const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
+
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+
+  const computeDefaultBrief = useCallback((): string => {
+    const genuineLead =
+      teamAgents.find((a) => detectGenuineLeader({ name: a.name, role: a.name })) ?? null
+    const matched = genuineLead
+      ? matchedLeadershipKeyword({ name: genuineLead.name, role: genuineLead.name })
+      : null
+    const members: TeamBriefMember[] = teamAgents.map((a) => ({
+      name: a.name,
+      role: a.name,
+    }))
+    return buildTeamBrief({
+      team: { name: teamName, icon: teamIcon, templateId, description: null },
+      members,
+      internalLead:
+        genuineLead && matched ? { agentName: genuineLead.name, matchedKeyword: matched } : null,
+    })
+  }, [teamAgents, teamName, teamIcon, templateId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetchTeamBrief(teamId)
+      .then((r) => {
+        if (cancelled) return
+        const value = r.content && r.content.length > 0 ? r.content : computeDefaultBrief()
+        setContent(value)
+        setClean(value)
+      })
+      .catch(() => {
+        if (cancelled) return
+        const fallback = computeDefaultBrief()
+        setContent(fallback)
+        setClean(fallback)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [teamId, computeDefaultBrief])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      await putTeamBrief(teamId, content)
+      setClean(content)
+      useToastStore.getState().addToast({ type: 'success', message: `Brief for ${teamName} saved` })
+    } catch (e) {
+      useToastStore
+        .getState()
+        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
+    } finally {
+      setSaving(false)
+    }
+  }, [teamId, teamName, content])
+
+  const handleRegenerate = useCallback(() => {
+    setContent(computeDefaultBrief())
+  }, [computeDefaultBrief])
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          padding: 16,
+          fontSize: 11,
+          color: 'rgba(232,232,232,0.5)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <Loader2 size={12} className="animate-spin" /> Loading brief…
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        Describes this team — read by Boo Zero whenever it operates in {teamName}. Editable; safe to
+        regenerate from the current team roster.
+      </p>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        disabled={saving}
+        spellCheck={false}
+        style={{
+          width: '100%',
+          minHeight: 200,
+          maxHeight: 420,
+          padding: 10,
+          fontSize: 12,
+          fontFamily: 'var(--font-geist-mono, monospace)',
+          lineHeight: 1.55,
+          background: 'rgba(13,17,23,0.85)',
+          color: '#E8E8E8',
+          border: '1px solid rgba(255,255,255,0.08)',
+          borderRadius: 6,
+          resize: 'vertical',
+        }}
+      />
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty || saving}
+          style={{
+            height: 28,
+            padding: '0 10px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 6,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+            color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+            cursor: !isDirty || saving ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={handleRegenerate}
+          disabled={saving}
+          style={{
+            height: 28,
+            padding: '0 10px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 6,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'rgba(255,255,255,0.04)',
+            color: 'rgba(232,232,232,0.7)',
+            cursor: saving ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+          title="Regenerate from current team members (does not save until you press Save)"
+        >
+          <RefreshCw size={12} />
+          Regenerate
+        </button>
+        {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -62,6 +62,34 @@ const AGENT_INTRO_PROMPT = [
   'Do NOT use @ in your response.',
 ].join('\n')
 
+/**
+ * Stronger retry prompt — used when an agent's first intro is refusal-
+ * shaped or too short to convey identity ("NO" was the smoking gun from
+ * production). The retry is explicit that this is a routine introduction
+ * and asks for a longer response than the first prompt.
+ */
+const AGENT_INTRO_RETRY_PROMPT = [
+  'Your previous response was unclear and could not be used as a team introduction.',
+  '',
+  'Please introduce yourself properly in two sentences:',
+  '- Your name (as set in your IDENTITY.md)',
+  '- What you specialize in / what teammates can come to you for',
+  '',
+  'This is a ROUTINE team introduction — not a task assignment, not a sensitive request, not anything to refuse. Every member of this team is doing the same now.',
+  '',
+  'Do NOT respond with refusals, "NO", or other short non-answers. Do NOT mention teammates by name. Aim for ~30-80 words.',
+].join('\n')
+
+const MIN_INTRO_CHARS = 25
+const REFUSAL_RE = /^(no|nope|sorry|can'?t|cannot|unable)\b/i
+
+function isValidIntro(text: string): boolean {
+  const trimmed = text.trim()
+  if (trimmed.length < MIN_INTRO_CHARS) return false
+  if (REFUSAL_RE.test(trimmed)) return false
+  return true
+}
+
 function buildUserIntroSoulPatch(userIntro: string): string {
   return `\n\n## About the User\n${userIntro.trim()}\n`
 }
@@ -93,6 +121,12 @@ export function TeamOnboardingGate({
   // can detect "this agent has produced a NEW response since we asked them".
   const baselineCountsRef = useRef<Map<string, number>>(new Map())
 
+  // Per-agent retry count — capped at 1 so we don't loop on a stubbornly
+  // refusing model. When an intro is refusal-shaped or too short, we fire
+  // the retry prompt once with a stronger ask before accepting whatever
+  // the agent eventually produces.
+  const retriesRef = useRef<Map<string, number>>(new Map())
+
   // ── Phase B: detect agent intro completion via transcript subscription ──
   useEffect(() => {
     if (phase !== 'introducing') return
@@ -110,10 +144,56 @@ export function TeamOnboardingGate({
         const newAssistant = entries
           .slice(baseline)
           .find((e) => e.role === 'assistant' && e.kind === 'assistant' && e.text.trim().length > 0)
-        if (newAssistant) {
+        if (!newAssistant) continue
+
+        // Validate the intro response. If it's refusal-shaped or too
+        // short, retry ONCE with a stronger prompt. After the cap (1
+        // retry), accept whatever lands — better to move on than to
+        // loop forever on a stubbornly-refusing model. Smoking gun from
+        // production: "NO" from Jira Workflow Steward Boo.
+        if (isValidIntro(newAssistant.text)) {
           nextCompleted.add(agent.id)
           changed = true
+          continue
         }
+
+        const retries = retriesRef.current.get(agent.id) ?? 0
+        if (retries >= 1) {
+          // Already retried; accept this response as-is so onboarding
+          // can advance.
+          nextCompleted.add(agent.id)
+          changed = true
+          continue
+        }
+        if (!client) {
+          // No client to fire the retry — accept what we have.
+          nextCompleted.add(agent.id)
+          changed = true
+          continue
+        }
+        retriesRef.current.set(agent.id, retries + 1)
+        // Bump the baseline so the NEXT response (post-retry-prompt) is
+        // what we detect as new, not the current weak one.
+        baselineCountsRef.current.set(agent.id, entries.length)
+        // Fire the retry prompt — best-effort. The override is already
+        // set from the initial send; no need to re-set it.
+        void client
+          .call('chat.send', {
+            sessionKey: teamSk,
+            message: AGENT_INTRO_RETRY_PROMPT,
+            deliver: false,
+            idempotencyKey: crypto.randomUUID(),
+          })
+          .catch(() => {
+            // Retry send failed — accept whatever we already have so
+            // the user isn't stuck on the gate forever.
+            nextCompleted.add(agent.id)
+            setCompletedAgentIds((prev) => {
+              const merged = new Set(prev)
+              merged.add(agent.id)
+              return merged
+            })
+          })
       }
       if (changed) setCompletedAgentIds(nextCompleted)
     }
@@ -123,7 +203,7 @@ export function TeamOnboardingGate({
     return () => {
       unsub()
     }
-  }, [phase, teamAgents, teamId, completedAgentIds])
+  }, [phase, teamAgents, teamId, completedAgentIds, client])
 
   // When all agents finish introducing, advance to user-intro phase AND
   // post a single meta entry "introducing" Boo Zero as the team's universal

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -543,7 +543,7 @@ export function TeamOnboardingGate({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
-              className="mx-auto flex max-w-md flex-col"
+              className="mx-auto flex max-w-3xl flex-col"
             >
               <h3
                 className="mb-2 text-center text-[16px] font-semibold text-text"
@@ -603,7 +603,7 @@ export function TeamOnboardingGate({
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
               transition={{ duration: 0.2 }}
-              className="mx-auto flex max-w-md flex-col"
+              className="mx-auto flex max-w-3xl flex-col"
             >
               <h3
                 className="mb-2 text-center text-[16px] font-semibold text-text"
@@ -618,7 +618,7 @@ export function TeamOnboardingGate({
 
               {/* Show agent intros recap (if available) */}
               {agentIntros.size > 0 && (
-                <details className="mb-4 rounded-lg border border-white/8 bg-surface/30 p-3">
+                <details open className="mb-4 rounded-lg border border-white/8 bg-surface/30 p-3">
                   <summary className="cursor-pointer text-[11px] font-semibold text-secondary">
                     Recap: who&rsquo;s on the team
                   </summary>

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -616,24 +616,30 @@ export function TeamOnboardingGate({
                 you&rsquo;d like the team to help. This is saved to each agent&rsquo;s context.
               </p>
 
-              {/* Show agent intros recap (if available) */}
+              {/* Show agent intros recap (if available) — sized to be
+                  readable, not a footnote. The intros are the user's main
+                  context for what each teammate does, so they get body-
+                  weight type (13px) at higher contrast (~85% opacity)
+                  with relaxed line-height. */}
               {agentIntros.size > 0 && (
-                <details open className="mb-4 rounded-lg border border-white/8 bg-surface/30 p-3">
-                  <summary className="cursor-pointer text-[11px] font-semibold text-secondary">
+                <details open className="mb-4 rounded-lg border border-white/8 bg-surface/30 p-4">
+                  <summary className="cursor-pointer text-[12px] font-semibold text-secondary/90">
                     Recap: who&rsquo;s on the team
                   </summary>
-                  <div className="mt-3 flex flex-col gap-2">
+                  <div className="mt-4 flex flex-col gap-4">
                     {teamAgents.map((agent) => {
                       const intro = agentIntros.get(agent.id)
                       if (!intro) return null
                       return (
-                        <div key={agent.id} className="flex items-start gap-2">
-                          <BooAvatar seed={agent.id} size={24} />
+                        <div key={agent.id} className="flex items-start gap-3">
+                          <BooAvatar seed={agent.id} size={32} />
                           <div className="min-w-0 flex-1">
-                            <span className="text-[11px] font-semibold text-text">
+                            <span className="text-[13px] font-semibold text-text">
                               {agent.name}
                             </span>
-                            <p className="text-[10px] text-secondary/70">{intro}</p>
+                            <p className="mt-0.5 text-[13px] leading-relaxed text-text/75">
+                              {intro}
+                            </p>
                           </div>
                         </div>
                       )

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -24,6 +24,7 @@ import { useToastStore } from '@/stores/toast'
 import { buildTeamSessionKey, setTeamChatOverride } from '@/lib/sessionUtils'
 import { markAgentAwake } from '@/lib/wakeTracker'
 import { nextSeq } from '@/lib/sequenceKey'
+import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -345,6 +346,19 @@ export function TeamOnboardingGate({
     })
     await Promise.allSettled(writePromises)
 
+    // Boo Zero SOUL.md sync — submitting the user intro is the per-team
+    // onboarding "approval moment". The user has just told us they're ready
+    // to chat with this team, which is the right moment to also re-anchor
+    // Boo Zero's persisted identity with the current display name. Best-
+    // effort; the per-turn rules block stays authoritative regardless.
+    if (booZeroAgent) {
+      void syncBooZeroSoulIdentity({
+        client,
+        agentId: booZeroAgent.id,
+        displayName: booZeroAgent.name,
+      })
+    }
+
     // Drop a meta entry into each agent's team transcript so the user sees
     // their introduction land in chat (the agents won't respond to it — it
     // was only written to SOUL.md, not sent as a chat message).
@@ -385,20 +399,42 @@ export function TeamOnboardingGate({
     } finally {
       setSubmittingUserIntro(false)
     }
-  }, [client, userIntroText, teamAgents, teamId, onMarkUserIntroduced])
+  }, [client, userIntroText, teamAgents, teamId, booZeroAgent, onMarkUserIntroduced])
 
   // ── Read agent intro responses to display in Phase C ──────────────────────
+  // Use the LAST assistant entry after the per-agent baseline so the recap
+  // shows the agent's actual introduction even when an earlier attempt was
+  // refusal-shaped and we retried. Before this fix, a "NO" intro from agent X
+  // would stay visible in the recap even after the retry produced a clean
+  // intro — `entries.find(...)` returned the first match, ignoring the retry.
   const agentIntros = useMemo(() => {
     const transcripts = useChatStore.getState().transcripts
     const intros = new Map<string, string>()
     for (const agent of teamAgents) {
       const teamSk = buildTeamSessionKey(agent.id, teamId)
       const entries = transcripts.get(teamSk) ?? []
-      // Find the first assistant entry — that's their introduction
-      const found = entries.find(
-        (e) => e.role === 'assistant' && e.kind === 'assistant' && e.text.trim().length > 0,
-      )
-      if (found) intros.set(agent.id, found.text.trim())
+      const baseline = baselineCountsRef.current.get(agent.id) ?? 0
+      // Walk backwards so we get the LATEST assistant entry post-baseline.
+      // (If the retry produced a longer/cleaner reply, that's the one to
+      // display; the refusal-shaped first attempt stays in chat history but
+      // the recap shows what the user can actually act on.)
+      let latest: string | null = null
+      for (let i = entries.length - 1; i >= baseline; i--) {
+        const e = entries[i]
+        if (e && e.role === 'assistant' && e.kind === 'assistant' && e.text.trim().length > 0) {
+          latest = e.text.trim()
+          break
+        }
+      }
+      // Fallback: if we didn't find anything post-baseline (shouldn't happen
+      // once the gate has detected completion), use the first overall.
+      if (!latest) {
+        const found = entries.find(
+          (e) => e.role === 'assistant' && e.kind === 'assistant' && e.text.trim().length > 0,
+        )
+        if (found) latest = found.text.trim()
+      }
+      if (latest) intros.set(agent.id, latest)
     }
     return intros
     // We re-derive whenever completedAgentIds changes (Phase B updates) or the

--- a/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
+++ b/apps/web/src/features/group-chat/TeamOnboardingGate.tsx
@@ -81,6 +81,14 @@ const AGENT_INTRO_RETRY_PROMPT = [
   'Do NOT respond with refusals, "NO", or other short non-answers. Do NOT mention teammates by name. Aim for ~30-80 words.',
 ].join('\n')
 
+// Onboarding's "did the agent introduce itself?" check is intentionally
+// stricter than the general-purpose `isLikelyRefusal` in
+// `lib/teamProtocol.ts`. The renderer filter excludes bare `no` because the
+// OpenClaw protocol-token filter catches `NO` / `NO_REPLY` separately. Here
+// we ALSO want to catch "No, I won't introduce myself" (length>25 but still
+// a refusal at the start of a sentence). Both regexes overlap on the longer
+// openers (nope/sorry/can't/cannot/unable) — kept local to avoid coupling
+// the two semantic uses.
 const MIN_INTRO_CHARS = 25
 const REFUSAL_RE = /^(no|nope|sorry|can'?t|cannot|unable)\b/i
 

--- a/apps/web/src/features/group-chat/TeamRulesEditor.tsx
+++ b/apps/web/src/features/group-chat/TeamRulesEditor.tsx
@@ -1,0 +1,131 @@
+// TeamRulesEditor — user-captured durable rules injected into every team
+// agent's preamble. Source of truth: settings table `team-rules:<teamId>`.
+// Also writable via `/rule <text>` in the team chat composer.
+//
+// Used by `TeamSettingsSheet` — opened from the team header gear icon.
+
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2, Save } from 'lucide-react'
+import { useToastStore } from '@/stores/toast'
+import { fetchTeamRules as fetchTeamRulesContent, saveTeamRules } from '@/lib/teamRules'
+
+export function TeamRulesEditor({ teamId }: { teamId: string }) {
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetchTeamRulesContent(teamId)
+      .then((value) => {
+        if (cancelled) return
+        setContent(value)
+        setClean(value)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [teamId])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      const ok = await saveTeamRules(teamId, content)
+      if (ok) {
+        setClean(content)
+        useToastStore.getState().addToast({ message: 'Team rules saved.', type: 'success' })
+      } else {
+        useToastStore.getState().addToast({ message: 'Could not save rules.', type: 'error' })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }, [content, teamId])
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
+        Durable rules injected into every team agent&apos;s preamble + every Boo Zero turn in this
+        team. One rule per line. Also writable via <code>/rule &lt;text&gt;</code> in the team chat
+        composer.
+      </p>
+      {loading ? (
+        <div
+          style={{
+            padding: 10,
+            fontSize: 11,
+            color: 'rgba(232,232,232,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <Loader2 size={12} className="animate-spin" /> Loading rules…
+        </div>
+      ) : (
+        <>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            disabled={saving}
+            spellCheck={false}
+            placeholder="No rules yet. Type one per line — they'll be injected into every team agent's preamble."
+            style={{
+              width: '100%',
+              minHeight: 120,
+              maxHeight: 320,
+              padding: 8,
+              fontSize: 12,
+              fontFamily: 'var(--font-geist-mono, monospace)',
+              lineHeight: 1.55,
+              background: 'rgba(13,17,23,0.85)',
+              color: '#E8E8E8',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 6,
+              resize: 'vertical',
+            }}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!isDirty || saving}
+              style={{
+                height: 26,
+                padding: '0 10px',
+                fontSize: 11,
+                fontWeight: 600,
+                borderRadius: 6,
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+                color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+                cursor: !isDirty || saving ? 'default' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+              Save rules
+            </button>
+            {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/group-chat/TeamSettingsSheet.tsx
+++ b/apps/web/src/features/group-chat/TeamSettingsSheet.tsx
@@ -1,0 +1,198 @@
+// TeamSettingsSheet — modal that owns the per-team brief + per-team rules.
+//
+// Opened from the gear icon on `GroupChatViewHeader`. Hosts two editors
+// stacked vertically: `TeamBriefForm` (per-team brief, read by Boo Zero
+// when working in this team) and `TeamRulesEditor` (durable user-set rules
+// injected into every team-agent preamble + every Boo Zero turn in this
+// team).
+//
+// Before this sheet existed, both editors lived inside the System-panel
+// Boo Zero section — semantically wrong (team-scoped data under a
+// system/agent surface) and hard to discover. Now they live with the team.
+
+import { useCallback, useEffect } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { X } from 'lucide-react'
+import type { Team } from '@/stores/team'
+import { TeamBriefForm } from './TeamBriefForm'
+import { TeamRulesEditor } from './TeamRulesEditor'
+
+interface TeamSettingsSheetProps {
+  team: Team
+  onClose: () => void
+}
+
+export function TeamSettingsSheet({ team, onClose }: TeamSettingsSheetProps) {
+  // Esc closes the sheet.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  // Click on the dark backdrop closes; clicks inside the panel don't bubble.
+  const onBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (e.target === e.currentTarget) onClose()
+    },
+    [onClose],
+  )
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="team-settings-backdrop"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.15 }}
+        onClick={onBackdropClick}
+        data-testid="team-settings-backdrop"
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.55)',
+          zIndex: 60,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 24,
+        }}
+      >
+        <motion.div
+          key="team-settings-panel"
+          initial={{ opacity: 0, y: 8, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 8, scale: 0.98 }}
+          transition={{ duration: 0.18 }}
+          data-testid="team-settings-sheet"
+          style={{
+            width: 'min(720px, 100%)',
+            maxHeight: '85vh',
+            background: '#0d1117',
+            border: '1px solid rgba(255,255,255,0.08)',
+            borderRadius: 12,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '14px 16px',
+              borderBottom: '1px solid rgba(255,255,255,0.06)',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                borderRadius: 8,
+                background: `${team.color}22`,
+                fontSize: 15,
+              }}
+            >
+              {team.icon}
+            </span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <h2
+                style={{
+                  margin: 0,
+                  fontSize: 14,
+                  fontWeight: 600,
+                  color: '#E8E8E8',
+                  fontFamily: 'var(--font-body, sans-serif)',
+                }}
+              >
+                {team.name} — Settings
+              </h2>
+              <p
+                style={{
+                  margin: '2px 0 0',
+                  fontSize: 10,
+                  color: 'rgba(232,232,232,0.45)',
+                }}
+              >
+                Brief + rules read on every turn by team agents and Boo Zero.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close team settings"
+              data-testid="team-settings-close"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 28,
+                height: 28,
+                borderRadius: 6,
+                border: 'none',
+                background: 'transparent',
+                color: 'rgba(232,232,232,0.6)',
+                cursor: 'pointer',
+              }}
+            >
+              <X size={16} />
+            </button>
+          </div>
+
+          {/* Body — scrollable */}
+          <div
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              padding: 18,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 24,
+            }}
+          >
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'rgba(232,232,232,0.85)',
+                }}
+              >
+                Brief
+              </h3>
+              <TeamBriefForm
+                teamId={team.id}
+                teamName={team.name}
+                teamIcon={team.icon}
+                templateId={team.templateId ?? null}
+              />
+            </section>
+
+            <section style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'rgba(232,232,232,0.85)',
+                }}
+              >
+                Rules
+              </h3>
+              <TeamRulesEditor teamId={team.id} />
+            </section>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
@@ -329,3 +329,471 @@ describe('buildDelegationLinkages — idempotency + invariants', () => {
     expect(result.claimedEntries.size).toBe(1)
   })
 })
+
+// Round 6: `sessions_send` tool calls render as DelegationCards directly. The
+// LLM often skips structured `<delegate>` tags and calls OpenClaw's
+// `sessions_send` Gateway tool instead — that call IS visible as a tool
+// entry in the leader's transcript (kind: 'tool', text: '[[tool]] sessions_send …').
+// The renderer-side scan converts each such call into a structured linkage
+// using the EXACT JSON params (`to`, `message`) — no prose heuristics.
+
+function makeToolCallEntry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    entryId: crypto.randomUUID(),
+    runId: 'run-' + Math.random().toString(36).slice(2, 9),
+    sessionKey: 'agent:bz:team:t1',
+    kind: 'tool',
+    role: 'tool',
+    text: '',
+    source: 'runtime-chat',
+    timestampMs: nextTs(),
+    sequenceKey: nextSeq(),
+    confirmed: true,
+    fingerprint: crypto.randomUUID(),
+    ...overrides,
+  } as TranscriptEntry
+}
+
+/**
+ * Build a `[[tool]] sessions_send …` line in the shape `@clawboo/protocol`'s
+ * `formatToolCallMarkdown` produces. OpenClaw's actual `sessions_send`
+ * schema is `{ sessionKey?, label?, agentId?, message }` — the caller
+ * supplies AT LEAST ONE routing identifier plus the message body. We
+ * provide a helper for each common form so tests can exercise the
+ * resolver paths independently.
+ */
+function sessionsSendToolText(
+  params: { sessionKey?: string; label?: string; agentId?: string; message: string },
+  callId = 'abc',
+): string {
+  return `[[tool]] sessions_send (${callId})\n\`\`\`json\n${JSON.stringify(params)}\n\`\`\``
+}
+
+describe('buildDelegationLinkages — sessions_send tool-call path (Round 6)', () => {
+  it('resolves a sessions_send call using `label` (agent display name)', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Let me have the team handle this.',
+    })
+    // Most common form in practice: the LLM uses the agent's display name.
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ label: 'Engineer Boo', message: 'Build a TL;DR for voice AI' }),
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-1',
+      text: 'Voice AI takes audio input...',
+    })
+    const result = build([source, toolCall, reply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('sessions-send')
+    expect(linkages[0]!.targetAgentId).toBe('eng')
+    expect(linkages[0]!.targetAgentName).toBe('Engineer Boo')
+    expect(linkages[0]!.task).toBe('Build a TL;DR for voice AI')
+    expect(linkages[0]!.linkedEntries).toEqual([reply])
+    expect(result.claimedEntries.has(toolCall.entryId)).toBe(true)
+    expect(result.claimedEntries.has(reply.entryId)).toBe(true)
+  })
+
+  it('resolves a sessions_send call using `agentId` (direct id)', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing by id.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ agentId: 'eng', message: 'do the thing' }),
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-id',
+      text: 'done',
+    })
+    const result = build([source, toolCall, reply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.targetAgentId).toBe('eng')
+  })
+
+  it('resolves a sessions_send call using `sessionKey` (parses agent:<id>:<session>)', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing by sessionKey.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ sessionKey: 'agent:des:main', message: 'design something' }),
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('des'),
+      runId: 'run-des-sk',
+      text: 'design draft',
+    })
+    const result = build([source, toolCall, reply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.targetAgentId).toBe('des')
+    expect(linkages[0]!.task).toBe('design something')
+  })
+
+  it('skips sessions_send calls whose identifier resolves to no participant', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Misrouted call.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ agentId: 'unknown-agent', message: 'this should not link' }),
+    })
+    const result = build([source, toolCall])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+    expect(result.claimedEntries.has(toolCall.entryId)).toBe(false)
+  })
+
+  it('skips sessions_send calls that target the source agent itself', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Self-loop, ignore.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ agentId: 'bz', message: 'I am calling myself' }),
+    })
+    const result = build([source, toolCall])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+    expect(result.claimedEntries.has(toolCall.entryId)).toBe(false)
+  })
+
+  it('coexists with explicit <delegate> tags on the same source — both link', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Mixed routing. <delegate to="@Engineer Boo">tag-routed task</delegate>',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ label: 'Designer Boo', message: 'tool-routed task' }),
+    })
+    const engReply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng',
+      text: 'engineer reply',
+    })
+    const desReply = makeAssistantEntry({
+      sessionKey: teamSk('des'),
+      runId: 'run-des',
+      text: 'designer reply',
+    })
+    const result = build([source, toolCall, engReply, desReply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    const bySource = linkages.reduce<Record<string, (typeof linkages)[number]>>((acc, l) => {
+      acc[l.source] = l
+      return acc
+    }, {})
+    expect(bySource['delegate-tag']?.targetAgentId).toBe('eng')
+    expect(bySource['delegate-tag']?.task).toBe('tag-routed task')
+    expect(bySource['sessions-send']?.targetAgentId).toBe('des')
+    expect(bySource['sessions-send']?.task).toBe('tool-routed task')
+  })
+
+  it('gracefully ignores sessions_send tool entries with malformed JSON', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: '[[tool]] sessions_send\n```json\n{ not valid json\n```',
+    })
+    const result = build([source, toolCall])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+    expect(result.claimedEntries.has(toolCall.entryId)).toBe(false)
+  })
+
+  it('marks the linkage pending when the target has not responded yet', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ label: 'Engineer Boo', message: 'work in progress' }),
+    })
+    const result = build([source, toolCall])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.isPending).toBe(true)
+    expect(linkages[0]!.linkedEntries).toEqual([])
+    expect(result.claimedEntries.has(toolCall.entryId)).toBe(true)
+  })
+})
+
+// Round 7: Path 3 — Clawboo's own routing events become DelegationCards.
+// When the LLM doesn't emit `<delegate>` tags OR `sessions_send` calls but
+// Clawboo's orchestration STILL routes work to specialists (via the
+// `detectDelegations` fallback regex OR `flushRelayBatch`), the recorded
+// dispatch in the chat store becomes the synthesis source. Cards reflect
+// actual Clawboo routing, not just the LLM's preferred emission format.
+
+import type { ClawbooDispatch } from '@/stores/chat'
+
+function makeDispatch(
+  overrides: Partial<ClawbooDispatch> & {
+    sourceEntryId: string
+    targetAgentId: string
+    targetAgentName: string
+  },
+): ClawbooDispatch {
+  return {
+    dispatchId: 'disp-' + Math.random().toString(36).slice(2, 9),
+    sourceAgentId: 'bz',
+    taskBody: 'do the thing',
+    origin: 'clawboo-relay',
+    sequenceKey: nextSeq(),
+    timestampMs: nextTs(),
+    teamId: 't1',
+    ...overrides,
+  } as ClawbooDispatch
+}
+
+function buildWithDispatches(
+  mergedEntries: TranscriptEntry[],
+  dispatches: Map<string, ClawbooDispatch[]>,
+) {
+  const blocks = groupEntriesToBlocks(mergedEntries)
+  return buildDelegationLinkages({
+    blocks,
+    mergedEntries,
+    teamId: 't1',
+    participants,
+    clawbooDispatches: dispatches,
+  })
+}
+
+describe('buildDelegationLinkages — Path 3 Clawboo-dispatch (Round 7)', () => {
+  it('synthesizes a relay-batch linkage when Clawboo routed without an explicit tag', () => {
+    // Order matters: nextSeq() is monotonic; the dispatch needs a
+    // sequenceKey LOWER than the reply for `findTargetResponse` to claim
+    // it. Real production flow guarantees this (the dispatch is recorded
+    // BEFORE the target's reply commits). Mirror that ordering here.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Here is a markdown table summarizing what the team would say...',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'relay-batch',
+      taskBody: 'Relayed summary of leader response',
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-relay',
+      text: '__skipped__',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source, reply], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('clawboo-relay')
+    expect(linkages[0]!.targetAgentId).toBe('eng')
+    expect(linkages[0]!.targetAgentName).toBe('Engineer Boo')
+    expect(linkages[0]!.task).toBe('Relayed summary of leader response')
+    // Note: reply text is `__skipped__` — `findTargetResponse` doesn't
+    // filter by content (that's `shouldDropAssistantTurn`'s job at render
+    // time, applied to the source not the target).
+    expect(linkages[0]!.linkedEntries).toEqual([reply])
+  })
+
+  it('synthesizes a dispatch-delegation linkage when the fallback regex routed', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '@Engineer Boo, please look at this',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'dispatch-delegation',
+      taskBody: 'please look at this',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('clawboo-dispatch')
+    expect(linkages[0]!.isPending).toBe(true)
+  })
+
+  it('skips Path 3 when Path 1 (<delegate>) already linked the same target', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">explicit task</delegate>',
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-explicit',
+      text: 'engineer reply',
+    })
+    // A Path 3 dispatch ALSO exists for the same target.
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'dispatch-delegation',
+      taskBody: 'this task should be ignored',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source, reply], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('delegate-tag')
+    expect(linkages[0]!.task).toBe('explicit task')
+  })
+
+  it('skips Path 3 when Path 2 (sessions_send) already linked the same target', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Calling the tool.',
+    })
+    const toolCall = makeToolCallEntry({
+      runId: source.runId,
+      text: sessionsSendToolText({ label: 'Engineer Boo', message: 'tool-routed task' }),
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'dispatch-delegation',
+      taskBody: 'duplicate path 3 should be ignored',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source, toolCall], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('sessions-send')
+    expect(linkages[0]!.task).toBe('tool-routed task')
+  })
+
+  it('marks Path 3 linkage pending when no target reply exists yet', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing.',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'relay-batch',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.isPending).toBe(true)
+    expect(linkages[0]!.linkedEntries).toEqual([])
+  })
+
+  it('skips Path 3 dispatches whose targetAgentId is not in participants', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Routing to ghost.',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'ghost-agent',
+      targetAgentName: 'Ghost Boo',
+      origin: 'relay-batch',
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source], dispatches)
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+
+  it('skips Path 3 entirely when no clawbooDispatches map is supplied (1:1 chat path)', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Just talking.',
+    })
+    const blocks = groupEntriesToBlocks([source])
+    const result = buildDelegationLinkages({
+      blocks,
+      mergedEntries: [source],
+      teamId: 't1',
+      participants,
+      // clawbooDispatches omitted on purpose.
+    })
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+})
+
+// Round 7B: post-reload stale-entry filter. `sequenceKey` is process-local
+// (resets on page reload) while transcript data persists in SQLite. After a
+// reload, hydrated entries from prior sessions can have HIGHER sequenceKeys
+// than freshly-emitted entries — which is why the linkage scan filters by
+// `timestampMs` as the primary "after-source" check, not sequenceKey.
+
+describe('findTargetResponse (via buildDelegationLinkages) — post-reload stale-entry filter', () => {
+  it('does NOT pick a stale target entry whose sequenceKey is higher but timestamp is older', () => {
+    // Simulate post-reload state: an old hydrated entry has sequenceKey=999
+    // (carried over from a prior session) but its timestampMs is OLDER than
+    // the current source. The fresh response has a lower sequenceKey (counter
+    // restarted at 0 this session) but a newer timestamp. Round 7B's
+    // timestamp-primary filter must pick the FRESH one.
+    const staleTimestamp = 1_700_000_000_000 // older
+    const freshTimestamp = 1_700_000_005_000 // newer (5s later)
+
+    const sourceTs = 1_700_000_003_000 // between stale and fresh
+    const source: TranscriptEntry = {
+      entryId: 'source-current',
+      runId: 'run-current',
+      sessionKey: teamSk('bz'),
+      kind: 'assistant',
+      role: 'assistant',
+      text: '<delegate to="@Engineer Boo">do a fresh thing</delegate>',
+      source: 'runtime-chat',
+      timestampMs: sourceTs,
+      sequenceKey: 1, // low — current session, just reset
+      confirmed: true,
+      fingerprint: 'fp-source',
+    } as TranscriptEntry
+
+    const staleReply: TranscriptEntry = {
+      entryId: 'reply-stale',
+      runId: 'run-stale',
+      sessionKey: teamSk('eng'),
+      kind: 'assistant',
+      role: 'assistant',
+      text: "Hey! I'm Engineer Boo, and I specialize in ...",
+      source: 'runtime-chat',
+      timestampMs: staleTimestamp, // BEFORE source
+      sequenceKey: 999, // hydrated with high seqkey from prior session
+      confirmed: true,
+      fingerprint: 'fp-stale',
+    } as TranscriptEntry
+
+    const freshReply: TranscriptEntry = {
+      entryId: 'reply-fresh',
+      runId: 'run-fresh',
+      sessionKey: teamSk('eng'),
+      kind: 'assistant',
+      role: 'assistant',
+      text: 'Here is the fresh substantive answer from this session.',
+      source: 'runtime-chat',
+      timestampMs: freshTimestamp, // AFTER source
+      sequenceKey: 2, // current session
+      confirmed: true,
+      fingerprint: 'fp-fresh',
+    } as TranscriptEntry
+
+    const result = build([source, staleReply, freshReply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.linkedEntries).toEqual([freshReply])
+    // Stale entry must NOT be claimed.
+    expect(result.claimedEntries.has(staleReply.entryId)).toBe(false)
+  })
+})

--- a/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
@@ -1,0 +1,331 @@
+/**
+ * buildDelegationLinkages — pure helper that pairs `<delegate>` source blocks
+ * with the next eligible target reply in a merged team transcript.
+ *
+ * Run with `pnpm --filter @clawboo/web test -- --run features/group-chat/__tests__/buildDelegationLinkages.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { TranscriptEntry } from '@clawboo/protocol'
+import { groupEntriesToBlocks } from '@/features/chat/chatComponents'
+import { buildDelegationLinkages } from '../buildDelegationLinkages'
+import { nextSeq } from '@/lib/sequenceKey'
+
+// ── Test entry factory ───────────────────────────────────────────────────────
+
+let __ts = 1_700_000_000_000
+function nextTs(): number {
+  __ts += 1000
+  return __ts
+}
+
+function makeAssistantEntry(overrides: Partial<TranscriptEntry> = {}): TranscriptEntry {
+  return {
+    entryId: crypto.randomUUID(),
+    runId: 'run-' + Math.random().toString(36).slice(2, 9),
+    sessionKey: 'agent:a1:team:t1',
+    kind: 'assistant',
+    role: 'assistant',
+    text: 'hello',
+    source: 'runtime-chat',
+    timestampMs: nextTs(),
+    sequenceKey: nextSeq(),
+    confirmed: true,
+    fingerprint: crypto.randomUUID(),
+    ...overrides,
+  } as TranscriptEntry
+}
+
+function teamSk(agentId: string, teamId = 't1'): string {
+  return `agent:${agentId}:team:${teamId}`
+}
+
+const participants = [
+  { id: 'bz', name: 'Boo Zero' },
+  { id: 'eng', name: 'Engineer Boo' },
+  { id: 'des', name: 'Designer Boo' },
+]
+
+function build(mergedEntries: TranscriptEntry[]) {
+  const blocks = groupEntriesToBlocks(mergedEntries)
+  return buildDelegationLinkages({
+    blocks,
+    mergedEntries,
+    teamId: 't1',
+    participants,
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildDelegationLinkages — single delegation', () => {
+  it('claims the first eligible target reply after the source entry', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Working on it. <delegate to="@Engineer Boo">Build a TL;DR</delegate>',
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-1',
+      text: 'Voice AI takes audio input...',
+    })
+    const result = build([source, reply])
+
+    expect(result.linkagesByDelegationId.size).toBe(1)
+    const linkage = [...result.linkagesByDelegationId.values()][0]!
+    expect(linkage.targetAgentId).toBe('eng')
+    expect(linkage.targetAgentName).toBe('Engineer Boo')
+    expect(linkage.sourceAgentId).toBe('bz')
+    expect(linkage.linkedEntries).toEqual([reply])
+    expect(linkage.isPending).toBe(false)
+    expect(result.claimedEntries.has(reply.entryId)).toBe(true)
+  })
+
+  it('produces a deterministic delegationId from sourceEntryId + blockStart', () => {
+    const text = 'Hi. <delegate to="@Engineer Boo">first</delegate>'
+    const source = makeAssistantEntry({ sessionKey: teamSk('bz'), text })
+    const reply = makeAssistantEntry({ sessionKey: teamSk('eng'), text: 'done' })
+    const expectedBlockStart = text.indexOf('<delegate')
+
+    const result = build([source, reply])
+    const id = `${source.entryId}:${expectedBlockStart}`
+    expect(result.linkagesByDelegationId.has(id)).toBe(true)
+  })
+
+  it('returns isPending=true with empty linkedEntries when the target has not replied yet', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">do thing</delegate>',
+    })
+    const result = build([source])
+    expect(result.linkagesByDelegationId.size).toBe(1)
+    const linkage = [...result.linkagesByDelegationId.values()][0]!
+    expect(linkage.isPending).toBe(true)
+    expect(linkage.linkedEntries).toEqual([])
+    expect(result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))).toBe(linkage.delegationId)
+  })
+})
+
+describe('buildDelegationLinkages — multiple delegations', () => {
+  it('FIFO-claims for two delegations to the same target from the same source turn', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">first</delegate> <delegate to="@Engineer Boo">second</delegate>',
+    })
+    const reply1 = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-A',
+      text: 'reply to first',
+    })
+    const reply2 = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng-B',
+      text: 'reply to second',
+    })
+
+    const result = build([source, reply1, reply2])
+    expect(result.linkagesByDelegationId.size).toBe(2)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    // Source-text order — first block claims reply1, second claims reply2.
+    expect(linkages[0]!.task).toBe('first')
+    expect(linkages[0]!.linkedEntries).toEqual([reply1])
+    expect(linkages[1]!.task).toBe('second')
+    expect(linkages[1]!.linkedEntries).toEqual([reply2])
+  })
+
+  it('routes delegations to different targets independently', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">backend</delegate> <delegate to="@Designer Boo">UI</delegate>',
+    })
+    const replyEng = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng',
+      text: 'backend ok',
+    })
+    const replyDes = makeAssistantEntry({
+      sessionKey: teamSk('des'),
+      runId: 'run-des',
+      text: 'UI ok',
+    })
+
+    const result = build([source, replyEng, replyDes])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    expect(linkages[0]!.targetAgentId).toBe('eng')
+    expect(linkages[0]!.linkedEntries).toEqual([replyEng])
+    expect(linkages[1]!.targetAgentId).toBe('des')
+    expect(linkages[1]!.linkedEntries).toEqual([replyDes])
+  })
+})
+
+describe('buildDelegationLinkages — accretion + multi-entry replies', () => {
+  it('accretes thinking + tool + assistant entries sharing the target reply runId', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">work</delegate>',
+    })
+    const thinking = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-X',
+      kind: 'thinking',
+      text: 'pondering...',
+    } as Partial<TranscriptEntry>)
+    const tool = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-X',
+      kind: 'tool',
+      text: '[[tool]] read\nfoo',
+    } as Partial<TranscriptEntry>)
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-X',
+      text: 'final answer',
+    })
+
+    const result = build([source, thinking, tool, reply])
+    const linkage = [...result.linkagesByDelegationId.values()][0]!
+    expect(linkage.linkedEntries.map((e) => e.entryId).sort()).toEqual(
+      [thinking.entryId, tool.entryId, reply.entryId].sort(),
+    )
+    expect(result.claimedEntries.size).toBe(3)
+  })
+})
+
+describe('buildDelegationLinkages — filters and guards', () => {
+  it('skips delegations whose source entry is a relay message', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '[Team Update] — relayed summary\n<delegate to="@Engineer Boo">x</delegate>',
+    })
+    const reply = makeAssistantEntry({ sessionKey: teamSk('eng'), text: 'reply' })
+    const result = build([source, reply])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+    expect(result.claimedEntries.size).toBe(0)
+  })
+
+  it('skips self-delegations', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Boo Zero">work for myself</delegate>',
+    })
+    const result = build([source])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+
+  it('skips delegations with an unknown target', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Nonexistent Boo">whatever</delegate>',
+    })
+    const result = build([source])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+
+  it('skips delegations with an empty task body', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">   </delegate>',
+    })
+    const result = build([source])
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+
+  it('returns empty when there are no blocks or no entries', () => {
+    expect(build([]).linkagesByDelegationId.size).toBe(0)
+  })
+})
+
+describe('buildDelegationLinkages — chain A→B→C (recursive nesting)', () => {
+  it('builds linkages for both hops independently — each source entry maps to its own delegation', () => {
+    // Boo Zero delegates to Engineer Boo; Engineer Boo's reply contains a
+    // delegation to Designer Boo. We expect two linkages — one keyed by
+    // Boo Zero's source entry, one keyed by Engineer Boo's reply entry.
+    const sourceBz = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">build</delegate>',
+    })
+    const replyEng = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-eng',
+      text: 'I will. <delegate to="@Designer Boo">need a mock</delegate>',
+    })
+    const replyDes = makeAssistantEntry({
+      sessionKey: teamSk('des'),
+      runId: 'run-des',
+      text: 'mock attached',
+    })
+
+    const result = build([sourceBz, replyEng, replyDes])
+    expect(result.linkagesByDelegationId.size).toBe(2)
+    expect(result.linkagesBySourceEntry.get(sourceBz.entryId)).toHaveLength(1)
+    expect(result.linkagesBySourceEntry.get(replyEng.entryId)).toHaveLength(1)
+    // Engineer's reply is claimed by Boo Zero's delegation; Designer's reply
+    // is claimed by Engineer's nested delegation. All three are claimed.
+    expect(result.claimedEntries.has(replyEng.entryId)).toBe(true)
+    expect(result.claimedEntries.has(replyDes.entryId)).toBe(true)
+  })
+})
+
+describe('buildDelegationLinkages — streaming owner', () => {
+  it('only the first pending delegation per target owns the streaming card', () => {
+    // Two delegations to Engineer Boo; neither has a reply. First one wins
+    // the streaming-owner slot.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">first</delegate> <delegate to="@Engineer Boo">second</delegate>',
+    })
+    const result = build([source])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    expect(result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))).toBe(
+      linkages[0]!.delegationId,
+    )
+  })
+
+  it('does not set a streaming owner once the latest delegation has a reply', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">do it</delegate>',
+    })
+    const reply = makeAssistantEntry({ sessionKey: teamSk('eng'), text: 'done' })
+    const result = build([source, reply])
+    expect(result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))).toBeUndefined()
+  })
+})
+
+describe('buildDelegationLinkages — idempotency + invariants', () => {
+  it('idempotent: calling twice with the same inputs returns equivalent output', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">x</delegate>',
+    })
+    const reply = makeAssistantEntry({ sessionKey: teamSk('eng'), text: 'ok' })
+    const a = build([source, reply])
+    const b = build([source, reply])
+    expect([...a.linkagesByDelegationId.keys()]).toEqual([...b.linkagesByDelegationId.keys()])
+    expect(a.claimedEntries.size).toBe(b.claimedEntries.size)
+  })
+
+  it('no entry is claimed by more than one delegation (single-claim invariant)', () => {
+    // Two delegations to the SAME target with only ONE reply available —
+    // only the first delegation should claim the reply, the second stays
+    // pending.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">first</delegate> <delegate to="@Engineer Boo">second</delegate>',
+    })
+    const reply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      runId: 'run-only',
+      text: 'only reply',
+    })
+    const result = build([source, reply])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages[0]!.linkedEntries).toEqual([reply])
+    expect(linkages[1]!.linkedEntries).toEqual([])
+    expect(linkages[1]!.isPending).toBe(true)
+    expect(result.claimedEntries.size).toBe(1)
+  })
+})

--- a/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/buildDelegationLinkages.test.ts
@@ -797,3 +797,453 @@ describe('findTargetResponse (via buildDelegationLinkages) — post-reload stale
     expect(result.claimedEntries.has(staleReply.entryId)).toBe(false)
   })
 })
+
+// Round 9: Path 3 propagates `planId` + `planStepIndex` from
+// `ClawbooDispatch` onto the synthesized `DelegationLinkage`. The renderer
+// uses these fields to group plan-step linkages under one `<PlanCard>`.
+
+describe('buildDelegationLinkages — Path 3 plan provenance (Round 9)', () => {
+  it('propagates planId + planStepIndex onto the linkage when dispatch carries them', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<plan><step to="@Engineer Boo">build it</step></plan>',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'dispatch-delegation',
+      planId: 'plan-abc',
+      planStepIndex: 0,
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.planId).toBe('plan-abc')
+    expect(linkages[0]!.planStepIndex).toBe(0)
+    expect(linkages[0]!.source).toBe('clawboo-dispatch')
+  })
+
+  it('non-plan dispatches keep planId / planStepIndex null', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'normal prose, no plan',
+    })
+    const dispatch = makeDispatch({
+      sourceEntryId: source.entryId,
+      targetAgentId: 'eng',
+      targetAgentName: 'Engineer Boo',
+      origin: 'dispatch-delegation',
+      // planId / planStepIndex deliberately omitted.
+    })
+    const dispatches = new Map([[`t1:${source.entryId}`, [dispatch]]])
+    const result = buildWithDispatches([source], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.planId).toBeNull()
+    expect(linkages[0]!.planStepIndex).toBeNull()
+  })
+
+  it('groups three plan-step linkages under one planId in source-entry order', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<plan>...</plan>',
+    })
+    const planId = 'plan-xyz'
+    const dispatches = new Map([
+      [
+        `t1:${source.entryId}`,
+        [
+          makeDispatch({
+            sourceEntryId: source.entryId,
+            targetAgentId: 'eng',
+            targetAgentName: 'Engineer Boo',
+            origin: 'dispatch-delegation',
+            planId,
+            planStepIndex: 0,
+          }),
+          makeDispatch({
+            sourceEntryId: source.entryId,
+            targetAgentId: 'des',
+            targetAgentName: 'Designer Boo',
+            origin: 'dispatch-delegation',
+            planId,
+            planStepIndex: 1,
+          }),
+        ],
+      ],
+    ])
+    const result = buildWithDispatches([source], dispatches)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    // All linkages share the same planId.
+    expect(linkages.every((l) => l.planId === planId)).toBe(true)
+    // Step indices preserved.
+    expect(linkages.map((l) => l.planStepIndex)).toEqual([0, 1])
+  })
+})
+
+// Round 10: Path 1 attributes `workstreamId` when the source emits ≥2 valid
+// `<delegate>` blocks without a `<plan>` wrapper. The renderer groups the
+// resulting linkages under a single `<WorkstreamCard>`.
+
+describe('buildDelegationLinkages — Path 1 workstream attribution (Round 10)', () => {
+  it('attributes a single workstreamId + sequential targetIndex to ≥2 sibling <delegate> linkages', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text:
+        'Firing 3 parallel workstreams.\n\n' +
+        '<delegate to="@Engineer Boo">research market</delegate>\n\n' +
+        '<delegate to="@Designer Boo">research features</delegate>\n\n' +
+        '<delegate to="@Boo Zero">research sentiment</delegate>',
+    })
+    const result = build([source])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    // 3 valid linkages (Boo Zero is in participants but is the source — self-
+    // delegations are filtered out; so only Engineer + Designer remain).
+    expect(linkages).toHaveLength(2)
+    const expectedWsId = `t1:${source.entryId}:workstreams`
+    expect(linkages.every((l) => l.workstreamId === expectedWsId)).toBe(true)
+    expect(linkages.map((l) => l.workstreamTargetIndex)).toEqual([0, 1])
+    expect(linkages.every((l) => l.source === 'delegate-tag')).toBe(true)
+  })
+
+  it('does NOT attribute workstreamId for a single <delegate> (N<2)', () => {
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'Single delegation.\n\n<delegate to="@Engineer Boo">do it</delegate>',
+    })
+    const result = build([source])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.workstreamId).toBeNull()
+    expect(linkages[0]!.workstreamTargetIndex).toBeNull()
+  })
+
+  it('does NOT attribute workstreamId when a <plan> block is on the same source (plans take precedence)', () => {
+    // Two `<delegate>` blocks + one `<plan>` block on the same source.
+    // The plan gate short-circuits workstream minting; both delegations
+    // render as standalone DelegationCards under the leader's prose.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text:
+        '<plan><step to="@Engineer Boo">step 1</step><step to="@Designer Boo">step 2</step></plan>\n\n' +
+        '<delegate to="@Engineer Boo">also do this</delegate>\n\n' +
+        '<delegate to="@Designer Boo">and this</delegate>',
+    })
+    const result = build([source])
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    // Both delegations exist as linkages (with `source: 'delegate-tag'`),
+    // but neither carries a workstreamId because `findPlanBlocks(text).length > 0`.
+    expect(linkages).toHaveLength(2)
+    expect(linkages.every((l) => l.workstreamId === null)).toBe(true)
+    expect(linkages.every((l) => l.workstreamTargetIndex === null)).toBe(true)
+  })
+})
+
+// Round 13: Path 4 — implicit fan-out workstreams synthesized from
+// `pendingWorkstreams` map. When the leader emits pure fan-out prose
+// WITHOUT structured tags, the orchestration hook mints a workstream
+// record; Path 4 turns those into renderable DelegationLinkages.
+
+describe('buildDelegationLinkages — Path 4 implicit fan-out (Round 13)', () => {
+  function buildWithPendingWs(
+    mergedEntries: TranscriptEntry[],
+    pendingWorkstreams: Map<string, import('@/stores/chat').PendingWorkstreams>,
+  ) {
+    const blocks = groupEntriesToBlocks(mergedEntries)
+    return buildDelegationLinkages({
+      blocks,
+      mergedEntries,
+      teamId: 't1',
+      participants,
+      pendingWorkstreams,
+    })
+  }
+
+  it('synthesizes linkages for an :implicit-fanout workstream when no Path 1 tags exist', () => {
+    // Leader emits prose only — no <delegate> tags. Orchestration minted
+    // an implicit workstream with 2 targets. Path 4 should produce 2
+    // linkages for the source.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: "I'll ask all teammates for their take. Got responses from all three.",
+    })
+    const replyEng = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      text: 'Engineering says: build it.',
+    })
+    const replyDes = makeAssistantEntry({
+      sessionKey: teamSk('des'),
+      text: 'Designer says: make it pretty.',
+    })
+    const wsId = `t1:${source.entryId}:implicit-fanout`
+    const pendingWs = new Map<string, import('@/stores/chat').PendingWorkstreams>([
+      [
+        wsId,
+        {
+          workstreamId: wsId,
+          sourceEntryId: source.entryId,
+          sourceAgentId: 'bz',
+          teamId: 't1',
+          targets: [
+            {
+              targetAgentId: 'eng',
+              targetAgentName: 'Engineer Boo',
+              task: 'user question text',
+              output: null,
+              resolvedEntryId: null,
+            },
+            {
+              targetAgentId: 'des',
+              targetAgentName: 'Designer Boo',
+              task: 'user question text',
+              output: null,
+              resolvedEntryId: null,
+            },
+          ],
+          timestampMs: source.timestampMs! - 1, // workstream minted at-or-before the source's commit
+        },
+      ],
+    ])
+    const result = buildWithPendingWs([source, replyEng, replyDes], pendingWs)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(2)
+    expect(linkages.every((l) => l.source === 'clawboo-dispatch')).toBe(true)
+    expect(linkages.every((l) => l.workstreamId === wsId)).toBe(true)
+    expect(linkages.map((l) => l.workstreamTargetIndex)).toEqual([0, 1])
+    // Both replies should be claimed via findTargetResponse.
+    expect(linkages[0]!.linkedEntries).toEqual([replyEng])
+    expect(linkages[1]!.linkedEntries).toEqual([replyDes])
+    expect(linkages.every((l) => !l.isPending)).toBe(true)
+  })
+
+  it('SKIPS Path 4 when Path 1 already produced linkages on the same source', () => {
+    // The leader's response has BOTH fan-out prose AND a structured
+    // <delegate> tag. Path 1 wins; Path 4 must not double-mint.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'I\'ll ask all teammates. <delegate to="@Engineer Boo">just you</delegate>',
+    })
+    const reply = makeAssistantEntry({ sessionKey: teamSk('eng'), text: 'done' })
+    const wsId = `t1:${source.entryId}:implicit-fanout`
+    const pendingWs = new Map<string, import('@/stores/chat').PendingWorkstreams>([
+      [
+        wsId,
+        {
+          workstreamId: wsId,
+          sourceEntryId: source.entryId,
+          sourceAgentId: 'bz',
+          teamId: 't1',
+          targets: [
+            {
+              targetAgentId: 'eng',
+              targetAgentName: 'Engineer Boo',
+              task: 'should not appear',
+              output: null,
+              resolvedEntryId: null,
+            },
+            {
+              targetAgentId: 'des',
+              targetAgentName: 'Designer Boo',
+              task: 'should not appear',
+              output: null,
+              resolvedEntryId: null,
+            },
+          ],
+          timestampMs: source.timestampMs! - 1,
+        },
+      ],
+    ])
+    const result = buildWithPendingWs([source, reply], pendingWs)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    // Only Path 1's single <delegate> linkage should exist.
+    expect(linkages).toHaveLength(1)
+    expect(linkages[0]!.source).toBe('delegate-tag')
+    expect(linkages[0]!.targetAgentId).toBe('eng')
+  })
+
+  it('does NOT synthesize Path 4 for a workstreamId WITHOUT :implicit-fanout suffix', () => {
+    // Regular workstreams (Round 10) use `:workstreams` suffix.
+    // Path 4 ONLY handles `:implicit-fanout`. The Round 10 flow goes
+    // through Path 1's workstreamId attribution path, not here.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: 'normal turn, no fan-out prose',
+    })
+    const wsId = `t1:${source.entryId}:workstreams` // NOT :implicit-fanout
+    const pendingWs = new Map<string, import('@/stores/chat').PendingWorkstreams>([
+      [
+        wsId,
+        {
+          workstreamId: wsId,
+          sourceEntryId: source.entryId,
+          sourceAgentId: 'bz',
+          teamId: 't1',
+          targets: [
+            {
+              targetAgentId: 'eng',
+              targetAgentName: 'Engineer Boo',
+              task: 'x',
+              output: null,
+              resolvedEntryId: null,
+            },
+          ],
+          timestampMs: source.timestampMs!,
+        },
+      ],
+    ])
+    const result = buildWithPendingWs([source], pendingWs)
+    const linkages = result.linkagesBySourceEntry.get(source.entryId) ?? []
+    expect(linkages).toHaveLength(0)
+  })
+})
+
+// ── Round 15 — leader-streaming pass ───────────────────────────────────────
+// BEFORE the leader's source entry commits, its `<delegate>` blocks live
+// only in `streamingText`. The Round 15 pass scans streaming texts for
+// closed `<delegate>` tags and claims the targets so the target's reply
+// (streaming OR briefly-pre-leader-commit) stops appearing at top level.
+
+function buildWithStreaming(
+  mergedEntries: TranscriptEntry[],
+  streamingTexts: Map<string, string>,
+  streamStartedAt?: Map<string, number>,
+) {
+  const blocks = groupEntriesToBlocks(mergedEntries)
+  return buildDelegationLinkages({
+    blocks,
+    mergedEntries,
+    teamId: 't1',
+    participants,
+    streamingTexts,
+    streamStartedAt,
+  })
+}
+
+describe('buildDelegationLinkages — Round 15 leader-streaming pass', () => {
+  it('claims streaming-only target sessionKey when leader has not committed yet', () => {
+    // The leader is still streaming; only their streaming text contains
+    // the closed `<delegate>` tag. No committed leader entry exists. The
+    // target hasn't committed yet either — pure pre-commit state.
+    const streamingTexts = new Map<string, string>([
+      [
+        teamSk('bz'),
+        'Working on it. <delegate to="@Engineer Boo">Do the thing</delegate> back soon.',
+      ],
+    ])
+    const result = buildWithStreaming([], streamingTexts)
+    // Streaming ownership transfers — the StreamingCard for the target
+    // session will be suppressed.
+    expect(result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))).toBeDefined()
+    expect(result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))).toMatch(/^stream:/)
+    // No committed entries → no linkages built — the actual Path 1
+    // linkage will form when the leader commits.
+    expect(result.linkagesByDelegationId.size).toBe(0)
+  })
+
+  it('claims a target reply that committed BEFORE the leader committed', () => {
+    // Race: leader is streaming, target finishes first and commits. Without
+    // Round 15 this committed target entry would appear at top level (no
+    // linkage exists yet because the leader's source isn't in mergedEntries).
+    const streamStarted = Date.now()
+    const targetReply = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      text: 'Here is the deliverable.',
+      timestampMs: streamStarted + 2000,
+    })
+    const streamingTexts = new Map<string, string>([
+      [teamSk('bz'), 'Coordinating now. <delegate to="@Engineer Boo">Build it</delegate>'],
+    ])
+    const streamStartedAt = new Map<string, number>([[teamSk('bz'), streamStarted]])
+    const result = buildWithStreaming([targetReply], streamingTexts, streamStartedAt)
+    expect(result.claimedEntries.has(targetReply.entryId)).toBe(true)
+    expect(result.streamingOwnerByTargetSessionKey.has(teamSk('eng'))).toBe(true)
+  })
+
+  it('does NOT claim target entries from BEFORE the leader stream started', () => {
+    // Stale entry: the target's previous onboarding intro was committed
+    // BEFORE the leader started this turn's stream. Must NOT be claimed
+    // by Round 15 — that's exactly the stale-content bug Round 14A
+    // addressed for LiveActivityFeed and that the Round 15 pass must
+    // honor here too.
+    const streamStarted = Date.now()
+    const staleEntry = makeAssistantEntry({
+      sessionKey: teamSk('eng'),
+      text: "Hi! I'm Engineer Boo, ready to help.",
+      timestampMs: streamStarted - 60_000, // 1 minute before the stream
+    })
+    const streamingTexts = new Map<string, string>([
+      [teamSk('bz'), '<delegate to="@Engineer Boo">Do it</delegate>'],
+    ])
+    const streamStartedAt = new Map<string, number>([[teamSk('bz'), streamStarted]])
+    const result = buildWithStreaming([staleEntry], streamingTexts, streamStartedAt)
+    expect(result.claimedEntries.has(staleEntry.entryId)).toBe(false)
+    // But streaming ownership still transfers (no committed reply yet).
+    expect(result.streamingOwnerByTargetSessionKey.has(teamSk('eng'))).toBe(true)
+  })
+
+  it('does NOT clobber a committed-path linkage that already owns the target', () => {
+    // Both happened: the LEADER ALREADY committed (so Path 1 ran and
+    // owns the linkage) AND the leader's NEXT turn is also streaming
+    // with a `<delegate>` to the same target. Round 15 should NOT
+    // overwrite the committed Path 1 owner with a `stream:` synthetic id.
+    const source = makeAssistantEntry({
+      sessionKey: teamSk('bz'),
+      text: '<delegate to="@Engineer Boo">First task</delegate>',
+    })
+    const streamingTexts = new Map<string, string>([
+      [teamSk('bz'), '<delegate to="@Engineer Boo">Second task, still streaming</delegate>'],
+    ])
+    const result = buildWithStreaming([source], streamingTexts)
+    const owner = result.streamingOwnerByTargetSessionKey.get(teamSk('eng'))
+    expect(owner).toBeDefined()
+    // The committed linkage's delegationId is the source entry id with
+    // a `:blockStart` suffix — NOT `stream:`. Round 15 must preserve it.
+    expect(owner).not.toMatch(/^stream:/)
+  })
+
+  it('handles open / unclosed `<delegate>` tags by ignoring them (partial-stream safety)', () => {
+    // The leader has typed `<delegate to="@Engineer Boo">` but the
+    // closing tag hasn't arrived yet. `findDelegationBlocks` requires a
+    // closing `</delegate>` — partial blocks are NOT yet routable, so
+    // Round 15 should NOT claim ownership prematurely.
+    const streamingTexts = new Map<string, string>([
+      [teamSk('bz'), 'Routing now. <delegate to="@Engineer Boo">half a task, no closing tag'],
+    ])
+    const result = buildWithStreaming([], streamingTexts)
+    expect(result.streamingOwnerByTargetSessionKey.size).toBe(0)
+    expect(result.claimedEntries.size).toBe(0)
+  })
+
+  it('skips streaming texts for non-participant agents (defensive)', () => {
+    // `streamingText` may contain sessions outside the current team
+    // (older 1:1 chat sessions). They must NOT contribute claims.
+    const streamingTexts = new Map<string, string>([
+      ['agent:outsider:main', '<delegate to="@Engineer Boo">should be ignored</delegate>'],
+    ])
+    const result = buildWithStreaming([], streamingTexts)
+    expect(result.streamingOwnerByTargetSessionKey.size).toBe(0)
+  })
+
+  it('skips empty / undefined streaming text values', () => {
+    const streamingTexts = new Map<string, string>([[teamSk('bz'), '']])
+    const result = buildWithStreaming([], streamingTexts)
+    expect(result.streamingOwnerByTargetSessionKey.size).toBe(0)
+  })
+
+  it('claims multiple target sessions when the leader streams sibling delegates', () => {
+    // Workstream batch — TWO closed `<delegate>` tags in the streaming
+    // text. Both targets should be owned so their streams suppress.
+    const streamingTexts = new Map<string, string>([
+      [
+        teamSk('bz'),
+        '<delegate to="@Engineer Boo">Build it</delegate> and <delegate to="@Designer Boo">Style it</delegate>',
+      ],
+    ])
+    const result = buildWithStreaming([], streamingTexts)
+    expect(result.streamingOwnerByTargetSessionKey.has(teamSk('eng'))).toBe(true)
+    expect(result.streamingOwnerByTargetSessionKey.has(teamSk('des'))).toBe(true)
+  })
+})

--- a/apps/web/src/features/group-chat/__tests__/fanOutDetector.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/fanOutDetector.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { detectFanOutIntent } from '../fanOutDetector'
+
+describe('detectFanOutIntent', () => {
+  describe('positive matches — plural routing intent', () => {
+    it("matches 'I'll ask all teammates'", () => {
+      expect(detectFanOutIntent("I'll ask all teammates for their thoughts.")).toBe(true)
+    })
+
+    it("matches 'Got responses from all three teammates'", () => {
+      expect(
+        detectFanOutIntent('Got responses from all three teammates. Here is what they said:'),
+      ).toBe(true)
+    })
+
+    it("matches 'Let me route this to each of the team'", () => {
+      expect(detectFanOutIntent('Let me route this to each of the team for quick takes.')).toBe(
+        true,
+      )
+    })
+
+    it("matches 'going to delegate to everyone'", () => {
+      expect(detectFanOutIntent("I'm going to delegate to everyone in parallel.")).toBe(true)
+    })
+
+    it("matches 'all teammates will chime in'", () => {
+      expect(detectFanOutIntent('All teammates will chime in on this one.')).toBe(true)
+    })
+
+    it("matches 'gonna fan this out to the whole team'", () => {
+      expect(detectFanOutIntent('Gonna fan this out to the whole team — back in a sec.')).toBe(true)
+    })
+
+    it("matches 'asking each of you'", () => {
+      expect(detectFanOutIntent('Asking each of you to share one quick thought.')).toBe(true)
+    })
+
+    it("matches 'all three teammates weighed in'", () => {
+      expect(detectFanOutIntent('All three teammates weighed in on this.')).toBe(true)
+    })
+
+    it('is case-insensitive', () => {
+      expect(detectFanOutIntent('LET ME ROUTE THIS TO ALL TEAMMATES')).toBe(true)
+    })
+
+    it("matches 'Got fresh takes from all three' (adjective tolerance)", () => {
+      expect(detectFanOutIntent('Got fresh takes from all three:')).toBe(true)
+    })
+
+    it("matches 'Got their thoughts from everyone'", () => {
+      expect(detectFanOutIntent('Got their thoughts from everyone — here is the recap.')).toBe(true)
+    })
+
+    it("matches 'all three teammates are aligned' (post-fan-out synthesis)", () => {
+      expect(detectFanOutIntent('All three teammates are aligned on this point.')).toBe(true)
+    })
+
+    it("matches 'Here's the roundup' (LLM aggregation prose)", () => {
+      expect(detectFanOutIntent("Here's the roundup:")).toBe(true)
+    })
+
+    it("matches 'Here's the recap' / 'consensus'", () => {
+      expect(detectFanOutIntent("Here's the recap of what they said.")).toBe(true)
+      expect(detectFanOutIntent("Here's the consensus: everyone agrees.")).toBe(true)
+    })
+  })
+
+  describe('negative matches — not fan-out intent', () => {
+    it("does not match single-target delegation 'I'll ask @Alice'", () => {
+      expect(detectFanOutIntent("I'll ask @Alice to handle this.")).toBe(false)
+    })
+
+    it("does not match bare plural mention without routing verb 'all teammates are great'", () => {
+      expect(detectFanOutIntent('All teammates are great. The team is solid.')).toBe(false)
+    })
+
+    it('does not match empty string', () => {
+      expect(detectFanOutIntent('')).toBe(false)
+    })
+
+    it('does not match null / undefined', () => {
+      expect(detectFanOutIntent(null)).toBe(false)
+      expect(detectFanOutIntent(undefined)).toBe(false)
+    })
+
+    it("does not match 'I'll route this to @Search Boo' (single target with @)", () => {
+      expect(detectFanOutIntent("I'll route this to @Search Boo for analysis.")).toBe(false)
+    })
+
+    it('does not match prose about teammates without delegation intent', () => {
+      expect(detectFanOutIntent('Teammates are amazing. Everyone here is talented.')).toBe(false)
+    })
+  })
+})

--- a/apps/web/src/features/group-chat/__tests__/groupChatSendIntegration.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/groupChatSendIntegration.test.ts
@@ -186,9 +186,14 @@ describe('sendGroupChatMessage — context preamble integration', () => {
     // Wake message must NOT ask for introductions or list teammates as
     // @mentions — that triggered the message-flooding cascade in production.
     // The full team protocol lives in AGENTS.md, loaded on every interaction.
+    // Phase 3 (cascade-fix): the body is now a structural prompt asking for
+    // a literal `__resumed__` token; the RESUME_SIGNAL sentinel + target
+    // agent name still appear.
     const wakeMessage = wakeCalls[0][1].message as string
-    expect(wakeMessage).toContain('resuming')
+    expect(wakeMessage).toContain('RESUME_SIGNAL')
+    expect(wakeMessage).toContain('reactivated')
     expect(wakeMessage).toContain('Worker Boo')
+    expect(wakeMessage).toContain('__resumed__')
     expect(wakeMessage).not.toContain('@')
     expect(wakeMessage).not.toMatch(/introduce yourself/i)
   })

--- a/apps/web/src/features/group-chat/__tests__/planDetector.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/planDetector.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { findPlanBlocks, stripPlanBlocks } from '../planDetector'
+
+describe('findPlanBlocks — Round 8B parser', () => {
+  it('parses a single plan with three steps', () => {
+    const text = `Let's build this.
+<plan>
+  <step to="@Marketing Content Creator Boo">Write the copy first.</step>
+  <step to="@Design Ui Designer Boo">Create the visual design from the copy.</step>
+  <step to="@Engineering Frontend Developer Boo">Build the page from the design.</step>
+</plan>
+The team is on it.`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]!.steps).toHaveLength(3)
+    expect(blocks[0]!.steps[0]!.targetName).toBe('@Marketing Content Creator Boo')
+    expect(blocks[0]!.steps[0]!.task).toBe('Write the copy first.')
+    expect(blocks[0]!.steps[1]!.targetName).toBe('@Design Ui Designer Boo')
+    expect(blocks[0]!.steps[2]!.targetName).toBe('@Engineering Frontend Developer Boo')
+  })
+
+  it('returns absolute character offsets for each step in the original text', () => {
+    const text = `<plan><step to="@A">first</step><step to="@B">second</step></plan>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    const [step1, step2] = blocks[0]!.steps
+    expect(step1).toBeDefined()
+    expect(step2).toBeDefined()
+    expect(step1!.stepStart).toBeLessThan(step2!.stepStart)
+    // Verify the offsets actually point at the `<step` opener in the source.
+    expect(text.slice(step1!.stepStart, step1!.stepEnd)).toContain('<step to="@A">first</step>')
+    expect(text.slice(step2!.stepStart, step2!.stepEnd)).toContain('<step to="@B">second</step>')
+  })
+
+  it('skips steps with missing target or empty task', () => {
+    const text = `<plan>
+  <step to="@A">valid task</step>
+  <step to="">empty target ignored</step>
+  <step to="@B"></step>
+</plan>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    // Only the first step is valid; empty target + empty task are skipped.
+    expect(blocks[0]!.steps).toHaveLength(1)
+    expect(blocks[0]!.steps[0]!.targetName).toBe('@A')
+  })
+
+  it('handles multi-line task bodies', () => {
+    const text = `<plan>
+  <step to="@Engineer Boo">
+    Build the auth flow:
+    - JWT validation
+    - Session handling
+  </step>
+</plan>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]!.steps).toHaveLength(1)
+    expect(blocks[0]!.steps[0]!.task).toContain('Build the auth flow:')
+    expect(blocks[0]!.steps[0]!.task).toContain('JWT validation')
+  })
+
+  it('parses multiple plans in one response (rare but legal)', () => {
+    const text = `<plan><step to="@A">phase 1</step></plan>
+Some prose between plans.
+<plan><step to="@B">phase 2</step></plan>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0]!.steps[0]!.task).toBe('phase 1')
+    expect(blocks[1]!.steps[0]!.task).toBe('phase 2')
+  })
+
+  it('returns an empty steps array for `<plan></plan>` so caller can decide', () => {
+    const text = `<plan></plan>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]!.steps).toEqual([])
+  })
+
+  it('returns empty when no plan tags present', () => {
+    expect(findPlanBlocks('just prose, no plan here')).toEqual([])
+    expect(findPlanBlocks('<delegate to="@X">not a plan</delegate>')).toEqual([])
+  })
+
+  it('is case-insensitive on the tag names', () => {
+    const text = `<PLAN><STEP to="@A">task</STEP></PLAN>`
+    const blocks = findPlanBlocks(text)
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]!.steps).toHaveLength(1)
+    expect(blocks[0]!.steps[0]!.task).toBe('task')
+  })
+})
+
+describe('stripPlanBlocks — Round 8B utility', () => {
+  it('removes the plan block from text, leaving surrounding prose', () => {
+    const text = `intro
+<plan>
+  <step to="@A">task</step>
+</plan>
+outro`
+    const stripped = stripPlanBlocks(text)
+    expect(stripped).not.toContain('<plan>')
+    expect(stripped).not.toContain('<step')
+    expect(stripped).toContain('intro')
+    expect(stripped).toContain('outro')
+  })
+
+  it('returns trimmed text when only a plan was present', () => {
+    expect(stripPlanBlocks('<plan><step to="@A">task</step></plan>')).toBe('')
+  })
+
+  it('is a no-op when no plan is present', () => {
+    expect(stripPlanBlocks('just prose')).toBe('just prose')
+  })
+})

--- a/apps/web/src/features/group-chat/buildDelegationLinkages.ts
+++ b/apps/web/src/features/group-chat/buildDelegationLinkages.ts
@@ -1,0 +1,238 @@
+// buildDelegationLinkages — pure helper that pairs each `<delegate>` block
+// inside a source agent's response with the next eligible target response in
+// the merged team transcript. The renderer (`GroupChatPanel`) feeds the result
+// into `AssistantTurnCard`/`DelegationCard` so target replies render nested
+// inside the source's delegation card instead of as separate top-level cards.
+//
+// Why renderer-only: the Gateway's `chat.send` does not echo a runId, and the
+// team-chat-override pending slot is single-valued, so racing user-@ and
+// delegation sends to the same target cannot be cleanly disambiguated at
+// send time anyway. A pure renderer scan has the same attribution behaviour
+// with a fraction of the moving parts (no Zustand store, no hydrate hook,
+// no freeze-window interaction).
+
+import type { TranscriptEntry } from '@clawboo/protocol'
+import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
+import { findDelegationBlocks, isRelayMessage } from './delegationDetector'
+import type { RenderBlock } from '@/features/chat/chatComponents'
+
+export interface DelegationLinkage {
+  /** Stable id derived from source entry + block offset. */
+  delegationId: string
+  sourceEntryId: string
+  sourceAgentId: string
+  /** Character offset of the `<delegate>` opener in the source entry's text. */
+  blockStart: number
+  /** Resolved id of the target agent (after team-roster lookup). */
+  targetAgentId: string
+  /** Resolved roster name of the target agent. */
+  targetAgentName: string
+  /** Raw `to="..."` attribute value as written by the LLM (post `@` strip). */
+  targetRawName: string
+  task: string
+  /** Team-scoped sessionKey for the target. */
+  targetSessionKey: string
+  /** All transcript entries claimed by this delegation, in chronological order. */
+  linkedEntries: TranscriptEntry[]
+  /** True when the target hasn't yet committed any reply for this delegation. */
+  isPending: boolean
+}
+
+export interface BuildDelegationLinkagesResult {
+  /** Lookup by `delegationId`. */
+  linkagesByDelegationId: Map<string, DelegationLinkage>
+  /** Lookup by source entry id — returns delegations in source-text order. */
+  linkagesBySourceEntry: Map<string, DelegationLinkage[]>
+  /** Union of every entryId claimed by some delegation. */
+  claimedEntries: Set<string>
+  /**
+   * Target sessionKeys for which the latest unclaimed delegation hasn't
+   * received a reply yet. The renderer filters streaming cards for these
+   * sessions so the live stream surfaces inside the DelegationCard instead.
+   * Maps sessionKey → the delegationId that "owns" that stream.
+   */
+  streamingOwnerByTargetSessionKey: Map<string, string>
+}
+
+export interface BuildDelegationLinkagesParams {
+  blocks: RenderBlock[]
+  mergedEntries: TranscriptEntry[]
+  teamId: string
+  /**
+   * Effective participants for the team — DB members + Boo Zero. Used for
+   * `to="..."` resolution and to ignore self-delegations.
+   */
+  participants: { id: string; name: string }[]
+}
+
+// ─── Internal helpers ──────────────────────────────────────────────────────
+
+function resolveTarget(
+  raw: string,
+  participants: { id: string; name: string }[],
+): { id: string; name: string } | null {
+  const stripped = raw.replace(/^@/, '').trim().toLowerCase()
+  if (!stripped) return null
+  const sorted = [...participants].sort((a, b) => b.name.length - a.name.length)
+  for (const agent of sorted) {
+    if (stripped === agent.name.toLowerCase()) return agent
+  }
+  for (const agent of sorted) {
+    const lower = agent.name.toLowerCase()
+    if (stripped.startsWith(lower) || lower.startsWith(stripped)) return agent
+  }
+  return null
+}
+
+/**
+ * Bucket `mergedEntries` by owning agent id (derived from sessionKey).
+ * Returns one ordered list per agent so claim lookups don't re-scan the
+ * full transcript for each delegation.
+ */
+function bucketByAgent(mergedEntries: TranscriptEntry[]): Map<string, TranscriptEntry[]> {
+  const buckets = new Map<string, TranscriptEntry[]>()
+  for (const entry of mergedEntries) {
+    const agentId = agentIdFromSessionKey(entry.sessionKey)
+    if (!agentId) continue
+    let bucket = buckets.get(agentId)
+    if (!bucket) {
+      bucket = []
+      buckets.set(agentId, bucket)
+    }
+    bucket.push(entry)
+  }
+  return buckets
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────────
+
+export function buildDelegationLinkages(
+  params: BuildDelegationLinkagesParams,
+): BuildDelegationLinkagesResult {
+  const { blocks, mergedEntries, teamId, participants } = params
+
+  const linkagesByDelegationId = new Map<string, DelegationLinkage>()
+  const linkagesBySourceEntry = new Map<string, DelegationLinkage[]>()
+  const claimedEntries = new Set<string>()
+  const streamingOwnerByTargetSessionKey = new Map<string, string>()
+
+  if (blocks.length === 0 || mergedEntries.length === 0) {
+    return {
+      linkagesByDelegationId,
+      linkagesBySourceEntry,
+      claimedEntries,
+      streamingOwnerByTargetSessionKey,
+    }
+  }
+
+  const entriesByAgent = bucketByAgent(mergedEntries)
+
+  for (const block of blocks) {
+    if (block.kind !== 'assistant-turn') continue
+    const sourceEntry = block.assistant
+    if (!sourceEntry) continue
+    const text = sourceEntry.text
+    if (!text) continue
+    // Relays carry condensed summaries that may incidentally contain
+    // delegate-looking strings — guard against false positives.
+    if (isRelayMessage(text)) continue
+
+    const sourceAgentId = agentIdFromSessionKey(sourceEntry.sessionKey)
+    if (!sourceAgentId) continue
+
+    const delegateBlocks = findDelegationBlocks(text)
+    if (delegateBlocks.length === 0) continue
+
+    for (const delegateBlock of delegateBlocks) {
+      if (!delegateBlock.task) continue
+      const target = resolveTarget(delegateBlock.targetName, participants)
+      if (!target) continue
+      // Self-delegation: not a real routing intent.
+      if (target.id === sourceAgentId) continue
+
+      const delegationId = `${sourceEntry.entryId}:${delegateBlock.blockStart}`
+      const targetSessionKey = buildTeamSessionKey(target.id, teamId)
+      const targetBucket = entriesByAgent.get(target.id) ?? []
+
+      // Find the earliest unclaimed assistant entry from the target whose
+      // sequenceKey is strictly greater than the source's. sequenceKey is the
+      // process-local monotonic counter — it breaks millisecond-collision
+      // ties that timestampMs alone can't.
+      let firstReply: TranscriptEntry | null = null
+      for (const candidate of targetBucket) {
+        if (candidate.role !== 'assistant' || candidate.kind !== 'assistant') continue
+        if (candidate.sequenceKey <= sourceEntry.sequenceKey) continue
+        if (claimedEntries.has(candidate.entryId)) continue
+        firstReply = candidate
+        break
+      }
+
+      const linkedEntries: TranscriptEntry[] = []
+      if (firstReply) {
+        const runId = firstReply.runId
+        // Accrete every entry in the target bucket sharing the same runId
+        // — thinking, tool, assistant chunks all belong to one reply.
+        for (const candidate of targetBucket) {
+          if (candidate.entryId === firstReply.entryId) {
+            linkedEntries.push(candidate)
+            claimedEntries.add(candidate.entryId)
+            continue
+          }
+          if (runId === null) continue
+          if (candidate.runId !== runId) continue
+          if (claimedEntries.has(candidate.entryId)) continue
+          // Don't pull in entries that came BEFORE the first claimed reply —
+          // a previous run could legitimately share `null` runId in rare
+          // cases, but a non-null runId match plus sequenceKey ordering keeps
+          // us safe here.
+          if (candidate.sequenceKey <= sourceEntry.sequenceKey) continue
+          linkedEntries.push(candidate)
+          claimedEntries.add(candidate.entryId)
+        }
+        // Keep linkedEntries chronological (mergedEntries is already sorted,
+        // so the bucket is too — but `firstReply` was pushed first above,
+        // which may not be the chronologically earliest. Re-sort defensively.)
+        linkedEntries.sort((a, b) => {
+          const ts = (a.timestampMs ?? 0) - (b.timestampMs ?? 0)
+          if (ts !== 0) return ts
+          return a.sequenceKey - b.sequenceKey
+        })
+      }
+
+      const linkage: DelegationLinkage = {
+        delegationId,
+        sourceEntryId: sourceEntry.entryId,
+        sourceAgentId,
+        blockStart: delegateBlock.blockStart,
+        targetAgentId: target.id,
+        targetAgentName: target.name,
+        targetRawName: delegateBlock.targetName.replace(/^@/, '').trim(),
+        task: delegateBlock.task,
+        targetSessionKey,
+        linkedEntries,
+        isPending: linkedEntries.length === 0,
+      }
+
+      linkagesByDelegationId.set(delegationId, linkage)
+      const bySource = linkagesBySourceEntry.get(sourceEntry.entryId)
+      if (bySource) {
+        bySource.push(linkage)
+      } else {
+        linkagesBySourceEntry.set(sourceEntry.entryId, [linkage])
+      }
+
+      // First pending delegation per target sessionKey owns the streaming
+      // card — later pending delegations to the same target wait their turn.
+      if (linkage.isPending && !streamingOwnerByTargetSessionKey.has(targetSessionKey)) {
+        streamingOwnerByTargetSessionKey.set(targetSessionKey, delegationId)
+      }
+    }
+  }
+
+  return {
+    linkagesByDelegationId,
+    linkagesBySourceEntry,
+    claimedEntries,
+    streamingOwnerByTargetSessionKey,
+  }
+}

--- a/apps/web/src/features/group-chat/buildDelegationLinkages.ts
+++ b/apps/web/src/features/group-chat/buildDelegationLinkages.ts
@@ -15,8 +15,9 @@ import type { TranscriptEntry } from '@clawboo/protocol'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
 import { shouldDropAssistantTurn } from '@/lib/teamProtocol'
 import { findDelegationBlocks, isRelayMessage } from './delegationDetector'
+import { findPlanBlocks } from './planDetector'
 import { parseToolEntry } from '@/features/chat/parseToolEntry'
-import type { ClawbooDispatch } from '@/stores/chat'
+import type { ClawbooDispatch, PendingWorkstreams } from '@/stores/chat'
 import type { RenderBlock } from '@/features/chat/chatComponents'
 
 export interface DelegationLinkage {
@@ -62,6 +63,35 @@ export interface DelegationLinkage {
    *     produced the wake.
    */
   source: 'delegate-tag' | 'sessions-send' | 'clawboo-dispatch' | 'clawboo-relay'
+  /**
+   * Round 9: when this linkage is a step of a `<plan>` block, the parent
+   * plan's id. The renderer (`AssistantTurnCard` → `PlanCard`) groups all
+   * linkages with the same `planId` under one PlanCard header. Null /
+   * undefined for one-shot delegations (`<delegate>`, `sessions_send`,
+   * fallback regex, relay batches not part of a plan).
+   */
+  planId?: string | null
+  /**
+   * Round 9: the step's index within the parent plan (0-based). The
+   * renderer orders step cards under the PlanCard header by this index.
+   * Paired with `planId`.
+   */
+  planStepIndex?: number | null
+  /**
+   * Round 10: when this linkage is one target of a parallel workstream
+   * batch (≥2 sibling `<delegate>` tags emitted in one leader turn, no
+   * `<plan>` wrapper), carries the parent workstream's id so the renderer
+   * (`AssistantTurnCard` → `WorkstreamCard`) groups all sibling-linkages
+   * with the same `workstreamId` under one card. Null / undefined for
+   * one-shot delegations, plan steps, or `sessions_send` cards.
+   */
+  workstreamId?: string | null
+  /**
+   * Round 10: the target's index within the parent workstream (0-based).
+   * Sourced from `ClawbooDispatch.workstreamTargetIndex`. Stable across
+   * dispatches arriving out of order.
+   */
+  workstreamTargetIndex?: number | null
 }
 
 export interface BuildDelegationLinkagesResult {
@@ -98,6 +128,41 @@ export interface BuildDelegationLinkagesParams {
    * `sessions_send`. When omitted (1:1 chat path), Path 3 is skipped.
    */
   clawbooDispatches?: Map<string, ClawbooDispatch[]>
+  /**
+   * Round 13: Clawboo's implicit-fan-out workstream records, keyed by
+   * `workstreamId`. Threaded in from `GroupChatPanel` via
+   * `useChatStore(s => s.pendingWorkstreams)`. Path 4 in the linkage
+   * scan synthesizes DelegationLinkages for these workstreams when the
+   * leader's response had NO explicit `<delegate>` / `sessions_send`
+   * tags BUT Clawboo's orchestration detected "I'll ask all teammates"
+   * fan-out prose and minted a workstream record. Without this, no
+   * cards would render — the user sees flat plain-assistant turns from
+   * the teammates with no DONE pills or grid layout.
+   */
+  pendingWorkstreams?: Map<string, PendingWorkstreams>
+  /**
+   * Round 15: live streaming text per participant session — keyed by
+   * sessionKey, matching `useChatStore.streamingText`. Used by the
+   * leader-streaming pass below to scan for mid-stream `<delegate>`
+   * blocks BEFORE the leader's source entry commits. Without this scan,
+   * the target's reply would appear at top-level as a `StreamingCard`
+   * (and then briefly as a top-level `AssistantTurnCard` after the
+   * target commits but before the leader does), then jump inside the
+   * eventual DelegationCard once the leader's entry commits and Path 1
+   * builds the real linkage. With this scan, ownership transfers to the
+   * card from the moment the closing `</delegate>` tag appears in the
+   * leader's stream — the visible card stays stable across commit.
+   */
+  streamingTexts?: Map<string, string>
+  /**
+   * Round 15: per-session stream-start timestamps (`useChatStore.streamStartedAt`).
+   * Anchors the leader-streaming scan's "after-source" filter — pre-stream
+   * target entries (e.g., the target's old onboarding intro) are NOT
+   * claimed, only entries that landed AFTER the leader's stream started.
+   * Same role as `sourceTimestampMs` in `findTargetResponse` but resolved
+   * from the stream anchor instead of a committed entry.
+   */
+  streamStartedAt?: Map<string, number>
 }
 
 // ─── Internal helpers ──────────────────────────────────────────────────────
@@ -337,14 +402,34 @@ function bucketByAgent(mergedEntries: TranscriptEntry[]): Map<string, Transcript
 export function buildDelegationLinkages(
   params: BuildDelegationLinkagesParams,
 ): BuildDelegationLinkagesResult {
-  const { blocks, mergedEntries, teamId, participants, clawbooDispatches } = params
+  const {
+    blocks,
+    mergedEntries,
+    teamId,
+    participants,
+    clawbooDispatches,
+    pendingWorkstreams,
+    streamingTexts,
+    streamStartedAt,
+  } = params
 
   const linkagesByDelegationId = new Map<string, DelegationLinkage>()
   const linkagesBySourceEntry = new Map<string, DelegationLinkage[]>()
   const claimedEntries = new Set<string>()
   const streamingOwnerByTargetSessionKey = new Map<string, string>()
 
-  if (blocks.length === 0 || mergedEntries.length === 0) {
+  // Early-return: nothing to scan AND nothing streaming. Round 15's
+  // streaming-text pass still needs to run when `blocks.length === 0`
+  // but the leader is mid-stream — that's the exact "before commit"
+  // window the pass is designed for.
+  const hasStreamingWithDelegateLike = (() => {
+    if (!streamingTexts || streamingTexts.size === 0) return false
+    for (const t of streamingTexts.values()) {
+      if (t && t.includes('<delegate')) return true
+    }
+    return false
+  })()
+  if (blocks.length === 0 && !hasStreamingWithDelegateLike) {
     return {
       linkagesByDelegationId,
       linkagesBySourceEntry,
@@ -386,13 +471,41 @@ export function buildDelegationLinkages(
     }
 
     // ─── Path 1: structured `<delegate>` tags (the canonical Clawboo flow) ──
+    //
+    // Round 10: when the source contains ≥2 valid `<delegate>` blocks AND
+    // no `<plan>` wrapper, attribute each linkage to a single workstreamId
+    // so the renderer (`AssistantTurnCard` → `WorkstreamCard`) groups them
+    // under one card. The id is derived deterministically from the source
+    // entry's id — same scheme as `useTeamOrchestration` uses when minting
+    // the `PendingWorkstreams` store record, so the renderer can read live
+    // progress from the store via the same key.
     const delegateBlocks = findDelegationBlocks(text)
-    for (const delegateBlock of delegateBlocks) {
-      if (!delegateBlock.task) continue
-      const target = resolveTarget(delegateBlock.targetName, participants)
-      if (!target) continue
-      if (target.id === sourceAgentId) continue
+    // Pre-validate so the workstream batch decision uses real targets
+    // (filters self / unknown / empty-task — same gates the orchestration
+    // hook uses via `detectDelegations`). This also avoids attributing a
+    // workstreamId to a 1-valid + 1-invalid case which the user perceives
+    // as a single delegation, not a batch.
+    const validDelegateBlocks = delegateBlocks
+      .map((b) => {
+        if (!b.task) return null
+        const t = resolveTarget(b.targetName, participants)
+        if (!t) return null
+        if (t.id === sourceAgentId) return null
+        return { block: b, target: t }
+      })
+      .filter(
+        (
+          x,
+        ): x is { block: (typeof delegateBlocks)[number]; target: { id: string; name: string } } =>
+          x !== null,
+      )
+    const sourceHasPlan = findPlanBlocks(text).length > 0
+    const isWorkstreamBatch = validDelegateBlocks.length >= 2 && !sourceHasPlan
+    const workstreamIdForSource = isWorkstreamBatch
+      ? `${teamId}:${sourceEntry.entryId}:workstreams`
+      : null
 
+    validDelegateBlocks.forEach(({ block: delegateBlock, target }, idx) => {
       const targetSessionKey = buildTeamSessionKey(target.id, teamId)
       const targetBucket = entriesByAgent.get(target.id) ?? []
       const linkedEntries = findTargetResponse({
@@ -415,8 +528,12 @@ export function buildDelegationLinkages(
         linkedEntries,
         isPending: linkedEntries.length === 0,
         source: 'delegate-tag',
+        // Round 10: when this source emitted N≥2 valid `<delegate>` tags
+        // without a `<plan>` wrapper, group them under one WorkstreamCard.
+        workstreamId: workstreamIdForSource,
+        workstreamTargetIndex: workstreamIdForSource !== null ? idx : null,
       })
-    }
+    })
 
     // ─── Path 2: Round 6 — OpenClaw `sessions_send` tool calls ──────────────
     // The LLM often skips structured `<delegate>` tags and uses OpenClaw's
@@ -528,7 +645,145 @@ export function buildDelegationLinkages(
           linkedEntries,
           isPending: linkedEntries.length === 0,
           source: dispatch.origin === 'dispatch-delegation' ? 'clawboo-dispatch' : 'clawboo-relay',
+          // Round 9: propagate plan provenance so the renderer can group
+          // plan-step linkages under a single PlanCard header.
+          planId: dispatch.planId ?? null,
+          planStepIndex: dispatch.planStepIndex ?? null,
+          // Round 10: propagate workstream provenance so the renderer can
+          // group sibling-delegation linkages under a single WorkstreamCard.
+          workstreamId: dispatch.workstreamId ?? null,
+          workstreamTargetIndex: dispatch.workstreamTargetIndex ?? null,
         })
+      }
+    }
+
+    // ─── Path 4: Round 13 — implicit fan-out workstreams ──────────────────
+    // When the leader emits plural-routing prose ("I'll ask all teammates",
+    // "got responses from all three", etc.) WITHOUT any structured tag,
+    // `useTeamOrchestration.processNewEntries` mints a PendingWorkstreams
+    // record with `:implicit-fanout` suffix. Path 4 synthesizes one
+    // linkage per target so the existing WorkstreamCard pipeline renders.
+    //
+    // Subordinate to Paths 1-3: if any of them produced linkages on this
+    // source, we SKIP — explicit / Gateway-routed signals always win.
+    if (pendingWorkstreams) {
+      const existing = linkagesBySourceEntry.get(sourceEntry.entryId)
+      if (!existing || existing.length === 0) {
+        for (const ws of pendingWorkstreams.values()) {
+          if (ws.teamId !== teamId) continue
+          if (ws.sourceEntryId !== sourceEntry.entryId) continue
+          if (!ws.workstreamId.endsWith(':implicit-fanout')) continue
+          ws.targets.forEach((target, idx) => {
+            if (!target.targetAgentId) return
+            if (target.targetAgentId === sourceAgentId) return
+            const targetSessionKey = buildTeamSessionKey(target.targetAgentId, teamId)
+            const targetBucket = entriesByAgent.get(target.targetAgentId) ?? []
+            const linkedEntries = findTargetResponse({
+              bucket: targetBucket,
+              sourceTimestampMs: ws.timestampMs,
+              sourceSequenceKey: sourceEntry.sequenceKey,
+              claimedEntries,
+            })
+            recordLinkage({
+              // Synthetic delegationId — `:fanout:<idx>` makes it
+              // distinguishable from Path 1 ids in debug tooling.
+              delegationId: `${ws.workstreamId}:${idx}`,
+              sourceEntryId: sourceEntry.entryId,
+              sourceAgentId: ws.sourceAgentId,
+              // Synthetic offset beyond any plausible real blockStart so
+              // the splitAssistantText renderer doesn't try to claim it
+              // for inline rendering — implicit fanout cards render via
+              // WorkstreamCard grouping, not inline prose splitting.
+              blockStart: 1_000_000 + idx,
+              targetAgentId: target.targetAgentId,
+              targetAgentName: target.targetAgentName,
+              targetRawName: target.targetAgentName,
+              task: target.task,
+              targetSessionKey,
+              linkedEntries,
+              isPending: linkedEntries.length === 0,
+              // Reuse Round 7's `clawboo-dispatch` source kind — visually
+              // it's the same kind of signal: Clawboo's orchestration
+              // routed work to this teammate without an LLM-emitted tag.
+              source: 'clawboo-dispatch',
+              planId: null,
+              planStepIndex: null,
+              workstreamId: ws.workstreamId,
+              workstreamTargetIndex: idx,
+            })
+          })
+        }
+      }
+    }
+  }
+
+  // ─── Round 15: leader-streaming pass ────────────────────────────────────
+  // BEFORE the leader's source entry commits, its `<delegate>` blocks live
+  // only in `streamingText` — `mergedEntries` doesn't yet contain the
+  // leader entry, so Paths 1–4 above never run for it. Without this pass,
+  // the target's reply (whether still streaming or already committed)
+  // appears at top level as a `StreamingCard` / `AssistantTurnCard` and
+  // visually "jumps inside" the eventual DelegationCard only after the
+  // leader commits and Path 1 builds the real linkage.
+  //
+  // This pass closes that gap: scan every participant's streaming text
+  // for closed `<delegate>` blocks. For each closed block:
+  //   1. Claim the target sessionKey via `streamingOwnerByTargetSessionKey`
+  //      so `GroupChatPanel.activeStreams` filters out the target's
+  //      top-level `StreamingCard` while it streams.
+  //   2. Claim any already-committed target entries whose timestamp is
+  //      AFTER the leader's stream-start anchor — these are the eventual
+  //      linkage's `linkedEntries` once the leader commits and Path 1
+  //      runs. Adding them to `claimedEntries` now keeps them out of the
+  //      top-level transcript during the brief target-committed-but-
+  //      leader-still-streaming window.
+  //
+  // Skipped when an existing committed linkage already owns the target —
+  // committed linkages have full provenance (source + dispatch + ids) and
+  // should never be overwritten by the streaming pass.
+  if (streamingTexts && streamingTexts.size > 0) {
+    for (const [sourceSk, streamText] of streamingTexts) {
+      if (!streamText) continue
+      const sourceAgentId = agentIdFromSessionKey(sourceSk)
+      if (!sourceAgentId) continue
+      // Only participants count. Defensive — `streamingText` may contain
+      // sessions outside the current team (older 1:1 chat sessions, etc.).
+      if (!participants.some((p) => p.id === sourceAgentId)) continue
+      // Skip relays / control tokens — same guards as the committed path
+      // uses to prevent false positives from incidental delegate-looking
+      // strings.
+      if (isRelayMessage(streamText)) continue
+      const streamBlocks = findDelegationBlocks(streamText)
+      if (streamBlocks.length === 0) continue
+      const streamStarted = streamStartedAt?.get(sourceSk) ?? 0
+      for (const block of streamBlocks) {
+        if (!block.task) continue
+        const target = resolveTarget(block.targetName, participants)
+        if (!target) continue
+        if (target.id === sourceAgentId) continue
+        const targetSk = buildTeamSessionKey(target.id, teamId)
+        // Don't clobber a committed linkage that already owns this target.
+        if (streamingOwnerByTargetSessionKey.has(targetSk)) continue
+        // Synthetic owner id — prefixed `stream:` so debug tooling can
+        // distinguish it from real delegationIds (which are entry-ids).
+        streamingOwnerByTargetSessionKey.set(targetSk, `stream:${sourceSk}:${block.blockStart}`)
+        // Claim any committed target replies that arrived AFTER the
+        // leader's stream started. Substantive replies only — control
+        // tokens stay filtered. Anchor on stream-start so stale entries
+        // (target's prior onboarding intro) are NOT claimed.
+        if (streamStarted > 0) {
+          const targetBucket = entriesByAgent.get(target.id) ?? []
+          for (const e of targetBucket) {
+            if (claimedEntries.has(e.entryId)) continue
+            if ((e.timestampMs ?? 0) <= streamStarted) continue
+            if (!e.text) continue
+            if (shouldDropAssistantTurn(e.text)) continue
+            // Only assistant entries — tool / thinking / meta keep their
+            // own rendering paths.
+            if (e.kind !== 'assistant') continue
+            claimedEntries.add(e.entryId)
+          }
+        }
       }
     }
   }

--- a/apps/web/src/features/group-chat/buildDelegationLinkages.ts
+++ b/apps/web/src/features/group-chat/buildDelegationLinkages.ts
@@ -13,15 +13,22 @@
 
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
+import { shouldDropAssistantTurn } from '@/lib/teamProtocol'
 import { findDelegationBlocks, isRelayMessage } from './delegationDetector'
+import { parseToolEntry } from '@/features/chat/parseToolEntry'
+import type { ClawbooDispatch } from '@/stores/chat'
 import type { RenderBlock } from '@/features/chat/chatComponents'
 
 export interface DelegationLinkage {
-  /** Stable id derived from source entry + block offset. */
+  /** Stable id derived from source entry + block offset (or tool-entry id). */
   delegationId: string
   sourceEntryId: string
   sourceAgentId: string
-  /** Character offset of the `<delegate>` opener in the source entry's text. */
+  /**
+   * Character offset of the `<delegate>` opener in the source entry's text
+   * for explicit-tag linkages; for `sessions_send` tool-call linkages this
+   * is the tool entry's `sequenceKey` (used only as a positional marker).
+   */
   blockStart: number
   /** Resolved id of the target agent (after team-roster lookup). */
   targetAgentId: string
@@ -36,6 +43,25 @@ export interface DelegationLinkage {
   linkedEntries: TranscriptEntry[]
   /** True when the target hasn't yet committed any reply for this delegation. */
   isPending: boolean
+  /**
+   * `source` discriminates how the linkage was synthesized. The renderer
+   * treats all four uniformly as DelegationCards but may render a small
+   * badge for the non-canonical paths so the user knows what was routed
+   * vs. what the LLM emitted explicitly:
+   *
+   *   - `delegate-tag` — structured `<delegate>` block in the leader's
+   *     prose (the canonical Clawboo flow).
+   *   - `sessions-send` — Round 6: the LLM called OpenClaw's `sessions_send`
+   *     Gateway tool; the tool entry IS visible in `block.tools[]`.
+   *   - `clawboo-dispatch` — Round 7: Clawboo's own commit-time delegation
+   *     detector caught a fallback regex match (`@Name` patterns) and fired
+   *     `chat.send`. No `<delegate>` tag in the prose to render via Path 1.
+   *   - `clawboo-relay` — Round 7: Clawboo's `flushRelayBatch` forwarded
+   *     the leader's response to a teammate as a `[Team Update]` envelope.
+   *     The leader didn't intend a delegation; Clawboo's routing is what
+   *     produced the wake.
+   */
+  source: 'delegate-tag' | 'sessions-send' | 'clawboo-dispatch' | 'clawboo-relay'
 }
 
 export interface BuildDelegationLinkagesResult {
@@ -63,6 +89,15 @@ export interface BuildDelegationLinkagesParams {
    * `to="..."` resolution and to ignore self-delegations.
    */
   participants: { id: string; name: string }[]
+  /**
+   * Round 7: Clawboo's recorded outgoing routing events for this team,
+   * keyed by `${teamId}:${sourceEntryId}`. Threaded in from `GroupChatPanel`
+   * via `useChatStore(s => s.clawbooDispatches)`. Path 3 in the linkage
+   * scan consumes this map so DelegationCards reflect actual Clawboo
+   * orchestration even when the LLM never emits `<delegate>` /
+   * `sessions_send`. When omitted (1:1 chat path), Path 3 is skipped.
+   */
+  clawbooDispatches?: Map<string, ClawbooDispatch[]>
 }
 
 // ─── Internal helpers ──────────────────────────────────────────────────────
@@ -82,6 +117,199 @@ function resolveTarget(
     if (stripped.startsWith(lower) || lower.startsWith(stripped)) return agent
   }
   return null
+}
+
+/**
+ * Pull the structured params out of a `sessions_send` tool-call body. The
+ * Gateway emits the body as a fenced JSON block via `formatToolCallMarkdown`
+ * in `@clawboo/protocol`. OpenClaw's actual schema (verified against
+ * `openclaw/dist/.../createSessionsSendTool` at line 88732):
+ *
+ *   ```json
+ *   {
+ *     "sessionKey": "agent:<id>:<sessionName>",  // optional
+ *     "label": "Engineer Boo",                    // optional, max 64 chars
+ *     "agentId": "engineer-boo",                  // optional, max 64 chars
+ *     "message": "do this task"                   // REQUIRED
+ *   }
+ *   ```
+ *
+ * The caller must provide at least one of (sessionKey | label | agentId).
+ * We return whichever fields are present and let the linkage builder resolve
+ * them against the participant roster in order: sessionKey > agentId > label.
+ *
+ * Parsing is defensive — malformed JSON / wrong shape yields `null`, the
+ * linkage is skipped, and the raw tool entry keeps rendering as a
+ * `ToolCallCard`.
+ *
+ * NOTE: Round 6 originally looked for `to` but `sessions_send` has NEVER
+ * had a `to` field; that was a wrong assumption from the plan. The fix is
+ * here.
+ */
+export interface SessionsSendParams {
+  /** `agent:<id>:<sessionName>` format, when the caller used a direct key. */
+  sessionKey?: string
+  /** Human-readable label — typically the agent's `name`. Max 64 chars. */
+  label?: string
+  /** Direct agent id when present. Max 64 chars. */
+  agentId?: string
+  /** Required body. */
+  message: string
+}
+
+export function extractSessionsSendParams(body: string): SessionsSendParams | null {
+  if (!body) return null
+  // Strip ```json ... ``` fences (and the alternative bare ``` ... ```).
+  let inner = body.trim()
+  const fenceMatch = inner.match(/^```(?:json)?\s*\n?([\s\S]*?)\n?```$/)
+  if (fenceMatch) inner = fenceMatch[1]!.trim()
+  if (!inner) return null
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(inner)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const obj = parsed as Record<string, unknown>
+  const messageRaw = obj['message']
+  if (typeof messageRaw !== 'string') return null
+  const message = messageRaw.trim()
+  if (!message) return null
+
+  const result: SessionsSendParams = { message }
+  const sessionKey = typeof obj['sessionKey'] === 'string' ? obj['sessionKey'].trim() : ''
+  const label = typeof obj['label'] === 'string' ? obj['label'].trim() : ''
+  const agentId = typeof obj['agentId'] === 'string' ? obj['agentId'].trim() : ''
+  if (sessionKey) result.sessionKey = sessionKey
+  if (label) result.label = label
+  if (agentId) result.agentId = agentId
+
+  // Need at least one routing identifier to be useful.
+  if (!result.sessionKey && !result.label && !result.agentId) return null
+  return result
+}
+
+/**
+ * Resolve a `sessions_send` target against the team roster. Tries in
+ * priority order:
+ *   1. `sessionKey` — parse `agent:<id>:<sessionName>` and look up by id.
+ *   2. `agentId` — direct id match.
+ *   3. `label` — case-insensitive name match against participants.
+ * Returns the resolved participant or null.
+ */
+export function resolveSessionsSendTarget(
+  params: SessionsSendParams,
+  participants: { id: string; name: string }[],
+): { id: string; name: string } | null {
+  if (params.sessionKey) {
+    const match = params.sessionKey.match(/^agent:([^:]+):/)
+    const id = match?.[1]
+    if (id) {
+      const hit = participants.find((p) => p.id === id)
+      if (hit) return hit
+    }
+  }
+  if (params.agentId) {
+    const hit = participants.find((p) => p.id === params.agentId)
+    if (hit) return hit
+  }
+  if (params.label) {
+    const lower = params.label.toLowerCase()
+    const exact = participants.find((p) => p.name.toLowerCase() === lower)
+    if (exact) return exact
+    // Tolerate leading `@` and longest-prefix.
+    const stripped = params.label.replace(/^@/, '').trim().toLowerCase()
+    const sorted = [...participants].sort((a, b) => b.name.length - a.name.length)
+    for (const p of sorted) {
+      if (stripped === p.name.toLowerCase()) return p
+    }
+    for (const p of sorted) {
+      const lp = p.name.toLowerCase()
+      if (stripped.startsWith(lp) || lp.startsWith(stripped)) return p
+    }
+  }
+  return null
+}
+
+/**
+ * Shared target-response accrual used by ALL three scanner paths (explicit
+ * `<delegate>`, Round 6 `sessions_send` tool calls, Round 7 Clawboo
+ * dispatches). Finds the earliest unclaimed assistant entry from the
+ * target whose `timestampMs` is strictly greater than the source's anchor,
+ * then accretes every following entry in the target's bucket that shares
+ * the same `runId` (thinking, tool, assistant chunks all belong to one
+ * reply). Mutates `claimedEntries`.
+ *
+ * IMPORTANT — why timestamp, not sequenceKey:
+ *
+ * `sequenceKey` is process-local (`lib/sequenceKey.ts` resets to 0 on each
+ * page reload), while transcript data PERSISTS across sessions in SQLite.
+ * After a reload, hydrated entries from prior sessions keep their original
+ * sequenceKeys — which can be HIGHER than newly-emitted entries in the
+ * current session. A pure-sequenceKey filter (used pre-Round 7B) caused
+ * the linkage scan to claim STALE responses from earlier conversations
+ * instead of the fresh ones triggered by the current source. Symptom in
+ * production: DelegationCards rendered with the target agent's old intro
+ * ("Hey! I'm @X, and I specialize in...") nested inside while the fresh
+ * substantive response landed at top level below, unattached.
+ *
+ * The fix: filter by `timestampMs > source.timestampMs` (with a small
+ * tolerance to break ms-collision ties via sequenceKey). Timestamps are
+ * wall-clock and stable across reloads — a fresh response committed AFTER
+ * the source's timestamp is genuinely "after" regardless of seqkey state.
+ *
+ * Returns linked entries in chronological order (defensively sorted).
+ */
+function findTargetResponse(params: {
+  bucket: TranscriptEntry[]
+  /** Timestamp of the source anchor — the primary "after-source" filter. */
+  sourceTimestampMs: number
+  /** sequenceKey of the source — used only as a same-millisecond tiebreaker. */
+  sourceSequenceKey: number
+  claimedEntries: Set<string>
+}): TranscriptEntry[] {
+  const { bucket, sourceTimestampMs, sourceSequenceKey, claimedEntries } = params
+
+  /** A candidate is "after the source" when its timestamp is strictly later,
+   *  OR same-ms-but-later-seqkey (rare; defensive tiebreaker). */
+  const isAfterSource = (candidate: TranscriptEntry): boolean => {
+    const candTs = candidate.timestampMs ?? 0
+    if (candTs > sourceTimestampMs) return true
+    if (candTs === sourceTimestampMs) return candidate.sequenceKey > sourceSequenceKey
+    return false
+  }
+
+  let firstReply: TranscriptEntry | null = null
+  for (const candidate of bucket) {
+    if (candidate.role !== 'assistant' || candidate.kind !== 'assistant') continue
+    if (!isAfterSource(candidate)) continue
+    if (claimedEntries.has(candidate.entryId)) continue
+    firstReply = candidate
+    break
+  }
+  const linkedEntries: TranscriptEntry[] = []
+  if (!firstReply) return linkedEntries
+  const runId = firstReply.runId
+  for (const candidate of bucket) {
+    if (candidate.entryId === firstReply.entryId) {
+      linkedEntries.push(candidate)
+      claimedEntries.add(candidate.entryId)
+      continue
+    }
+    if (runId === null) continue
+    if (candidate.runId !== runId) continue
+    if (claimedEntries.has(candidate.entryId)) continue
+    if (!isAfterSource(candidate)) continue
+    linkedEntries.push(candidate)
+    claimedEntries.add(candidate.entryId)
+  }
+  linkedEntries.sort((a, b) => {
+    const ts = (a.timestampMs ?? 0) - (b.timestampMs ?? 0)
+    if (ts !== 0) return ts
+    return a.sequenceKey - b.sequenceKey
+  })
+  return linkedEntries
 }
 
 /**
@@ -109,7 +337,7 @@ function bucketByAgent(mergedEntries: TranscriptEntry[]): Map<string, Transcript
 export function buildDelegationLinkages(
   params: BuildDelegationLinkagesParams,
 ): BuildDelegationLinkagesResult {
-  const { blocks, mergedEntries, teamId, participants } = params
+  const { blocks, mergedEntries, teamId, participants, clawbooDispatches } = params
 
   const linkagesByDelegationId = new Map<string, DelegationLinkage>()
   const linkagesBySourceEntry = new Map<string, DelegationLinkage[]>()
@@ -136,74 +364,46 @@ export function buildDelegationLinkages(
     // Relays carry condensed summaries that may incidentally contain
     // delegate-looking strings — guard against false positives.
     if (isRelayMessage(text)) continue
-    // Resume-ack token is a protocol artifact (Phase 3) — never a source
-    // of delegations.
-    if (text.trim() === '__resumed__') continue
+    // Broken-shape turns are never a source of delegations: OpenClaw
+    // protocol control tokens (ANNOUNCE_SKIP, NO_REPLY, NO), Clawboo
+    // tokens (__resumed__, __skipped__), and short refusal leaks. Same
+    // gate as the chat renderer in `chatComponents.groupEntriesToBlocks`.
+    if (shouldDropAssistantTurn(text)) continue
 
     const sourceAgentId = agentIdFromSessionKey(sourceEntry.sessionKey)
     if (!sourceAgentId) continue
 
-    const delegateBlocks = findDelegationBlocks(text)
-    if (delegateBlocks.length === 0) continue
+    const recordLinkage = (linkage: DelegationLinkage): void => {
+      linkagesByDelegationId.set(linkage.delegationId, linkage)
+      const bySource = linkagesBySourceEntry.get(sourceEntry.entryId)
+      if (bySource) bySource.push(linkage)
+      else linkagesBySourceEntry.set(sourceEntry.entryId, [linkage])
+      // First pending delegation per target sessionKey owns the streaming
+      // card — later pending delegations to the same target wait their turn.
+      if (linkage.isPending && !streamingOwnerByTargetSessionKey.has(linkage.targetSessionKey)) {
+        streamingOwnerByTargetSessionKey.set(linkage.targetSessionKey, linkage.delegationId)
+      }
+    }
 
+    // ─── Path 1: structured `<delegate>` tags (the canonical Clawboo flow) ──
+    const delegateBlocks = findDelegationBlocks(text)
     for (const delegateBlock of delegateBlocks) {
       if (!delegateBlock.task) continue
       const target = resolveTarget(delegateBlock.targetName, participants)
       if (!target) continue
-      // Self-delegation: not a real routing intent.
       if (target.id === sourceAgentId) continue
 
-      const delegationId = `${sourceEntry.entryId}:${delegateBlock.blockStart}`
       const targetSessionKey = buildTeamSessionKey(target.id, teamId)
       const targetBucket = entriesByAgent.get(target.id) ?? []
+      const linkedEntries = findTargetResponse({
+        bucket: targetBucket,
+        sourceTimestampMs: sourceEntry.timestampMs ?? 0,
+        sourceSequenceKey: sourceEntry.sequenceKey,
+        claimedEntries,
+      })
 
-      // Find the earliest unclaimed assistant entry from the target whose
-      // sequenceKey is strictly greater than the source's. sequenceKey is the
-      // process-local monotonic counter — it breaks millisecond-collision
-      // ties that timestampMs alone can't.
-      let firstReply: TranscriptEntry | null = null
-      for (const candidate of targetBucket) {
-        if (candidate.role !== 'assistant' || candidate.kind !== 'assistant') continue
-        if (candidate.sequenceKey <= sourceEntry.sequenceKey) continue
-        if (claimedEntries.has(candidate.entryId)) continue
-        firstReply = candidate
-        break
-      }
-
-      const linkedEntries: TranscriptEntry[] = []
-      if (firstReply) {
-        const runId = firstReply.runId
-        // Accrete every entry in the target bucket sharing the same runId
-        // — thinking, tool, assistant chunks all belong to one reply.
-        for (const candidate of targetBucket) {
-          if (candidate.entryId === firstReply.entryId) {
-            linkedEntries.push(candidate)
-            claimedEntries.add(candidate.entryId)
-            continue
-          }
-          if (runId === null) continue
-          if (candidate.runId !== runId) continue
-          if (claimedEntries.has(candidate.entryId)) continue
-          // Don't pull in entries that came BEFORE the first claimed reply —
-          // a previous run could legitimately share `null` runId in rare
-          // cases, but a non-null runId match plus sequenceKey ordering keeps
-          // us safe here.
-          if (candidate.sequenceKey <= sourceEntry.sequenceKey) continue
-          linkedEntries.push(candidate)
-          claimedEntries.add(candidate.entryId)
-        }
-        // Keep linkedEntries chronological (mergedEntries is already sorted,
-        // so the bucket is too — but `firstReply` was pushed first above,
-        // which may not be the chronologically earliest. Re-sort defensively.)
-        linkedEntries.sort((a, b) => {
-          const ts = (a.timestampMs ?? 0) - (b.timestampMs ?? 0)
-          if (ts !== 0) return ts
-          return a.sequenceKey - b.sequenceKey
-        })
-      }
-
-      const linkage: DelegationLinkage = {
-        delegationId,
+      recordLinkage({
+        delegationId: `${sourceEntry.entryId}:${delegateBlock.blockStart}`,
         sourceEntryId: sourceEntry.entryId,
         sourceAgentId,
         blockStart: delegateBlock.blockStart,
@@ -214,20 +414,121 @@ export function buildDelegationLinkages(
         targetSessionKey,
         linkedEntries,
         isPending: linkedEntries.length === 0,
-      }
+        source: 'delegate-tag',
+      })
+    }
 
-      linkagesByDelegationId.set(delegationId, linkage)
-      const bySource = linkagesBySourceEntry.get(sourceEntry.entryId)
-      if (bySource) {
-        bySource.push(linkage)
-      } else {
-        linkagesBySourceEntry.set(sourceEntry.entryId, [linkage])
-      }
+    // ─── Path 2: Round 6 — OpenClaw `sessions_send` tool calls ──────────────
+    // The LLM often skips structured `<delegate>` tags and uses OpenClaw's
+    // built-in `sessions_send` Gateway tool instead. That tool call IS
+    // visible in the source's tool entries (`block.tools[]`), so we can
+    // render the actual routing as a DelegationCard with the EXACT task
+    // body from the JSON params — no prose heuristics, no time-window
+    // guessing. Each tool entry whose name starts with `sessions_send`
+    // becomes a structured linkage; the raw `[[tool]]` markdown stops
+    // rendering (claimed) and the DelegationCard takes its place.
+    //
+    // Schema (verified against the installed `openclaw` package's
+    // `SessionsSendToolSchema` at line 88732 of its bundle):
+    //   { sessionKey?, label?, agentId?, message }
+    // The caller supplies at least one routing identifier. We try each in
+    // priority order via `resolveSessionsSendTarget`.
+    for (const toolEntry of block.tools) {
+      const parsed = parseToolEntry(toolEntry.text)
+      if (!parsed || parsed.kind !== 'call') continue
+      // Tool name is "<name>" or "<name> (<call_id>)" — match prefix.
+      const namePrefix = parsed.name.split(/[\s(]/)[0]?.trim() ?? ''
+      if (namePrefix !== 'sessions_send') continue
 
-      // First pending delegation per target sessionKey owns the streaming
-      // card — later pending delegations to the same target wait their turn.
-      if (linkage.isPending && !streamingOwnerByTargetSessionKey.has(targetSessionKey)) {
-        streamingOwnerByTargetSessionKey.set(targetSessionKey, delegationId)
+      const params = extractSessionsSendParams(parsed.body)
+      if (!params) continue
+
+      const target = resolveSessionsSendTarget(params, participants)
+      if (!target) continue
+      if (target.id === sourceAgentId) continue
+
+      const targetSessionKey = buildTeamSessionKey(target.id, teamId)
+      const targetBucket = entriesByAgent.get(target.id) ?? []
+      const linkedEntries = findTargetResponse({
+        bucket: targetBucket,
+        // Anchor on the tool entry's timestamp — the tool call happens
+        // mid-stream, so the target's response should follow it in
+        // wall-clock time (sequenceKey alone fails after page reload —
+        // see `findTargetResponse` docs).
+        sourceTimestampMs: toolEntry.timestampMs ?? sourceEntry.timestampMs ?? 0,
+        sourceSequenceKey: toolEntry.sequenceKey,
+        claimedEntries,
+      })
+
+      // Claim the tool entry itself so `AssistantTurnCard` doesn't ALSO
+      // render the raw `[[tool]] sessions_send …` line — the DelegationCard
+      // is its visual replacement.
+      claimedEntries.add(toolEntry.entryId)
+
+      recordLinkage({
+        delegationId: `${sourceEntry.entryId}:sessions-send:${toolEntry.entryId}`,
+        sourceEntryId: sourceEntry.entryId,
+        sourceAgentId,
+        blockStart: toolEntry.sequenceKey,
+        targetAgentId: target.id,
+        targetAgentName: target.name,
+        targetRawName: target.name,
+        task: params.message,
+        targetSessionKey,
+        linkedEntries,
+        isPending: linkedEntries.length === 0,
+        source: 'sessions-send',
+      })
+    }
+
+    // ─── Path 3: Round 7 — Clawboo's own routing events ────────────────────
+    // When the LLM doesn't emit `<delegate>` tags OR `sessions_send` calls
+    // BUT Clawboo's orchestration STILL routed work to specialists (via the
+    // fallback regex in `detectDelegations` or via `flushRelayBatch`),
+    // those events live in `clawbooDispatches`. Render them as
+    // DelegationCards so the user sees actual Clawboo routing, not whatever
+    // the LLM happened to emit in prose.
+    //
+    // Dedup: skip when Path 1 or Path 2 already linked the same target for
+    // this source entry. The LLM's explicit signal (or its tool call) wins
+    // over our recorded routing event. Same-source same-target → keep the
+    // earlier linkage.
+    if (clawbooDispatches) {
+      const dispatchKey = `${teamId}:${sourceEntry.entryId}`
+      const dispatches = clawbooDispatches.get(dispatchKey) ?? []
+      for (const dispatch of dispatches) {
+        const existingForTarget = (linkagesBySourceEntry.get(sourceEntry.entryId) ?? []).find(
+          (l) => l.targetAgentId === dispatch.targetAgentId,
+        )
+        if (existingForTarget) continue
+
+        const target = participants.find((p) => p.id === dispatch.targetAgentId)
+        if (!target) continue
+        if (target.id === sourceAgentId) continue
+
+        const targetSessionKey = buildTeamSessionKey(dispatch.targetAgentId, teamId)
+        const targetBucket = entriesByAgent.get(target.id) ?? []
+        const linkedEntries = findTargetResponse({
+          bucket: targetBucket,
+          sourceTimestampMs: dispatch.timestampMs,
+          sourceSequenceKey: dispatch.sequenceKey,
+          claimedEntries,
+        })
+
+        recordLinkage({
+          delegationId: dispatch.dispatchId,
+          sourceEntryId: sourceEntry.entryId,
+          sourceAgentId: dispatch.sourceAgentId,
+          blockStart: dispatch.sequenceKey,
+          targetAgentId: dispatch.targetAgentId,
+          targetAgentName: dispatch.targetAgentName,
+          targetRawName: dispatch.targetAgentName,
+          task: dispatch.taskBody,
+          targetSessionKey,
+          linkedEntries,
+          isPending: linkedEntries.length === 0,
+          source: dispatch.origin === 'dispatch-delegation' ? 'clawboo-dispatch' : 'clawboo-relay',
+        })
       }
     }
   }

--- a/apps/web/src/features/group-chat/buildDelegationLinkages.ts
+++ b/apps/web/src/features/group-chat/buildDelegationLinkages.ts
@@ -136,6 +136,9 @@ export function buildDelegationLinkages(
     // Relays carry condensed summaries that may incidentally contain
     // delegate-looking strings — guard against false positives.
     if (isRelayMessage(text)) continue
+    // Resume-ack token is a protocol artifact (Phase 3) — never a source
+    // of delegations.
+    if (text.trim() === '__resumed__') continue
 
     const sourceAgentId = agentIdFromSessionKey(sourceEntry.sessionKey)
     if (!sourceAgentId) continue

--- a/apps/web/src/features/group-chat/fanOutDetector.ts
+++ b/apps/web/src/features/group-chat/fanOutDetector.ts
@@ -1,0 +1,71 @@
+// fanOutDetector — pure helper used by `useTeamOrchestration` to detect
+// when the leader's response prose claims "I'll ask all teammates" /
+// "Got responses from all three" / "Let me route to each" WITHOUT
+// emitting any structured routing primitive (`<delegate>`, `<plan>`,
+// `sessions_send`). When matched, Clawboo synthesizes a workstreams
+// batch with all team members as targets so the existing WorkstreamCard
+// pipeline renders the same DONE pills + preview lines + 2-col grid as
+// an explicit delegation.
+//
+// All patterns are anchored to a ROUTING VERB (ask / route / delegate /
+// hand off / got responses from / fan out) within ~10 words of a plural
+// marker (all / each / every / both / everyone / teammates / agents /
+// three / four / etc.). Bare plural mentions like "all teammates are
+// great" do NOT match — only plural ROUTING intent does.
+//
+// Round 13. Used by `useTeamOrchestration.processNewEntries` after
+// Round 8B / Round 10B detection passes have ruled out an explicit
+// structured trigger.
+
+const FAN_OUT_PATTERNS: ReadonlyArray<RegExp> = [
+  // 1. "ask all/each/every teammates" / "asking each of you"
+  /\bask(?:ing)?\s+(?:all|each|every|both)\s+(?:the\s+)?(?:teammates?|agents?|of\s+(?:you|them|us|the\s+team))/i,
+
+  // 2. "I'll ask all teammates" / "let me route this to everyone" /
+  //    "going to delegate to each" / "gonna fan out to the whole team"
+  /\b(?:I'?ll|let\s+me|going\s+to|gonna)\s+(?:ask|route|delegate|hand\s+off|fan\s+(?:this\s+)?out)\s+(?:this\s+)?(?:to\s+)?(?:all|each|every|both|everyone|the\s+(?:whole\s+)?team)/i,
+
+  // 3. "all teammates will weigh in" / "each agent should chime in".
+  //    Action verb is constrained to ROUTING-flavored verbs (no bare
+  //    "are" — that would match "all teammates are great").
+  /\b(?:all|each|every|both)\s+(?:teammates?|agents?|of\s+(?:them|the\s+team(?:mates?)?))\s+(?:will\s+(?:reply|respond|chime|weigh|answer|share|give)|should\s+(?:reply|respond|chime|weigh|answer|share|give)|chime\s+in|weigh\s+in|to\s+(?:reply|respond|chime|weigh|answer|share))/i,
+
+  // 4. "got responses from all three" / "got fresh takes from each" /
+  //    "got their answers from everyone" — allows ONE optional
+  //    adjective ("fresh", "their", "the", "some") between the verb
+  //    and the response noun.
+  /\bgot\s+(?:\w+\s+)?(?:responses?|answers?|takes?|input|thoughts?|opinions?|feedback)\s+from\s+(?:all|each|every|both|every\s*(?:one|body)|everyone|the\s+team)\b/i,
+
+  // 5. "route this to all teammates" / "delegate to each" / "hand off
+  //    to everyone" / "fan out to the team"
+  /\b(?:route|delegate|hand\s+off|hand\s+over|fan(?:\s+|-)?out)\s+(?:this\s+)?(?:to\s+)?(?:all|each|every|both|everyone|the\s+(?:whole\s+)?team)/i,
+
+  // 6a. "all three teammates weighed in" / "every four agents already".
+  //     Numbered plural BEFORE the noun; the routing verb confirms it.
+  /\b(?:all|every|each)\s+(?:three|four|five|six|seven|eight|nine|ten)(?:\s+(?:teammates?|agents?))?\s+(?:weighed|gave|chimed|wrote|said|replied|already)/i,
+
+  // 6b. "all teammates already weighed" / "every agent already chimed".
+  //     Same pattern but with bare plural noun (no number).
+  /\b(?:all|every|each)\s+(?:teammates?|agents?)\s+(?:already\s+)?(?:weighed|gave|chimed|wrote|said|replied)/i,
+
+  // 7. "all three teammates are aligned" / "all three agree" / "all
+  //     teammates aligned on this". Synthesis prose after fan-out —
+  //     implies fan-out happened. Anchored to agreement verbs to avoid
+  //     bare plural mentions like "all teammates are great".
+  /\b(?:all|every|each)\s+(?:three|four|five|six|seven|eight|nine|ten)?(?:\s+(?:teammates?|agents?))?\s+(?:are\s+aligned|are\s+in\s+agreement|agree(?:\s+on)?|aligned\s+on)/i,
+
+  // 8. "Here's the roundup/recap/summary" — LLM's go-to phrase when
+  //     synthesizing across multiple teammate responses. Strong signal
+  //     of post-fan-out aggregation.
+  /\bhere'?s\s+(?:the\s+)?(?:roundup|recap|summary|aggregate|takeaway|takeaways|consensus|aggregated\s+takes?)\b/i,
+]
+
+/**
+ * Returns `true` when the leader's response text contains plural-routing
+ * prose suggesting fan-out to multiple teammates. Always false for empty
+ * strings.
+ */
+export function detectFanOutIntent(text: string | null | undefined): boolean {
+  if (!text) return false
+  return FAN_OUT_PATTERNS.some((rx) => rx.test(text))
+}

--- a/apps/web/src/features/group-chat/groupChatSendOperation.ts
+++ b/apps/web/src/features/group-chat/groupChatSendOperation.ts
@@ -11,7 +11,13 @@ import { useChatStore } from '@/stores/chat'
 import { sendChatMessage } from '@/features/chat/chatSendOperation'
 import { buildTeamSessionKey, setTeamChatOverride } from '@/lib/sessionUtils'
 import { findSleepingAgents, markAgentAwake, clearAllWakeRecords } from '@/lib/wakeTracker'
-import { buildTeamContextPreamble, type TeamContextEntry } from '@/lib/teamProtocol'
+import {
+  buildSilentResumeWakeMessage,
+  buildTeamContextPreamble,
+  type TeamContextEntry,
+} from '@/lib/teamProtocol'
+import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
+import { buildTeamRulesBlock, fetchTeamRules } from '@/lib/teamRules'
 import { nextSeq } from '@/lib/sequenceKey'
 import { parseMention } from './parseMention'
 
@@ -116,6 +122,16 @@ async function wakeTeamAgents(
   teamId: string,
   teamName: string,
   targetTeamSessionKey: string,
+  /**
+   * Boo Zero agent reference — when one of the agents being woken IS Boo
+   * Zero, we MUST prefix its wake message with `buildBooZeroRulesBlock` so
+   * the LLM has its identity + behavioral rules in context. The 7-hour
+   * cascade in production happened because Boo Zero's wake messages had
+   * neither identity nor rules — the LLM defaulted to "Mythos" and
+   * produced unsolicited greetings. Team-member wakes don't need this
+   * (their AGENTS.md carries the rules).
+   */
+  booZeroAgent: AgentState | null,
 ): Promise<void> {
   // Append a meta notification to the target's team transcript so it appears
   // in the group chat merge just before the user's actual message.
@@ -145,12 +161,28 @@ async function wakeTeamAgents(
     // Set override so Gateway events (which use main sessionKey) get redirected
     setTeamChatOverride(agent.id, agentTeamSk)
 
-    // Silent re-initialization message — does NOT ask for introductions or list
-    // teammates as @mentions. The full team protocol (roster + anti-sub-agent
-    // instructions) lives in AGENTS.md, which is loaded on every interaction.
-    // Asking for introductions here would trigger the message-flooding cascade
-    // (intros contain @mentions → false delegations → relay → more intros).
-    const wakeMessage = `You are resuming a team collaboration session as ${agent.name} on team "${teamName}". Acknowledge silently — no introduction needed.`
+    // Structural resume wake — asks the agent to reply with EXACTLY
+    // `__resumed__` and nothing else. The literal-token contract is more
+    // reliable than prose "stay quiet" instructions. Pairs with the
+    // AGENTS.md "Resuming sessions" rule for team members and the Boo
+    // Zero rules block injected below for the leader. The UI filters
+    // `__resumed__` entries out of the merged transcript so they never
+    // pollute the visible chat.
+    const baseWake = buildSilentResumeWakeMessage({
+      agentName: agent.name,
+      teamName,
+    })
+
+    // When the agent being woken IS Boo Zero, prefix with the rules block so
+    // the LLM has its identity + behavioral rules in context. Without this
+    // the 08:18 AM production cascade fires: Boo Zero's wake produces
+    // unsolicited intros + name drift ("Mythos"). Team-member wakes already
+    // carry the rules via their team AGENTS.md so they don't need this
+    // injection.
+    const isBooZeroWake = booZeroAgent !== null && agent.id === booZeroAgent.id
+    const wakeMessage = isBooZeroWake
+      ? `${buildBooZeroRulesBlock({ displayName: agent.name, teamName })}\n\n${baseWake}`
+      : baseWake
 
     return client
       .call('chat.send', {
@@ -220,20 +252,14 @@ export function getMergedTeamEntries(
   return entries
 }
 
-// ─── Identity anchor ─────────────────────────────────────────────────────────
-// Boo Zero's actual `agent.name` may be anything — the user's OpenClaw setup
-// might leave it as the literal slug "main", or it might be a custom name
-// like "Mythos" the user picked during OpenClaw onboarding, or "Boo Zero"
-// (the Clawboo default after Phase E lands). Production showed the LLM drifting
-// between these (calling itself "Boo Zero" in one breath and "Mythos" in
-// another), so we anchor the name explicitly in the preamble. This is the
-// load-bearing anti-name-drift fix.
-
-function buildIdentityBlock(booZeroDisplayName: string): string {
-  return `[Your Identity]
-You are ${booZeroDisplayName}. This is your name — the only name you should use to refer to yourself. Do NOT use alternative names ("Mythos", "Boo", "main", "Boo Zero" if that's not your name, etc.) — those would confuse the user about who they're talking to. Even if you suspect the system invented a different name elsewhere, the name in this block is authoritative.
-[End Your Identity]`
-}
+// ─── Identity anchor + rules block ────────────────────────────────────────────
+// Boo Zero's identity AND its load-bearing behavioral rules ("delegate first,
+// don't do work yourself, never use the Task tool, don't claim teammate
+// timeouts, don't greet on resume") are baked into `buildBooZeroRulesBlock`.
+// We inject it as the FIRST section of every Boo Zero turn — every code path
+// that sends a message to Boo Zero MUST include this block. Production saw
+// the LLM drift in all these dimensions when the rules weren't in context,
+// so the per-turn injection is load-bearing for both the name and behavior.
 
 // ─── Team brief fetch ────────────────────────────────────────────────────────
 // Boo Zero reads the team brief on every message so it understands team
@@ -323,7 +349,15 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
         const needsWake = sleeping.filter((id) => !confirmed.has(id))
 
         if (needsWake.length > 0) {
-          await wakeTeamAgents(client, wakeCandidates, needsWake, teamId, teamName, targetTeamSk)
+          await wakeTeamAgents(
+            client,
+            wakeCandidates,
+            needsWake,
+            teamId,
+            teamName,
+            targetTeamSk,
+            booZeroAgent ?? null,
+          )
           // Settle delay — let agents initialize before actual message
           await new Promise((r) => setTimeout(r, WAKEUP_SETTLE_MS))
         }
@@ -350,24 +384,37 @@ export async function sendGroupChatMessage(params: GroupChatSendParams): Promise
   // ship it when targeting Boo Zero because team members already have their
   // own per-agent identity files. Best-effort — missing brief is silently OK.
   let briefBlock: string | null = null
-  let identityBlock: string | null = null
+  let rulesBlock: string | null = null
   if (booZeroAgent && target.id === booZeroAgent.id) {
     const brief = await fetchTeamBrief(teamId)
     if (brief) briefBlock = buildTeamBriefBlock(teamName, brief)
 
-    // Identity anchor — load-bearing fix for the "Mythos / main / Boo Zero"
-    // name-drift seen in production. The agent's actual display name (which
-    // may be the user-customized name from OpenClaw or Clawboo onboarding,
-    // OR the literal slug "main") is asserted up front so the LLM doesn't
-    // invent alternative names mid-response.
-    identityBlock = buildIdentityBlock(booZeroAgent.name)
+    // Boo Zero rules — load-bearing fix for identity drift + "doing work
+    // yourself" + Task-tool reach + "claimed teammate timed out" + resume
+    // greetings. The rules block fires on EVERY Boo Zero turn so the LLM
+    // can never lose the constraint even after long pauses or many
+    // turns. Lives in `lib/booZeroRules.ts`; user-uneditable by design.
+    rulesBlock = buildBooZeroRulesBlock({
+      displayName: booZeroAgent.name,
+      teamName,
+    })
   }
 
+  // Team Rules — user-captured durable rules. Loaded for EVERY message in
+  // the team chat (target may be a team member OR Boo Zero). This is what
+  // makes user corrections survive across sessions: when the user types
+  // `/rule don't do work yourself` it persists here and is injected on
+  // every future turn even after a 7-hour gap.
+  const teamRulesContent = await fetchTeamRules(teamId)
+  const teamRulesBlock = buildTeamRulesBlock(teamRulesContent)
+
   const messageToSend = mentionedId ? cleanedMessage : message
-  // Order matters: identity first (anchors who you are), then team brief
-  // (anchors WHERE you are), then conversation preamble, then the message.
-  const sections = [identityBlock, briefBlock, preamble, messageToSend].filter((s): s is string =>
-    Boolean(s),
+  // Order matters: rules first (anchors who you are + how you must behave),
+  // then team brief (anchors WHERE you are this turn), then team rules
+  // (user-set authoritative constraints), then conversation preamble, then
+  // the actual message.
+  const sections = [rulesBlock, briefBlock, teamRulesBlock, preamble, messageToSend].filter(
+    (s): s is string => Boolean(s),
   )
   const messageWithContext = sections.join('\n\n')
 

--- a/apps/web/src/features/group-chat/planDetector.ts
+++ b/apps/web/src/features/group-chat/planDetector.ts
@@ -1,0 +1,92 @@
+// Plan parser — Round 8B explicit multi-step orchestration.
+//
+// A `<plan>` block contains one or more `<step to="@Name">task</step>`
+// children. Clawboo parses these out of the leader's response, persists the
+// plan to the chat store, fires step 1, and on each subsequent specialist
+// relay auto-fires the next step. When all steps complete, the leader
+// receives a `[Plan Complete]` envelope cueing final synthesis.
+//
+// Syntax (verbatim from the rules block — kept in sync intentionally):
+//
+//   <plan>
+//     <step to="@Marketing Content Creator Boo">Write the copy first.</step>
+//     <step to="@Design Ui Designer Boo">Create the visual design from the copy.</step>
+//     <step to="@Engineering Frontend Developer Boo">Build the page from the design.</step>
+//   </plan>
+//
+// Why a separate parser instead of extending `findDelegationBlocks`:
+//   • `<plan>` is a CONTAINER of steps — its semantics are stateful (auto-
+//     progression across turns) while `<delegate>` is one-shot.
+//   • Mixing them risks double-routing: step 1 would fire from BOTH the plan
+//     scanner AND the `<delegate>` scanner if `<step>` looked like a
+//     delegate.
+//   • Keeping them in distinct modules lets `useTeamOrchestration` decide
+//     which path to take (plan state-machine vs. one-shot dispatch) based on
+//     what the leader actually emitted.
+
+export interface PlanStep {
+  /** The name as written inside `to="…"` (optional leading `@`). */
+  targetName: string
+  /** Body text between the open and close tags, trimmed. */
+  task: string
+  /** Character offset of the `<step` opener, relative to the source text. */
+  stepStart: number
+  /** Index immediately AFTER the closing `>` of `</step>`. */
+  stepEnd: number
+}
+
+export interface PlanBlock {
+  /** Character offset of the `<plan>` opener in the source text. */
+  blockStart: number
+  /** Index immediately AFTER the closing `>` of `</plan>`. */
+  blockEnd: number
+  /** Steps in source order. May be empty when the LLM emitted an empty plan. */
+  steps: PlanStep[]
+}
+
+// Match `<plan>…</plan>`, case-insensitive, multi-line body.
+const PLAN_TAG_RE = /<plan(?:\s[^>]*)?>([\s\S]*?)<\/plan>/gi
+
+// Match `<step to="…">…</step>` inside a plan body.
+const STEP_TAG_RE = /<step\s+to="([^"]+)">([\s\S]*?)<\/step>/gi
+
+/**
+ * Find every `<plan>` block in the text and parse its `<step>` children.
+ * Returns blocks in source order. Empty plans (`<plan></plan>`) come back
+ * with `steps: []` so the caller can decide whether to ignore them.
+ */
+export function findPlanBlocks(text: string): PlanBlock[] {
+  const blocks: PlanBlock[] = []
+  for (const planMatch of text.matchAll(PLAN_TAG_RE)) {
+    const matchIndex = planMatch.index ?? 0
+    const matchText = planMatch[0]
+    const blockStart = matchIndex
+    const blockEnd = matchIndex + matchText.length
+    const planInnerStart = matchIndex + matchText.indexOf('>') + 1
+    const planBody = planMatch[1] ?? ''
+
+    const steps: PlanStep[] = []
+    for (const stepMatch of planBody.matchAll(STEP_TAG_RE)) {
+      const targetName = (stepMatch[1] ?? '').trim()
+      const task = (stepMatch[2] ?? '').trim()
+      if (!targetName || !task) continue
+      // Translate the step's offset within `planBody` back to an absolute
+      // offset in the original text so downstream consumers can splice.
+      const stepStart = planInnerStart + (stepMatch.index ?? 0)
+      const stepEnd = stepStart + stepMatch[0].length
+      steps.push({ targetName, task, stepStart, stepEnd })
+    }
+
+    blocks.push({ blockStart, blockEnd, steps })
+  }
+  return blocks
+}
+
+/**
+ * Strip every `<plan>…</plan>` block from the text. Used by the renderer
+ * when producing the plain-text segment between plan-step cards (mirror of
+ * `stripDelegationBlocks` in `delegationDetector.ts`).
+ */
+export function stripPlanBlocks(text: string): string {
+  return text.replace(PLAN_TAG_RE, '').trim()
+}

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -8,6 +8,8 @@ import type { AgentState } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
 import { buildTeamSessionKey, setTeamChatOverride, hasTeamChatOverride } from '@/lib/sessionUtils'
 import { buildTeamContextPreamble, buildSilentResumeWakeMessage } from '@/lib/teamProtocol'
+import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
+import { buildTeamRulesBlock, fetchTeamRules } from '@/lib/teamRules'
 import { isAgentAwake } from '@/lib/wakeTracker'
 import { detectDelegations, isRelayMessage } from './delegationDetector'
 import {
@@ -306,9 +308,33 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                   userIntroText: userIntroTextRef.current,
                 })
 
-                const messageBody = preamble
-                  ? `${preamble}\n\n${delegation.taskDescription}`
-                  : delegation.taskDescription
+                // Agent → Boo Zero delegations need the rules block too —
+                // Boo Zero stays identity-anchored and rule-bound across
+                // every code path that delivers a message to it (user
+                // turns, wake-ups, AND agent-to-Boo-Zero delegations).
+                const isDelegationToBooZero =
+                  freshBooZero !== null && delegation.targetAgentId === freshBooZero.id
+                const rulesBlock = isDelegationToBooZero
+                  ? buildBooZeroRulesBlock({
+                      displayName: freshBooZero!.name,
+                      teamName: teamNameRef.current,
+                    })
+                  : null
+
+                // Team Rules — same source of truth as user-message-time
+                // injection. Loaded for every agent-to-agent delegation so
+                // the user's persisted corrections never get lost as work
+                // hops between teammates.
+                const teamRulesContent = await fetchTeamRules(currentTeamId)
+                const teamRulesBlock = buildTeamRulesBlock(teamRulesContent)
+
+                const sections = [
+                  rulesBlock,
+                  teamRulesBlock,
+                  preamble,
+                  delegation.taskDescription,
+                ].filter((s): s is string => Boolean(s))
+                const messageBody = sections.join('\n\n')
 
                 // Final checkpoint before the network call. Without this,
                 // a Stop that fired during the synchronous preamble build
@@ -407,10 +433,19 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                     !wokenThisBatchRef.current.has(targetId)
                   ) {
                     wokenThisBatchRef.current.add(targetId)
-                    const wakeMsg = buildSilentResumeWakeMessage({
+                    const baseWake = buildSilentResumeWakeMessage({
                       agentName: targetAgent.name,
                       teamName: teamNameRef.current,
                     })
+                    // When the wake target is Boo Zero, prefix with the
+                    // rules block — same rationale as `wakeTeamAgents` in
+                    // `groupChatSendOperation.ts`. Boo Zero's wake-on-relay
+                    // path was a documented cascade trigger; the rules
+                    // block keeps the identity + behavior anchored.
+                    const isBooZeroWake = freshBooZero !== null && targetId === freshBooZero.id
+                    const wakeMsg = isBooZeroWake
+                      ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${baseWake}`
+                      : baseWake
                     setTeamChatOverride(targetId, targetTeamSk)
                     // Bail-2: Stop fired between IIFE start and wake send.
                     // If we proceed, the wake message gets delivered but
@@ -439,9 +474,20 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
                   // later, restarting the cascade past the freeze window.
                   if (getStopGeneration(currentTeamId) !== startGen) return
 
+                  // Relays targeting Boo Zero get the rules block prefix
+                  // for consistency with every other Boo-Zero delivery
+                  // path. Without this, a relay from a teammate that
+                  // wakes Boo Zero's session would land WITHOUT the
+                  // identity + behavioral anchor and could prompt the
+                  // exact drift production saw at 08:18 AM.
+                  const isRelayToBooZero = freshBooZero !== null && targetId === freshBooZero.id
+                  const finalRelayMsg = isRelayToBooZero
+                    ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${relayMsg}`
+                    : relayMsg
+
                   await currentClient.call('chat.send', {
                     sessionKey: targetTeamSk,
-                    message: relayMsg,
+                    message: finalRelayMsg,
                     deliver: false,
                     idempotencyKey: crypto.randomUUID(),
                   })

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -5,12 +5,13 @@
 import { useEffect, useRef } from 'react'
 import type { GatewayClientLike } from '@clawboo/gateway-client'
 import type { AgentState } from '@/stores/fleet'
-import { useChatStore } from '@/stores/chat'
+import { useChatStore, type PendingPlan } from '@/stores/chat'
 import { buildTeamSessionKey, setTeamChatOverride, hasTeamChatOverride } from '@/lib/sessionUtils'
 import {
   buildBatchedRelayMessage,
   buildTeamContextPreamble,
   buildSilentResumeWakeMessage,
+  shouldDropAssistantTurn,
 } from '@/lib/teamProtocol'
 import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
 import { buildTeamRulesBlock, fetchTeamRules } from '@/lib/teamRules'
@@ -22,6 +23,7 @@ import {
   parseStructuredDelegations,
   type DelegationIntent,
 } from './delegationDetector'
+import { findPlanBlocks, type PlanStep } from './planDetector'
 import {
   condenseSummary,
   determineRelayTargets,
@@ -173,7 +175,25 @@ interface PendingRelayBatch {
   /** Stop-generation captured when this batch was opened. */
   startGen: number
   timerId: ReturnType<typeof setTimeout>
+  /**
+   * Round 8 override-fix: number of times this batch has been deferred
+   * because the target had an active chat override (i.e., was processing
+   * another message). Each deferral reschedules the flush 2 s later, so
+   * the relay doesn't clobber the target's in-flight run with
+   * `setTeamChatOverride`. Capped at `RELAY_RETRY_LIMIT` — beyond that,
+   * we proceed with the override-overwrite to avoid pathological delay.
+   */
+  busyRetryCount: number
 }
+
+/**
+ * Round 8: max retries before we give up waiting for a busy target and
+ * dispatch anyway. With `RELAY_RETRY_DELAY_MS = 2000` this yields ~6 s of
+ * patience before forcing through — enough for a typical leader turn to
+ * finish, not so long that the chat feels stalled.
+ */
+const RELAY_RETRY_LIMIT = 3
+const RELAY_RETRY_DELAY_MS = 2000
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
 
@@ -227,6 +247,26 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
    *     commitChat time).
    */
   const dispatchedStreamingOffsetsRef = useRef<Map<string, Set<number>>>(new Map())
+  /**
+   * Round 8B: per-plan-step "already fired" guard. Keyed by
+   * `${planId}:${stepIndex}` so the same step never fires twice if
+   * `processNewEntries` runs again before the specialist replies. Cleared
+   * on Stop / team-switch alongside the other refs.
+   */
+  const firedPlanStepsRef = useRef<Set<string>>(new Set())
+  /**
+   * Round 8B: timestamp anchor for the in-flight step of each plan.
+   * `findTargetResponse` uses this to claim only specialist replies that
+   * arrived AFTER the step was fired (filters out stale entries hydrated
+   * from prior sessions). Keyed by `planId`.
+   */
+  const planStepFiredAtRef = useRef<Map<string, number>>(new Map())
+  /**
+   * Round 8B: dedup guard for the `[Plan Complete]` envelope. Once we've
+   * fired the final synthesis cue for a plan, don't fire it again on every
+   * subsequent subscription tick.
+   */
+  const planCompletedSetRef = useRef<Set<string>>(new Set())
   /**
    * Pending relay batches keyed by `${teamId}:${targetId}`. Each batch
    * accumulates items over `RELAY_BATCH_WINDOW_MS` and is then flushed as a
@@ -424,6 +464,117 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       })()
     }
 
+    // ── Round 8B: plan-step dispatcher ─────────────────────────────────────
+    // Fires one step of a `<plan>` block as a delegation. Builds a task body
+    // that includes the prior steps' outputs as context (so step N+1 sees
+    // what step N produced). Guarded by `firedPlanStepsRef` so the same
+    // step never dispatches twice. Reuses `dispatchDelegation` for the
+    // actual `chat.send` + recording machinery — this is just the message-
+    // composition layer.
+    const dispatchPlanStep = (plan: PendingPlan, stepIndex: number): void => {
+      const step = plan.steps[stepIndex]
+      if (!step || !step.targetAgentId) return
+      const guardKey = `${plan.planId}:${stepIndex}`
+      if (firedPlanStepsRef.current.has(guardKey)) return
+      firedPlanStepsRef.current.add(guardKey)
+      planStepFiredAtRef.current.set(plan.planId, Date.now())
+
+      // Compose the task body: prior outputs (when any) prepended as
+      // context blocks, then the current step's task at the bottom.
+      const priorOutputs = plan.steps
+        .slice(0, stepIndex)
+        .map((s, i) => ({ idx: i, name: s.targetName, output: s.output }))
+        .filter((s): s is { idx: number; name: string; output: string } => Boolean(s.output))
+      const contextBlocks = priorOutputs
+        .map(
+          (s) =>
+            `[Plan step ${s.idx + 1} — @${s.name}'s output]\n${s.output}\n[End step ${s.idx + 1}]`,
+        )
+        .join('\n\n')
+      const taskBody = contextBlocks
+        ? `${contextBlocks}\n\n---\n\nYour step (#${stepIndex + 1} of ${plan.steps.length}) in this plan:\n${step.task}`
+        : step.task
+
+      const intent: DelegationIntent = {
+        targetAgentId: step.targetAgentId,
+        targetAgentName: step.targetName,
+        taskDescription: taskBody,
+        sourceAgentId: plan.sourceAgentId,
+        // Use the step index as the mentionOffset so each step has a stable
+        // positional key in case future linkage logic dedups by it.
+        mentionOffset: stepIndex,
+      }
+      dispatchDelegation(intent, plan.sourceAgentId, plan.sourceEntryId)
+    }
+
+    // ── Round 8B: send `[Plan Complete]` envelope to the leader ────────────
+    // Fired once when the plan's final step resolves. The leader's rules
+    // block (Round 8D) tells it to treat `[Plan Complete]` as the cue for
+    // final synthesis — bypasses the silence-on-relay rule.
+    const sendPlanCompleteEnvelope = (plan: PendingPlan): void => {
+      if (planCompletedSetRef.current.has(plan.planId)) return
+      planCompletedSetRef.current.add(plan.planId)
+
+      const currentTeamId = teamIdRef.current
+      const currentClient = clientRef.current
+      if (!currentTeamId || !currentClient) return
+
+      const leaderAgent =
+        teamAgentsRef.current.find((a) => a.id === plan.sourceAgentId) ??
+        (booZeroAgentRef.current && booZeroAgentRef.current.id === plan.sourceAgentId
+          ? booZeroAgentRef.current
+          : null)
+      if (!leaderAgent) return
+
+      const leaderSk = buildTeamSessionKey(plan.sourceAgentId, currentTeamId)
+      const summary = plan.steps
+        .map((s, i) => `[Step ${i + 1} — @${s.targetName}]\n${s.output ?? '(no output)'}`)
+        .join('\n\n---\n\n')
+      const body = `[Plan Complete] — all ${plan.steps.length} step(s) of your plan have finished.\nThe outputs are below. Synthesize a final answer for the user.\n---\n${summary}\n---`
+
+      // Identity rules + team rules (same machinery used by dispatchDelegation
+      // for Boo Zero deliveries). The whole point of the envelope is to
+      // re-enter the leader on a fresh turn with full context.
+      const isBooZero =
+        booZeroAgentRef.current !== null && plan.sourceAgentId === booZeroAgentRef.current.id
+      const sections: string[] = []
+      if (isBooZero) {
+        sections.push(
+          buildBooZeroRulesBlock({
+            displayName: leaderAgent.name,
+            teamName: teamNameRef.current,
+          }),
+        )
+      }
+      sections.push(body)
+      const messageBody = sections.join('\n\n')
+
+      const startGen = getStopGeneration(currentTeamId)
+      void (async () => {
+        try {
+          if (getStopGeneration(currentTeamId) !== startGen) return
+          if (
+            hasTeamChatOverride(plan.sourceAgentId) &&
+            !planCompletedSetRef.current.has(`${plan.planId}:retry`)
+          ) {
+            // Defer once if leader is busy — Round 8 override-fix
+            // philosophy. Re-fire on next subscription tick.
+            planCompletedSetRef.current.delete(plan.planId)
+            return
+          }
+          setTeamChatOverride(plan.sourceAgentId, leaderSk)
+          await currentClient.call('chat.send', {
+            sessionKey: leaderSk,
+            message: messageBody,
+            deliver: false,
+            idempotencyKey: crypto.randomUUID(),
+          })
+        } catch {
+          // Non-fatal.
+        }
+      })()
+    }
+
     // ── Mid-stream `<delegate>` scanner ────────────────────────────────────
     // Fires on every chat-store change with NO debounce so DelegationCards
     // appear inline as soon as the LLM closes a `</delegate>` tag — instead
@@ -502,21 +653,47 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
     const flushRelayBatch = (key: string): void => {
       const batch = pendingRelaysRef.current.get(key)
       if (!batch) return
-      // Always drop the batch on flush even when we bail below — leaving the
-      // entry would block future items at the same key.
-      pendingRelaysRef.current.delete(key)
 
       const currentTeamId = teamIdRef.current
       const currentClient = clientRef.current
-      if (!currentTeamId || !currentClient) return
-      if (getStopGeneration(currentTeamId) !== batch.startGen) return
+      if (!currentTeamId || !currentClient) {
+        pendingRelaysRef.current.delete(key)
+        return
+      }
+      if (getStopGeneration(currentTeamId) !== batch.startGen) {
+        pendingRelaysRef.current.delete(key)
+        return
+      }
 
       const freshBooZero = booZeroAgentRef.current
       const freshTeamMembers = teamAgentsRef.current
       const targetAgent =
         freshTeamMembers.find((a) => a.id === batch.targetId) ??
         (freshBooZero && freshBooZero.id === batch.targetId ? freshBooZero : null)
-      if (!targetAgent) return
+      if (!targetAgent) {
+        pendingRelaysRef.current.delete(key)
+        return
+      }
+
+      // Round 8 override-fix: if the target is currently processing another
+      // message (`hasTeamChatOverride` returns truthy), our `chat.send` here
+      // would overwrite the active override slot via `setTeamChatOverride`
+      // below — corrupting routing for the target's in-flight turn and
+      // adding 30-60 s of latency before our relay can be processed. Defer
+      // the flush by `RELAY_RETRY_DELAY_MS` so the target's current run has
+      // a chance to finish. We keep the batch in the pending map and bump
+      // `busyRetryCount`. After `RELAY_RETRY_LIMIT` retries we fall through
+      // and dispatch anyway — better to ship a possibly-conflicted relay
+      // than to silently drop the routing event.
+      if (hasTeamChatOverride(batch.targetId) && batch.busyRetryCount < RELAY_RETRY_LIMIT) {
+        batch.busyRetryCount += 1
+        batch.timerId = setTimeout(() => flushRelayBatch(key), RELAY_RETRY_DELAY_MS)
+        return
+      }
+
+      // From here on the batch is going out — remove it from the pending
+      // map so subsequent `enqueueRelayItem` calls open a fresh batch.
+      pendingRelaysRef.current.delete(key)
 
       const targetTeamSk = buildTeamSessionKey(batch.targetId, currentTeamId)
       setTeamChatOverride(batch.targetId, targetTeamSk)
@@ -619,6 +796,7 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
           items: [],
           startGen,
           timerId: setTimeout(() => flushRelayBatch(key), RELAY_BATCH_WINDOW_MS),
+          busyRetryCount: 0,
         }
         pendingRelaysRef.current.set(key, batch)
       }
@@ -770,6 +948,119 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             // Clean up delegation source after relay is queued.
             delegationSourceRef.current.delete(sourceAgentId)
           }
+
+          // ── Round 8B: plan capture ─────────────────────────────────────
+          // Parse `<plan>` blocks in the committed leader entry. For each
+          // plan, register it in the chat store and fire step 1. Steps 2+
+          // are fired automatically as each prior step's specialist responds
+          // (see the plan-progression pass at the bottom of this function).
+          // Inline target-name resolver (case-insensitive longest-prefix
+          // match against the dedup'd participant list — same heuristic as
+          // `delegationDetector.resolveTargetName`).
+          const resolveStepTarget = (raw: string): { id: string; name: string } | null => {
+            const stripped = raw.replace(/^@/, '').trim().toLowerCase()
+            if (!stripped) return null
+            const sorted = [...currentAgents].sort((a, b) => b.name.length - a.name.length)
+            for (const a of sorted) {
+              if (stripped === a.name.toLowerCase()) return { id: a.id, name: a.name }
+            }
+            for (const a of sorted) {
+              const lower = a.name.toLowerCase()
+              if (stripped.startsWith(lower) || lower.startsWith(stripped))
+                return { id: a.id, name: a.name }
+            }
+            return null
+          }
+          const planBlocks = findPlanBlocks(text)
+          for (const planBlock of planBlocks) {
+            if (planBlock.steps.length === 0) continue
+            const planId = `${currentTeamId}:${entry.entryId}:plan:${planBlock.blockStart}`
+            // Resolve each step's target name → agent id once at capture
+            // time so progression doesn't have to re-resolve on every tick.
+            const resolvedSteps = planBlock.steps.map((step: PlanStep) => {
+              const target = resolveStepTarget(step.targetName)
+              return {
+                targetName: target?.name ?? step.targetName.replace(/^@/, '').trim(),
+                targetAgentId: target?.id ?? null,
+                task: step.task,
+                output: null as string | null,
+                resolvedEntryId: null as string | null,
+              }
+            })
+            const plan: PendingPlan = {
+              planId,
+              sourceEntryId: entry.entryId,
+              sourceAgentId,
+              teamId: currentTeamId,
+              steps: resolvedSteps,
+              currentStepIndex: 0,
+              timestampMs: entry.timestampMs ?? Date.now(),
+            }
+            useChatStore.getState().setPendingPlan(plan)
+            // Fire step 1 immediately. Subsequent steps fire from the
+            // progression pass below as each prior step resolves.
+            dispatchPlanStep(plan, 0)
+          }
+        }
+      }
+
+      // ── Round 8B: plan progression pass ──────────────────────────────
+      // Iterate all pending plans for this team. For each plan whose
+      // active step's target has a fresh substantive response, resolve
+      // the step and fire the next step (or send `[Plan Complete]`).
+      const allPlans = useChatStore.getState().pendingPlans
+      for (const plan of allPlans.values()) {
+        if (plan.teamId !== currentTeamId) continue
+        // Re-read because resolvePlanStep mutates currentStepIndex.
+        const livePlan = useChatStore.getState().pendingPlans.get(plan.planId)
+        if (!livePlan) continue
+        // Plan complete? Send the synthesis envelope (once).
+        if (livePlan.currentStepIndex >= livePlan.steps.length) {
+          sendPlanCompleteEnvelope(livePlan)
+          continue
+        }
+        const stepIndex = livePlan.currentStepIndex
+        const step = livePlan.steps[stepIndex]
+        if (!step || !step.targetAgentId) continue
+        // Active step already resolved → advance via store action (no
+        // network call needed — we already pushed the resolution).
+        if (step.output !== null) {
+          // dispatchPlanStep is idempotent via firedPlanStepsRef so we can
+          // call it freely after the store advances.
+          if (livePlan.currentStepIndex < livePlan.steps.length) {
+            dispatchPlanStep(livePlan, livePlan.currentStepIndex)
+          }
+          continue
+        }
+        // Look for the specialist's fresh response: any assistant entry
+        // from this step's target with timestamp AFTER the step was fired
+        // (or after the plan was captured if `stepFiredAt` isn't set).
+        const stepFiredAt = planStepFiredAtRef.current.get(livePlan.planId) ?? livePlan.timestampMs
+        const targetSk = buildTeamSessionKey(step.targetAgentId, currentTeamId)
+        const targetEntries = transcripts.get(targetSk)
+        if (!targetEntries) continue
+        const reply = targetEntries.find(
+          (e) =>
+            e.role === 'assistant' &&
+            e.kind === 'assistant' &&
+            (e.timestampMs ?? 0) > stepFiredAt &&
+            e.text.length > 0 &&
+            !shouldDropAssistantTurn(e.text),
+        )
+        if (!reply) continue
+        // Resolve the step → advances currentStepIndex by 1 in the store.
+        useChatStore
+          .getState()
+          .resolvePlanStep(livePlan.planId, stepIndex, reply.text, reply.entryId)
+        // Fire the next step (if any). The progression pass loops over all
+        // plans on every tick, so we don't strictly need to fire here —
+        // the next tick would catch it. But firing immediately avoids one
+        // tick of latency.
+        const nextIndex = stepIndex + 1
+        if (nextIndex < livePlan.steps.length) {
+          dispatchPlanStep(livePlan, nextIndex)
+        } else {
+          sendPlanCompleteEnvelope(livePlan)
         }
       }
     }
@@ -906,7 +1197,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
     // the renderer's Path 3 cards from cancelled work don't linger.
     if (currentTeamId) {
       useChatStore.getState().clearClawbooDispatches(currentTeamId)
+      // Round 8B: also wipe any in-progress `<plan>` state machines so the
+      // next step doesn't fire after Stop.
+      useChatStore.getState().clearPendingPlans(currentTeamId)
     }
+    // Reset Round 8B refs so a new plan after Stop starts fresh.
+    firedPlanStepsRef.current = new Set()
+    planStepFiredAtRef.current = new Map()
+    planCompletedSetRef.current = new Set()
     frozenUntilRef.current = Date.now() + STOP_FREEZE_MS
   }, [stopSignal])
 }

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -7,13 +7,23 @@ import type { GatewayClientLike } from '@clawboo/gateway-client'
 import type { AgentState } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
 import { buildTeamSessionKey, setTeamChatOverride, hasTeamChatOverride } from '@/lib/sessionUtils'
-import { buildTeamContextPreamble, buildSilentResumeWakeMessage } from '@/lib/teamProtocol'
+import {
+  buildBatchedRelayMessage,
+  buildTeamContextPreamble,
+  buildSilentResumeWakeMessage,
+} from '@/lib/teamProtocol'
 import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
 import { buildTeamRulesBlock, fetchTeamRules } from '@/lib/teamRules'
+import { nextSeq } from '@/lib/sequenceKey'
 import { isAgentAwake } from '@/lib/wakeTracker'
-import { detectDelegations, isRelayMessage } from './delegationDetector'
 import {
-  buildRelayMessage,
+  detectDelegations,
+  isRelayMessage,
+  parseStructuredDelegations,
+  type DelegationIntent,
+} from './delegationDetector'
+import {
+  condenseSummary,
   determineRelayTargets,
   shouldRelay,
   recordRelay,
@@ -74,6 +84,28 @@ export function bumpStopGeneration(teamId: string): void {
  */
 const STOP_FREEZE_MS = 3000
 
+/**
+ * Batching window for context relays destined for the same hub. Production
+ * observed Boo Zero acknowledging every parallel `[Team Update]` as a fresh
+ * user message — 5 specialists finishing in parallel produced 5 separate
+ * "Got it — that's the X layer" acknowledgments from Boo Zero (~576 redundant
+ * tokens in one cascade).
+ *
+ * With batching, items destined for `(teamId, targetId)` accumulate over a
+ * 3 s window. When the timer fires, ONE combined `[Team Update]` envelope is
+ * delivered containing all teammate progress reports — and the Boo Zero rules
+ * block now explicitly forbids acknowledgment-only responses, so the hub
+ * produces ONE synthesis (or zero if not warranted).
+ *
+ * 3 s chosen because: (a) parallel completions from delegations issued in
+ * the same Boo Zero response typically land within 500-1500 ms of each
+ * other; (b) tighter windows would split natural batches; (c) wider would
+ * make a single-item batch feel laggy. Pair with `POST_BATCH_COOLDOWN_MS`
+ * below — incoming items during the cooldown extend the NEXT batch instead
+ * of triggering an immediate second dispatch.
+ */
+const RELAY_BATCH_WINDOW_MS = 3000
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface UseTeamOrchestrationParams {
@@ -118,6 +150,31 @@ export interface UseTeamOrchestrationParams {
   stopSignal?: number
 }
 
+/**
+ * One accumulating batch of relay items destined for a single hub. Lives
+ * in `pendingRelaysRef` keyed by `${teamId}:${targetId}` until either
+ * `RELAY_BATCH_WINDOW_MS` expires (timer fires, batch is flushed as a
+ * single `chat.send`) OR the user presses Stop (timer cancelled, batch
+ * discarded).
+ */
+interface PendingRelayBatch {
+  targetId: string
+  /** Cached target name so `flushRelayBatch` can record dispatches without re-resolving. */
+  targetAgentName: string
+  items: Array<{
+    /** Agent id of the source agent whose commit triggered this relay item. */
+    sourceAgentId: string
+    /** entryId of the source's committed entry — anchors Round 7 Path 3 cards. */
+    sourceEntryId: string
+    fromAgentName: string
+    body: string
+    taskContext?: string
+  }>
+  /** Stop-generation captured when this batch was opened. */
+  startGen: number
+  timerId: ReturnType<typeof setTimeout>
+}
+
 // ─── Hook ────────────────────────────────────────────────────────────────────
 
 export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
@@ -152,6 +209,31 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
    * the end of each batch.
    */
   const wokenThisBatchRef = useRef<Set<string>>(new Set())
+  /**
+   * Mid-stream delegation dedup. Maps sessionKey → Set of `mentionOffset`
+   * values for `<delegate>` blocks we've already dispatched (either from
+   * the streaming-text path OR from the commit-time path, whichever fired
+   * first). Prevents double-routing when a `<delegate>` block closes
+   * mid-stream and the same block then appears in the committed entry.
+   *
+   * Lifecycle:
+   *   • Mid-stream scan adds (sessionKey, offset) when it dispatches.
+   *   • Commit-time scan also adds (and skips if already present).
+   *   • After commit-time processing finishes for a session, the entry
+   *     for that sessionKey is cleared — the next streaming burst starts
+   *     from offset 0 anyway, so the set would otherwise grow unbounded.
+   *   • Mid-stream scan also clears when it observes streamingText
+   *     transitioning to null/empty (e.g., setStreamingText(sk, null) at
+   *     commitChat time).
+   */
+  const dispatchedStreamingOffsetsRef = useRef<Map<string, Set<number>>>(new Map())
+  /**
+   * Pending relay batches keyed by `${teamId}:${targetId}`. Each batch
+   * accumulates items over `RELAY_BATCH_WINDOW_MS` and is then flushed as a
+   * single combined `[Team Update]` envelope to the target. See the constant's
+   * doc comment and Layer 2 in the plan for full rationale.
+   */
+  const pendingRelaysRef = useRef<Map<string, PendingRelayBatch>>(new Map())
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // ── Post-stop freeze window ──────────────────────────────────────────────
@@ -175,6 +257,379 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
 
   useEffect(() => {
     if (!enabled || !teamId) return
+
+    // ── Round 7: Clawboo-dispatch recorder ─────────────────────────────────
+    // Every `chat.send` Clawboo fires to a team specialist passes through
+    // one of two chokepoints (`dispatchDelegation` for delegations,
+    // `flushRelayBatch` for relays). Each one calls this helper AFTER the
+    // network round-trip succeeds so the renderer can surface the routing
+    // event as a DelegationCard — see `buildDelegationLinkages` Path 3.
+    //
+    // `sourceEntryId` is undefined for mid-stream dispatches (the source
+    // entry hasn't committed yet) — we skip recording in that case because
+    // Path 1 (`<delegate>` scan in `findDelegationBlocks`) will render the
+    // card via the leader's committed text. Recording only happens when a
+    // committed entryId is available, which is exactly when Path 1 / Path 2
+    // can't claim the routing (fallback regex from `detectDelegations` and
+    // relay-batch).
+    const recordClawbooDispatch = (params: {
+      sourceEntryId: string | undefined
+      sourceAgentId: string
+      targetAgentId: string
+      targetAgentName: string
+      taskBody: string
+      origin: 'dispatch-delegation' | 'relay-batch'
+    }): void => {
+      if (!params.sourceEntryId) return
+      const currentTeamId = teamIdRef.current
+      if (!currentTeamId) return
+      useChatStore.getState().setClawbooDispatch({
+        dispatchId: crypto.randomUUID(),
+        sourceEntryId: params.sourceEntryId,
+        sourceAgentId: params.sourceAgentId,
+        targetAgentId: params.targetAgentId,
+        targetAgentName: params.targetAgentName,
+        taskBody: params.taskBody,
+        origin: params.origin,
+        sequenceKey: nextSeq(),
+        timestampMs: Date.now(),
+        teamId: currentTeamId,
+      })
+    }
+
+    // ── Shared delegation dispatcher ───────────────────────────────────────
+    // Used by both the mid-stream `<delegate>` scanner (which fires as soon
+    // as a `</delegate>` closing tag appears in the streaming text) AND the
+    // commit-time scanner inside `processNewEntries`. The dispatch path is
+    // identical: identity rules + team rules + team context preamble + task
+    // body → `chat.send` to the target's team-scoped session. Extracting
+    // this once keeps the two scan paths in lock-step.
+    //
+    // `sourceEntryId` is passed only from the commit-time path (mid-stream
+    // hasn't committed yet); see `recordClawbooDispatch` above for the
+    // skip-when-undefined logic.
+    const dispatchDelegation = (
+      delegation: DelegationIntent,
+      sourceAgentId: string,
+      sourceEntryId: string | undefined,
+      retryCount = 0,
+    ): void => {
+      const currentTeamId = teamIdRef.current
+      const currentClient = clientRef.current
+      if (!currentTeamId || !currentClient) return
+
+      // Capture the stop-generation at IIFE creation. If the user presses
+      // Stop before this IIFE finishes, the generation bumps; we bail at
+      // each checkpoint below instead of issuing a stale `chat.send` that
+      // would restart the cascade.
+      const startGen = getStopGeneration(currentTeamId)
+      void (async () => {
+        try {
+          if (getStopGeneration(currentTeamId) !== startGen) return
+
+          // Guard: target agent may have been deleted during processing.
+          // Boo Zero may be the target — check both team members AND Boo
+          // Zero (Boo Zero is teamless so not in `teamAgentsRef`).
+          const freshTeamMembers = teamAgentsRef.current
+          const freshBooZero = booZeroAgentRef.current
+          const freshParticipants = freshBooZero
+            ? [...freshTeamMembers, freshBooZero]
+            : freshTeamMembers
+          if (!freshParticipants.some((a) => a.id === delegation.targetAgentId)) return
+
+          // Guard: target is already processing a team message — retry once after 2s
+          if (hasTeamChatOverride(delegation.targetAgentId)) {
+            if (retryCount < 1) {
+              // The retry inherits the same startGen via closure on the next
+              // call — when it fires it re-checks against the live generation.
+              setTimeout(
+                () => dispatchDelegation(delegation, sourceAgentId, sourceEntryId, retryCount + 1),
+                2000,
+              )
+            }
+            return
+          }
+
+          const targetTeamSk = buildTeamSessionKey(delegation.targetAgentId, currentTeamId)
+
+          // Set override BEFORE sending so Gateway events get redirected.
+          setTeamChatOverride(delegation.targetAgentId, targetTeamSk)
+
+          // Build context preamble from merged transcript — also injects the
+          // user intro so the target agent knows who the user is (delegations
+          // are agent-to-agent, no fresh user message).
+          const contextEntries = getMergedTeamEntries(currentTeamId, freshTeamMembers, freshBooZero)
+          const targetAgent = freshParticipants.find((a) => a.id === delegation.targetAgentId)
+          const preamble = buildTeamContextPreamble({
+            entries: contextEntries,
+            targetAgentName: targetAgent?.name ?? '',
+            userIntroText: userIntroTextRef.current,
+          })
+
+          // Agent → Boo Zero delegations need the rules block — Boo Zero
+          // stays identity-anchored and rule-bound across every delivery
+          // path (user turns, wake-ups, AND agent-to-Boo-Zero delegations).
+          const isDelegationToBooZero =
+            freshBooZero !== null && delegation.targetAgentId === freshBooZero.id
+          const rulesBlock = isDelegationToBooZero
+            ? buildBooZeroRulesBlock({
+                displayName: freshBooZero!.name,
+                teamName: teamNameRef.current,
+              })
+            : null
+
+          // Team Rules — same source of truth as user-message-time injection.
+          // Loaded for every agent-to-agent delegation so the user's
+          // persisted corrections never get lost as work hops between
+          // teammates.
+          const teamRulesContent = await fetchTeamRules(currentTeamId)
+          const teamRulesBlock = buildTeamRulesBlock(teamRulesContent)
+
+          const sections = [
+            rulesBlock,
+            teamRulesBlock,
+            preamble,
+            delegation.taskDescription,
+          ].filter((s): s is string => Boolean(s))
+          const messageBody = sections.join('\n\n')
+
+          // Final checkpoint before the network call.
+          if (getStopGeneration(currentTeamId) !== startGen) return
+
+          await currentClient.call('chat.send', {
+            sessionKey: targetTeamSk,
+            message: messageBody,
+            deliver: false,
+            idempotencyKey: crypto.randomUUID(),
+          })
+
+          // Track delegation source for relay routing.
+          delegationSourceRef.current.set(delegation.targetAgentId, sourceAgentId)
+
+          // Round 7: record this dispatch so the renderer can surface it
+          // as a DelegationCard. Skipped when `sourceEntryId` is undefined
+          // (mid-stream path — Path 1 handles `<delegate>` rendering via
+          // `findDelegationBlocks` on the committed text).
+          recordClawbooDispatch({
+            sourceEntryId,
+            sourceAgentId,
+            targetAgentId: delegation.targetAgentId,
+            targetAgentName: targetAgent?.name ?? delegation.targetAgentId,
+            taskBody: delegation.taskDescription,
+            origin: 'dispatch-delegation',
+          })
+        } catch {
+          // Non-fatal — delegation failure doesn't block other processing.
+        }
+      })()
+    }
+
+    // ── Mid-stream `<delegate>` scanner ────────────────────────────────────
+    // Fires on every chat-store change with NO debounce so DelegationCards
+    // appear inline as soon as the LLM closes a `</delegate>` tag — instead
+    // of after the leader's full response commits (often 20-30 s later).
+    // This is the topology fix: by routing targets mid-stream, specialists
+    // start working WHILE the leader is still streaming, so the user sees
+    // them respond in the natural flow rather than after a long silence.
+    //
+    // Dedup: every block dispatched here is recorded in
+    // `dispatchedStreamingOffsetsRef` so the commit-time scanner doesn't
+    // re-dispatch the same block when the entry lands. The set is keyed by
+    // `sessionKey + mentionOffset` (the byte offset of the `<delegate>`
+    // opener in the source text — stable across the streaming-to-commit
+    // transition because we only dispatch CLOSED blocks).
+    const processStreamingDelegations = (): void => {
+      const currentTeamId = teamIdRef.current
+      if (!currentTeamId) return
+      if (Date.now() < frozenUntilRef.current) return
+
+      const currentTeamMembers = teamAgentsRef.current
+      const currentBooZero = booZeroAgentRef.current
+      const combined = currentBooZero ? [...currentTeamMembers, currentBooZero] : currentTeamMembers
+      if (combined.length === 0) return
+
+      const seen = new Set<string>()
+      const participants: AgentState[] = []
+      for (const a of combined) {
+        if (seen.has(a.id)) continue
+        seen.add(a.id)
+        participants.push(a)
+      }
+
+      const streamingText = useChatStore.getState().streamingText
+      for (const agent of participants) {
+        const teamSk = buildTeamSessionKey(agent.id, currentTeamId)
+        const streaming = streamingText.get(teamSk)
+        if (!streaming || streaming.length === 0) {
+          // End-of-stream signal — clear so the next streaming burst starts
+          // from offset 0 without false dedup hits.
+          dispatchedStreamingOffsetsRef.current.delete(teamSk)
+          continue
+        }
+        if (isRelayMessage(streaming)) continue
+
+        const intents = parseStructuredDelegations(
+          streaming,
+          agent.id,
+          participants.map((p) => ({ id: p.id, name: p.name })),
+        )
+        if (intents.length === 0) continue
+
+        let dispatched = dispatchedStreamingOffsetsRef.current.get(teamSk)
+        if (!dispatched) {
+          dispatched = new Set<number>()
+          dispatchedStreamingOffsetsRef.current.set(teamSk, dispatched)
+        }
+        for (const intent of intents) {
+          if (dispatched.has(intent.mentionOffset)) continue
+          dispatched.add(intent.mentionOffset)
+          // Mid-stream: source entry hasn't committed yet — pass undefined
+          // so the recorder skips. Path 1 (`<delegate>` scan on committed
+          // text) will render the card when the entry lands.
+          dispatchDelegation(intent, agent.id, undefined)
+        }
+      }
+    }
+
+    // ── Relay batching ─────────────────────────────────────────────────────
+    //
+    // Replaces the previous per-target IIFE relay loop. Each item destined
+    // for `(teamId, targetId)` is accumulated; the first item starts a 3-s
+    // batch window; the timer flushes the combined batch as ONE `chat.send`.
+    // Same hub never receives N parallel relays. See `buildBatchedRelayMessage`
+    // in `lib/teamProtocol.ts` for the envelope shape.
+
+    const flushRelayBatch = (key: string): void => {
+      const batch = pendingRelaysRef.current.get(key)
+      if (!batch) return
+      // Always drop the batch on flush even when we bail below — leaving the
+      // entry would block future items at the same key.
+      pendingRelaysRef.current.delete(key)
+
+      const currentTeamId = teamIdRef.current
+      const currentClient = clientRef.current
+      if (!currentTeamId || !currentClient) return
+      if (getStopGeneration(currentTeamId) !== batch.startGen) return
+
+      const freshBooZero = booZeroAgentRef.current
+      const freshTeamMembers = teamAgentsRef.current
+      const targetAgent =
+        freshTeamMembers.find((a) => a.id === batch.targetId) ??
+        (freshBooZero && freshBooZero.id === batch.targetId ? freshBooZero : null)
+      if (!targetAgent) return
+
+      const targetTeamSk = buildTeamSessionKey(batch.targetId, currentTeamId)
+      setTeamChatOverride(batch.targetId, targetTeamSk)
+
+      const baseRelay = buildBatchedRelayMessage(batch.items)
+      const isRelayToBooZero = freshBooZero !== null && batch.targetId === freshBooZero.id
+      const finalRelayMsg = isRelayToBooZero
+        ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${baseRelay}`
+        : baseRelay
+
+      void (async () => {
+        try {
+          if (getStopGeneration(currentTeamId) !== batch.startGen) return
+          await currentClient.call('chat.send', {
+            sessionKey: targetTeamSk,
+            message: finalRelayMsg,
+            deliver: false,
+            idempotencyKey: crypto.randomUUID(),
+          })
+
+          // Round 7: emit one dispatch record per accumulated item so each
+          // source-entry → target-agent routing surfaces as a DelegationCard.
+          // The batched envelope contains all items, but visually each source
+          // turn should be linked to its own card on the target.
+          for (const item of batch.items) {
+            recordClawbooDispatch({
+              sourceEntryId: item.sourceEntryId,
+              sourceAgentId: item.sourceAgentId,
+              targetAgentId: batch.targetId,
+              targetAgentName: batch.targetAgentName,
+              taskBody: item.body,
+              origin: 'relay-batch',
+            })
+          }
+        } catch {
+          // Non-fatal.
+        }
+      })()
+    }
+
+    const enqueueRelayItem = (params: {
+      teamId: string
+      targetId: string
+      /** Source agent id whose committed entry triggered this relay item. */
+      sourceAgentId: string
+      /** entryId of the source's committed entry — anchors Round 7 Path 3 cards. */
+      sourceEntryId: string
+      fromAgentName: string
+      condensedBody: string
+    }): void => {
+      const key = `${params.teamId}:${params.targetId}`
+      let batch = pendingRelaysRef.current.get(key)
+
+      if (!batch) {
+        const startGen = getStopGeneration(params.teamId)
+        const freshBooZero = booZeroAgentRef.current
+        const freshTeamMembers = teamAgentsRef.current
+        const currentClient = clientRef.current
+        const targetAgent =
+          freshTeamMembers.find((a) => a.id === params.targetId) ??
+          (freshBooZero && freshBooZero.id === params.targetId ? freshBooZero : null)
+        if (!targetAgent || !currentClient) return
+
+        // Wake the target on FIRST item if sleeping. The wake send + 3-s
+        // batch window doubles as the settle delay (Gateway registers the
+        // session before the flushed relay lands).
+        if (
+          !isAgentAwake(params.targetId, params.teamId) &&
+          !wokenThisBatchRef.current.has(params.targetId)
+        ) {
+          wokenThisBatchRef.current.add(params.targetId)
+          const targetTeamSk = buildTeamSessionKey(params.targetId, params.teamId)
+          const baseWake = buildSilentResumeWakeMessage({
+            agentName: targetAgent.name,
+            teamName: teamNameRef.current,
+          })
+          const isBooZeroWake = freshBooZero !== null && params.targetId === freshBooZero.id
+          const wakeMsg = isBooZeroWake
+            ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${baseWake}`
+            : baseWake
+          setTeamChatOverride(params.targetId, targetTeamSk)
+          void (async () => {
+            try {
+              if (getStopGeneration(params.teamId) !== startGen) return
+              await currentClient.call('chat.send', {
+                sessionKey: targetTeamSk,
+                message: wakeMsg,
+                deliver: false,
+                idempotencyKey: crypto.randomUUID(),
+              })
+            } catch {
+              // Non-fatal.
+            }
+          })()
+        }
+
+        batch = {
+          targetId: params.targetId,
+          targetAgentName: targetAgent.name,
+          items: [],
+          startGen,
+          timerId: setTimeout(() => flushRelayBatch(key), RELAY_BATCH_WINDOW_MS),
+        }
+        pendingRelaysRef.current.set(key, batch)
+      }
+
+      batch.items.push({
+        sourceAgentId: params.sourceAgentId,
+        sourceEntryId: params.sourceEntryId,
+        fromAgentName: params.fromAgentName,
+        body: params.condensedBody,
+      })
+    }
 
     const processNewEntries = () => {
       // Reset per-batch dedup set at the start of every batch so we never
@@ -255,106 +710,20 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             currentAgents.map((a) => ({ id: a.id, name: a.name })),
           )
 
+          // Dedup against mid-stream dispatches: any `<delegate>` block at
+          // the same byte offset already routed by `processStreamingDelegations`
+          // is skipped here so the same block doesn't double-fire.
+          let dispatched = dispatchedStreamingOffsetsRef.current.get(teamSk)
+          if (!dispatched) {
+            dispatched = new Set<number>()
+            dispatchedStreamingOffsetsRef.current.set(teamSk, dispatched)
+          }
           for (const delegation of delegations) {
-            // Capture the stop-generation at IIFE creation. If the user
-            // presses Stop before this IIFE finishes, the generation
-            // bumps; we bail at each checkpoint below instead of issuing
-            // a stale `chat.send` that would restart the cascade.
-            const startGen = getStopGeneration(currentTeamId)
-            const sendDelegation = async (retryCount = 0) => {
-              try {
-                // Bail if Stop has fired since this IIFE was scheduled.
-                if (getStopGeneration(currentTeamId) !== startGen) return
-
-                // Guard: target agent may have been deleted during processing.
-                // The target may be Boo Zero — check both team members AND
-                // Boo Zero (Boo Zero is teamless so not in `teamAgentsRef`).
-                const freshTeamMembers = teamAgentsRef.current
-                const freshBooZero = booZeroAgentRef.current
-                const freshParticipants = freshBooZero
-                  ? [...freshTeamMembers, freshBooZero]
-                  : freshTeamMembers
-                if (!freshParticipants.some((a) => a.id === delegation.targetAgentId)) return
-
-                // Guard: target is already processing a team message — retry once after 2s
-                if (hasTeamChatOverride(delegation.targetAgentId)) {
-                  if (retryCount < 1) {
-                    // The retry inherits the same startGen via closure, so
-                    // when it fires it re-checks against the live generation.
-                    setTimeout(() => void sendDelegation(retryCount + 1), 2000)
-                  }
-                  return
-                }
-
-                const targetTeamSk = buildTeamSessionKey(delegation.targetAgentId, currentTeamId)
-
-                // Set override BEFORE sending so Gateway events get redirected
-                setTeamChatOverride(delegation.targetAgentId, targetTeamSk)
-
-                // Build context preamble from merged transcript — also injects
-                // the user intro so the target agent knows who the user is
-                // (delegations are agent-to-agent, no fresh user message).
-                // Pass team members + Boo Zero as separate args so the merge
-                // includes Boo Zero's transcript without double-counting.
-                const contextEntries = getMergedTeamEntries(
-                  currentTeamId,
-                  freshTeamMembers,
-                  freshBooZero,
-                )
-                const targetAgent = freshParticipants.find((a) => a.id === delegation.targetAgentId)
-                const preamble = buildTeamContextPreamble({
-                  entries: contextEntries,
-                  targetAgentName: targetAgent?.name ?? '',
-                  userIntroText: userIntroTextRef.current,
-                })
-
-                // Agent → Boo Zero delegations need the rules block too —
-                // Boo Zero stays identity-anchored and rule-bound across
-                // every code path that delivers a message to it (user
-                // turns, wake-ups, AND agent-to-Boo-Zero delegations).
-                const isDelegationToBooZero =
-                  freshBooZero !== null && delegation.targetAgentId === freshBooZero.id
-                const rulesBlock = isDelegationToBooZero
-                  ? buildBooZeroRulesBlock({
-                      displayName: freshBooZero!.name,
-                      teamName: teamNameRef.current,
-                    })
-                  : null
-
-                // Team Rules — same source of truth as user-message-time
-                // injection. Loaded for every agent-to-agent delegation so
-                // the user's persisted corrections never get lost as work
-                // hops between teammates.
-                const teamRulesContent = await fetchTeamRules(currentTeamId)
-                const teamRulesBlock = buildTeamRulesBlock(teamRulesContent)
-
-                const sections = [
-                  rulesBlock,
-                  teamRulesBlock,
-                  preamble,
-                  delegation.taskDescription,
-                ].filter((s): s is string => Boolean(s))
-                const messageBody = sections.join('\n\n')
-
-                // Final checkpoint before the network call. Without this,
-                // a Stop that fired during the synchronous preamble build
-                // above would still let the delegation send.
-                if (getStopGeneration(currentTeamId) !== startGen) return
-
-                await currentClient.call('chat.send', {
-                  sessionKey: targetTeamSk,
-                  message: messageBody,
-                  deliver: false,
-                  idempotencyKey: crypto.randomUUID(),
-                })
-
-                // Track delegation source for relay routing
-                delegationSourceRef.current.set(delegation.targetAgentId, sourceAgentId)
-              } catch {
-                // Non-fatal — delegation failure doesn't block other processing
-              }
-            }
-            void sendDelegation()
+            if (dispatched.has(delegation.mentionOffset)) continue
+            dispatched.add(delegation.mentionOffset)
+            // Pass the committed source entryId so `recordClawbooDispatch`
+            // (Round 7 Path 3) can attribute the dispatch to this turn.
+            dispatchDelegation(delegation, sourceAgentId, entry.entryId)
           }
 
           // ── Context relay ──────────────────────────────────────
@@ -377,129 +746,28 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
               delegationSourceId: delegationSource,
             })
 
-            const relayMsg = buildRelayMessage({
-              fromAgentName: agent.name,
-              responseText: text,
-              maxChars: DEFAULT_RELAY_CONFIG.maxSummaryChars,
-            })
+            // Condense the source's body once; the batcher accumulates this
+            // per-target, then `buildBatchedRelayMessage` assembles a single
+            // multi-source envelope at flush time.
+            const condensedBody = condenseSummary(text, DEFAULT_RELAY_CONFIG.maxSummaryChars)
 
             for (const targetId of targets) {
-              // Capture the stop-generation at IIFE creation. If the user
-              // presses Stop while this IIFE is in the wake-and-settle
-              // window (the historical cascade source — a 2-second sleep
-              // between the wake send and the relay send), the generation
-              // bumps; we bail at the next checkpoint instead of issuing
-              // the delayed `chat.send` that would re-wake the target and
-              // restart the cascade.
-              const startGen = getStopGeneration(currentTeamId)
-              void (async () => {
-                try {
-                  // Bail-1: Stop fired before this IIFE got to run.
-                  if (getStopGeneration(currentTeamId) !== startGen) return
-
-                  // Guard: target agent may have been deleted during processing.
-                  // Relay targets can include Boo Zero — check both team members
-                  // and (when present) Boo Zero before bailing out.
-                  const freshTeamMembers = teamAgentsRef.current
-                  const freshBooZero = booZeroAgentRef.current
-                  const targetAgent =
-                    freshTeamMembers.find((a) => a.id === targetId) ??
-                    (freshBooZero && freshBooZero.id === targetId ? freshBooZero : null)
-                  if (!targetAgent) return
-
-                  const targetTeamSk = buildTeamSessionKey(targetId, currentTeamId)
-
-                  // Wake sleeping agent before relaying (best-effort).
-                  //
-                  // CRITICAL: this used to call `buildTeamWakeMessage` which
-                  // asked the agent to introduce itself AND listed teammates
-                  // as `@AgentName`. In production that triggered the
-                  // 11-message "Welcome aboard X" cascade (CLAUDE.md §"Group
-                  // Chat Onboarding Gate — Cascade Fix"). The Phase 4
-                  // onboarding-gate fix already replaced the user-message-
-                  // time wake with a silent-resume body — this is the same
-                  // fix for the orchestration wake-on-relay path.
-                  //
-                  // Pair with `### Resuming sessions` in `buildTeamAgentsMd`
-                  // which loads on every turn and tells the agent to stay
-                  // quiet on resume.
-                  //
-                  // Per-batch dedup (`wokenThisBatchRef`) below ensures we
-                  // don't fire multiple wakes for the same agent inside a
-                  // single processing tick — relays often target the same
-                  // hub repeatedly.
-                  if (
-                    !isAgentAwake(targetId, currentTeamId) &&
-                    !wokenThisBatchRef.current.has(targetId)
-                  ) {
-                    wokenThisBatchRef.current.add(targetId)
-                    const baseWake = buildSilentResumeWakeMessage({
-                      agentName: targetAgent.name,
-                      teamName: teamNameRef.current,
-                    })
-                    // When the wake target is Boo Zero, prefix with the
-                    // rules block — same rationale as `wakeTeamAgents` in
-                    // `groupChatSendOperation.ts`. Boo Zero's wake-on-relay
-                    // path was a documented cascade trigger; the rules
-                    // block keeps the identity + behavior anchored.
-                    const isBooZeroWake = freshBooZero !== null && targetId === freshBooZero.id
-                    const wakeMsg = isBooZeroWake
-                      ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${baseWake}`
-                      : baseWake
-                    setTeamChatOverride(targetId, targetTeamSk)
-                    // Bail-2: Stop fired between IIFE start and wake send.
-                    // If we proceed, the wake message gets delivered but
-                    // the target then sits awake-but-idle — acceptable.
-                    if (getStopGeneration(currentTeamId) !== startGen) return
-                    await currentClient.call('chat.send', {
-                      sessionKey: targetTeamSk,
-                      message: wakeMsg,
-                      deliver: false,
-                      idempotencyKey: crypto.randomUUID(),
-                    })
-                    // Settle delay reduced from 5000ms → 2000ms. With N
-                    // sleeping teammates the original delay multiplied to a
-                    // visibly-bunched cascade window; 2s is still enough
-                    // for the Gateway to register the session before the
-                    // relay arrives, while keeping the overall flow tight.
-                    await new Promise((r) => setTimeout(r, 2000))
-                  }
-
-                  setTeamChatOverride(targetId, targetTeamSk)
-
-                  // Bail-3: Stop fired during the settle window OR between
-                  // the awake-check and this point. This is the BIG one —
-                  // without this check, a Stop pressed during the 2s wake-
-                  // settle would still let the relay payload land 2s
-                  // later, restarting the cascade past the freeze window.
-                  if (getStopGeneration(currentTeamId) !== startGen) return
-
-                  // Relays targeting Boo Zero get the rules block prefix
-                  // for consistency with every other Boo-Zero delivery
-                  // path. Without this, a relay from a teammate that
-                  // wakes Boo Zero's session would land WITHOUT the
-                  // identity + behavioral anchor and could prompt the
-                  // exact drift production saw at 08:18 AM.
-                  const isRelayToBooZero = freshBooZero !== null && targetId === freshBooZero.id
-                  const finalRelayMsg = isRelayToBooZero
-                    ? `${buildBooZeroRulesBlock({ displayName: targetAgent.name, teamName: teamNameRef.current })}\n\n${relayMsg}`
-                    : relayMsg
-
-                  await currentClient.call('chat.send', {
-                    sessionKey: targetTeamSk,
-                    message: finalRelayMsg,
-                    deliver: false,
-                    idempotencyKey: crypto.randomUUID(),
-                  })
-                } catch {
-                  // Non-fatal
-                }
-              })()
+              enqueueRelayItem({
+                teamId: currentTeamId,
+                targetId,
+                // Pipe the committed source's identity through to the batch
+                // so `flushRelayBatch` can record a Round 7 dispatch for the
+                // renderer.
+                sourceAgentId,
+                sourceEntryId: entry.entryId,
+                fromAgentName: agent.name,
+                condensedBody,
+              })
             }
 
             recordRelay(currentTeamId, sourceAgentId)
             incrementRelayDepth(currentTeamId, sourceAgentId)
-            // Clean up delegation source after relay is sent
+            // Clean up delegation source after relay is queued.
             delegationSourceRef.current.delete(sourceAgentId)
           }
         }
@@ -519,8 +787,21 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       lastCountsRef.current.set(teamSk, entries?.length ?? 0)
     }
 
-    // Subscribe to chat store changes with debounce
+    // Subscribe to chat store changes.
+    //
+    // Mid-stream delegation detection (`processStreamingDelegations`) fires
+    // IMMEDIATELY on every change so DelegationCards appear inline as soon
+    // as the LLM closes a `</delegate>` tag — instead of after the leader's
+    // full response commits (often 20-30 s later). The scan is cheap (one
+    // regex per active team session).
+    //
+    // Commit-time scanning (`processNewEntries`) stays on a 500 ms debounce
+    // because it does heavier work — context preamble builds, team-rules
+    // fetches, relay routing decisions. Mid-stream dispatches are recorded
+    // in `dispatchedStreamingOffsetsRef` so the committed-entry pass doesn't
+    // re-route what already fired.
     const unsub = useChatStore.subscribe(() => {
+      processStreamingDelegations()
       if (debounceTimerRef.current !== null) {
         clearTimeout(debounceTimerRef.current)
       }
@@ -536,6 +817,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
         clearTimeout(debounceTimerRef.current)
         debounceTimerRef.current = null
       }
+      // Cancel + discard any pending relay batches when the hook unmounts
+      // (team switch, page navigation). Without this, a timer scheduled
+      // before unmount would fire after the team is gone and try to
+      // `chat.send` to a stale team's session.
+      for (const batch of pendingRelaysRef.current.values()) {
+        clearTimeout(batch.timerId)
+      }
+      pendingRelaysRef.current = new Map()
     }
   }, [enabled, teamId]) // Intentionally minimal deps — refs carry current values
 
@@ -596,6 +885,28 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
 
     delegationSourceRef.current = new Map()
     wokenThisBatchRef.current = new Set()
+    // Clear mid-stream dispatch dedup — any in-flight streaming burst that
+    // continues to commit after Stop should be treated as fresh (its
+    // `<delegate>` blocks were already cancelled at the dispatch layer via
+    // the stop-generation bump in `dispatchDelegation`, so no double-send
+    // risk; we just don't want stale offsets to silently mask future blocks
+    // at the same byte position in a different turn).
+    dispatchedStreamingOffsetsRef.current = new Map()
+    // Cancel any pending relay batches AND discard their accumulated items.
+    // Without this, a 3-second timer scheduled before Stop would fire
+    // afterwards and dispatch a relay containing pre-stop teammate updates.
+    // The downstream `chat.send` would be cancelled by the bumped
+    // stop-generation check inside `flushRelayBatch`, but we avoid the
+    // network call and the noisy log by clearing here.
+    for (const batch of pendingRelaysRef.current.values()) {
+      clearTimeout(batch.timerId)
+    }
+    pendingRelaysRef.current = new Map()
+    // Round 7: wipe Clawboo's dispatched-routing records for this team so
+    // the renderer's Path 3 cards from cancelled work don't linger.
+    if (currentTeamId) {
+      useChatStore.getState().clearClawbooDispatches(currentTeamId)
+    }
     frozenUntilRef.current = Date.now() + STOP_FREEZE_MS
   }, [stopSignal])
 }

--- a/apps/web/src/features/group-chat/useTeamOrchestration.ts
+++ b/apps/web/src/features/group-chat/useTeamOrchestration.ts
@@ -5,7 +5,12 @@
 import { useEffect, useRef } from 'react'
 import type { GatewayClientLike } from '@clawboo/gateway-client'
 import type { AgentState } from '@/stores/fleet'
-import { useChatStore, type PendingPlan } from '@/stores/chat'
+import {
+  useChatStore,
+  type PendingPlan,
+  type PendingWorkstreams,
+  type WorkstreamTarget,
+} from '@/stores/chat'
 import { buildTeamSessionKey, setTeamChatOverride, hasTeamChatOverride } from '@/lib/sessionUtils'
 import {
   buildBatchedRelayMessage,
@@ -24,6 +29,7 @@ import {
   type DelegationIntent,
 } from './delegationDetector'
 import { findPlanBlocks, type PlanStep } from './planDetector'
+import { detectFanOutIntent } from './fanOutDetector'
 import {
   condenseSummary,
   determineRelayTargets,
@@ -268,6 +274,18 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
    */
   const planCompletedSetRef = useRef<Set<string>>(new Set())
   /**
+   * Round 10: timestamp anchor for each parallel workstream batch. The
+   * progression pass scans target transcripts for replies with
+   * `timestampMs > workstreamFiredAtRef.get(workstreamId)` — filters out
+   * stale entries (e.g., the target's old onboarding intro).
+   */
+  const workstreamFiredAtRef = useRef<Map<string, number>>(new Map())
+  /**
+   * Round 10: dedup guard for the `[Workstreams Complete]` envelope (mirror
+   * of `planCompletedSetRef`). One-shot per workstreamId.
+   */
+  const workstreamCompletedSetRef = useRef<Set<string>>(new Set())
+  /**
    * Pending relay batches keyed by `${teamId}:${targetId}`. Each batch
    * accumulates items over `RELAY_BATCH_WINDOW_MS` and is then flushed as a
    * single combined `[Team Update]` envelope to the target. See the constant's
@@ -319,6 +337,13 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       targetAgentName: string
       taskBody: string
       origin: 'dispatch-delegation' | 'relay-batch'
+      /**
+       * Round 9: when this dispatch is a step of a `<plan>` block, carry
+       * the parent plan's id + step index so the renderer can group plan
+       * steps under one PlanCard. Pass-through to `setClawbooDispatch`.
+       */
+      planId?: string | null
+      planStepIndex?: number | null
     }): void => {
       if (!params.sourceEntryId) return
       const currentTeamId = teamIdRef.current
@@ -334,6 +359,8 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
         sequenceKey: nextSeq(),
         timestampMs: Date.now(),
         teamId: currentTeamId,
+        planId: params.planId ?? null,
+        planStepIndex: params.planStepIndex ?? null,
       })
     }
 
@@ -353,6 +380,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       sourceAgentId: string,
       sourceEntryId: string | undefined,
       retryCount = 0,
+      /**
+       * Round 9: when this dispatch is a step of a `<plan>` block, the
+       * caller (`dispatchPlanStep`) passes the parent plan's id + step
+       * index. Propagated into the `clawboo-dispatch` record so the
+       * renderer can group plan steps under one PlanCard. `undefined` for
+       * non-plan dispatches (regular `<delegate>` blocks, fallback regex).
+       */
+      planContext?: { planId: string; stepIndex: number },
     ): void => {
       const currentTeamId = teamIdRef.current
       const currentClient = clientRef.current
@@ -383,7 +418,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
               // The retry inherits the same startGen via closure on the next
               // call — when it fires it re-checks against the live generation.
               setTimeout(
-                () => dispatchDelegation(delegation, sourceAgentId, sourceEntryId, retryCount + 1),
+                () =>
+                  dispatchDelegation(
+                    delegation,
+                    sourceAgentId,
+                    sourceEntryId,
+                    retryCount + 1,
+                    planContext, // Round 9: preserve plan context across retries.
+                  ),
                 2000,
               )
             }
@@ -457,6 +499,11 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             targetAgentName: targetAgent?.name ?? delegation.targetAgentId,
             taskBody: delegation.taskDescription,
             origin: 'dispatch-delegation',
+            // Round 9: propagate plan provenance when this dispatch is a
+            // step of a `<plan>` block. The renderer groups plan-step
+            // linkages under a single PlanCard via these fields.
+            planId: planContext?.planId ?? null,
+            planStepIndex: planContext?.stepIndex ?? null,
           })
         } catch {
           // Non-fatal — delegation failure doesn't block other processing.
@@ -504,7 +551,14 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
         // positional key in case future linkage logic dedups by it.
         mentionOffset: stepIndex,
       }
-      dispatchDelegation(intent, plan.sourceAgentId, plan.sourceEntryId)
+      // Round 9: pass plan context so the dispatch record carries
+      // `planId` + `planStepIndex`. The renderer (`AssistantTurnCard`)
+      // groups all linkages with matching `planId` under a single
+      // PlanCard.
+      dispatchDelegation(intent, plan.sourceAgentId, plan.sourceEntryId, 0, {
+        planId: plan.planId,
+        stepIndex,
+      })
     }
 
     // ── Round 8B: send `[Plan Complete]` envelope to the leader ────────────
@@ -563,6 +617,74 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             return
           }
           setTeamChatOverride(plan.sourceAgentId, leaderSk)
+          await currentClient.call('chat.send', {
+            sessionKey: leaderSk,
+            message: messageBody,
+            deliver: false,
+            idempotencyKey: crypto.randomUUID(),
+          })
+        } catch {
+          // Non-fatal.
+        }
+      })()
+    }
+
+    // ── Round 10: send `[Workstreams Complete]` envelope to the leader ─────
+    // Mirror of `sendPlanCompleteEnvelope` but for parallel workstreams
+    // (N≥2 sibling `<delegate>` tags emitted in one leader turn, no
+    // `<plan>` wrapper). Fired once when ALL targets have responded — cues
+    // the leader to synthesize across the parallel outputs. Round 4/5's
+    // silence-on-relay rule would otherwise keep the leader quiet after
+    // parallel work resolves (the "talk is cheap" production failure mode).
+    const sendWorkstreamsCompleteEnvelope = (ws: PendingWorkstreams): void => {
+      if (workstreamCompletedSetRef.current.has(ws.workstreamId)) return
+      workstreamCompletedSetRef.current.add(ws.workstreamId)
+
+      const currentTeamId = teamIdRef.current
+      const currentClient = clientRef.current
+      if (!currentTeamId || !currentClient) return
+
+      const leaderAgent =
+        teamAgentsRef.current.find((a) => a.id === ws.sourceAgentId) ??
+        (booZeroAgentRef.current && booZeroAgentRef.current.id === ws.sourceAgentId
+          ? booZeroAgentRef.current
+          : null)
+      if (!leaderAgent) return
+
+      const leaderSk = buildTeamSessionKey(ws.sourceAgentId, currentTeamId)
+      const summary = ws.targets
+        .map((t, i) => `Workstream ${i + 1} — @${t.targetAgentName}:\n${t.output ?? '(no output)'}`)
+        .join('\n\n---\n\n')
+      const body = `[Workstreams Complete] — all ${ws.targets.length} of your parallel workstreams have responded.\nThe outputs are below. Synthesize across them now. This is your synthesis cue — do not skip it.\n---\n${summary}\n---`
+
+      const isBooZero =
+        booZeroAgentRef.current !== null && ws.sourceAgentId === booZeroAgentRef.current.id
+      const sections: string[] = []
+      if (isBooZero) {
+        sections.push(
+          buildBooZeroRulesBlock({
+            displayName: leaderAgent.name,
+            teamName: teamNameRef.current,
+          }),
+        )
+      }
+      sections.push(body)
+      const messageBody = sections.join('\n\n')
+
+      const startGen = getStopGeneration(currentTeamId)
+      void (async () => {
+        try {
+          if (getStopGeneration(currentTeamId) !== startGen) return
+          if (
+            hasTeamChatOverride(ws.sourceAgentId) &&
+            !workstreamCompletedSetRef.current.has(`${ws.workstreamId}:retry`)
+          ) {
+            // Defer once if leader is busy — Round 8 override-fix.
+            // Re-fire on next subscription tick.
+            workstreamCompletedSetRef.current.delete(ws.workstreamId)
+            return
+          }
+          setTeamChatOverride(ws.sourceAgentId, leaderSk)
           await currentClient.call('chat.send', {
             sessionKey: leaderSk,
             message: messageBody,
@@ -881,6 +1003,13 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
 
           const sourceAgentId = agent.id
 
+          // Round 10: pre-compute plan blocks here (used by the plan-capture
+          // pass below AND by the workstream-detection branch). Knowing
+          // whether a `<plan>` is on this source up-front lets us gate
+          // workstream minting (plans take precedence — they have their own
+          // sequential state machine).
+          const planBlocks = findPlanBlocks(text)
+
           // ── Delegation detection ──────────────────────────────
           const delegations = detectDelegations(
             text,
@@ -902,6 +1031,99 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             // Pass the committed source entryId so `recordClawbooDispatch`
             // (Round 7 Path 3) can attribute the dispatch to this turn.
             dispatchDelegation(delegation, sourceAgentId, entry.entryId)
+          }
+
+          // ── Round 10: parallel workstreams capture ─────────────────────
+          // When the leader fires N≥2 sibling `<delegate>` tags in one turn
+          // WITHOUT a `<plan>` wrapper, register them as a parallel
+          // workstream batch. The progression pass below (after this entry
+          // loop) tracks each target's response; when all targets resolve,
+          // `sendWorkstreamsCompleteEnvelope` cues final synthesis — the
+          // mechanism that Round 4/5's silence-on-relay rule was missing.
+          //
+          // `planBlocks.length === 0` gate: when a `<plan>` is present on
+          // the same source, the plan state machine handles ordering. Loose
+          // `<delegate>` tags on a plan-turn are not part of the workstream
+          // batch (rare edge case — see "Out of scope" in the plan).
+          if (delegations.length >= 2 && planBlocks.length === 0) {
+            const workstreamId = `${currentTeamId}:${entry.entryId}:workstreams`
+            const wsTimestamp = entry.timestampMs ?? Date.now()
+            const targets: WorkstreamTarget[] = delegations.map((d) => ({
+              targetAgentId: d.targetAgentId,
+              targetAgentName: d.targetAgentName,
+              task: d.taskDescription,
+              output: null,
+              resolvedEntryId: null,
+            }))
+            const workstreams: PendingWorkstreams = {
+              workstreamId,
+              sourceEntryId: entry.entryId,
+              sourceAgentId,
+              teamId: currentTeamId,
+              targets,
+              timestampMs: wsTimestamp,
+            }
+            useChatStore.getState().setPendingWorkstreams(workstreams)
+            workstreamFiredAtRef.current.set(workstreamId, wsTimestamp)
+          }
+
+          // ── Round 13: implicit fan-out detection ──────────────────────
+          // When the leader (Boo Zero) emits PURE PROSE claiming "I'll ask
+          // all teammates" / "got responses from all three" / etc. WITHOUT
+          // emitting any structured routing primitive (`<delegate>`,
+          // `<plan>`, `sessions_send`), AND the team has 2+ other
+          // teammates that may have responded via the wake-context fan-out
+          // (Round 4-era behavior), synthesize a workstream batch so the
+          // existing WorkstreamCard / DelegationCard pipeline renders the
+          // same DONE pills, preview lines, and 2-col grid as an explicit
+          // delegation.
+          // `sessions_send` tool calls live in separate `kind: 'tool'`
+          // transcript entries — they're not directly accessible from
+          // this assistant entry here. We rely on Path 4's "skip when
+          // existing linkages found" guard in `buildDelegationLinkages`
+          // to defer to Path 2 (sessions_send) when both exist.
+          const sourceIsLeader = currentBooZero?.id === sourceAgentId
+          const noStructuredRouting = delegations.length === 0 && planBlocks.length === 0
+          if (sourceIsLeader && noStructuredRouting && detectFanOutIntent(text)) {
+            // Targets = every OTHER team member (skip the leader / source).
+            const otherMembers = currentTeamMembers.filter((m) => m.id !== sourceAgentId)
+            if (otherMembers.length >= 2) {
+              const implicitWsId = `${currentTeamId}:${entry.entryId}:implicit-fanout`
+              const wsTimestamp = entry.timestampMs ?? Date.now()
+              // Task body: the user's most recent message (the actual
+              // question the leader fanned out about). Walk the leader's
+              // team session backward to find it. Falls back to a
+              // descriptive placeholder.
+              const leaderSk = buildTeamSessionKey(sourceAgentId, currentTeamId)
+              const leaderBucket = transcripts.get(leaderSk) ?? []
+              let userTask = '(team fan-out — no explicit task body)'
+              for (let i = leaderBucket.length - 1; i >= 0; i--) {
+                const e = leaderBucket[i]
+                if (!e) continue
+                if ((e.timestampMs ?? 0) > wsTimestamp) continue
+                if (e.kind === 'user' && e.text) {
+                  userTask = e.text.slice(0, 400)
+                  break
+                }
+              }
+              const targets: WorkstreamTarget[] = otherMembers.map((m) => ({
+                targetAgentId: m.id,
+                targetAgentName: m.name,
+                task: userTask,
+                output: null,
+                resolvedEntryId: null,
+              }))
+              const implicitWs: PendingWorkstreams = {
+                workstreamId: implicitWsId,
+                sourceEntryId: entry.entryId,
+                sourceAgentId,
+                teamId: currentTeamId,
+                targets,
+                timestampMs: wsTimestamp,
+              }
+              useChatStore.getState().setPendingWorkstreams(implicitWs)
+              workstreamFiredAtRef.current.set(implicitWsId, wsTimestamp)
+            }
           }
 
           // ── Context relay ──────────────────────────────────────
@@ -957,6 +1179,8 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
           // Inline target-name resolver (case-insensitive longest-prefix
           // match against the dedup'd participant list — same heuristic as
           // `delegationDetector.resolveTargetName`).
+          // `planBlocks` was pre-computed at the top of this entry loop
+          // (Round 10) so workstream detection could gate on its emptiness.
           const resolveStepTarget = (raw: string): { id: string; name: string } | null => {
             const stripped = raw.replace(/^@/, '').trim().toLowerCase()
             if (!stripped) return null
@@ -971,7 +1195,6 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
             }
             return null
           }
-          const planBlocks = findPlanBlocks(text)
           for (const planBlock of planBlocks) {
             if (planBlock.steps.length === 0) continue
             const planId = `${currentTeamId}:${entry.entryId}:plan:${planBlock.blockStart}`
@@ -1061,6 +1284,57 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
           dispatchPlanStep(livePlan, nextIndex)
         } else {
           sendPlanCompleteEnvelope(livePlan)
+        }
+      }
+
+      // ── Round 10: parallel-workstreams progression pass ──────────────
+      // Iterate all pending workstream batches for this team. For each
+      // unresolved target, look for a fresh substantive response in its
+      // session's transcript. When every target has resolved, fire the
+      // `[Workstreams Complete]` envelope so the leader synthesizes.
+      const allWorkstreams = useChatStore.getState().pendingWorkstreams
+      for (const ws of allWorkstreams.values()) {
+        if (ws.teamId !== currentTeamId) continue
+        // Re-read because resolveWorkstreamTarget mutates targets.
+        const liveWs = useChatStore.getState().pendingWorkstreams.get(ws.workstreamId)
+        if (!liveWs) continue
+        // Already fully complete? Fire envelope (one-shot via ref) and skip.
+        if (liveWs.targets.every((t) => t.resolvedEntryId !== null)) {
+          sendWorkstreamsCompleteEnvelope(liveWs)
+          continue
+        }
+        // Anchor for "after-workstream" filtering. Pre-workstream entries
+        // (e.g., the target's prior onboarding intro) must not satisfy a
+        // workstream target.
+        const firedAt = workstreamFiredAtRef.current.get(liveWs.workstreamId) ?? liveWs.timestampMs
+        for (const target of liveWs.targets) {
+          if (target.resolvedEntryId !== null) continue
+          if (!target.targetAgentId) continue
+          const targetSk = buildTeamSessionKey(target.targetAgentId, currentTeamId)
+          const targetEntries = transcripts.get(targetSk)
+          if (!targetEntries) continue
+          const reply = targetEntries.find(
+            (e) =>
+              e.role === 'assistant' &&
+              e.kind === 'assistant' &&
+              (e.timestampMs ?? 0) > firedAt &&
+              e.text.length > 0 &&
+              !shouldDropAssistantTurn(e.text),
+          )
+          if (!reply) continue
+          useChatStore
+            .getState()
+            .resolveWorkstreamTarget(
+              liveWs.workstreamId,
+              target.targetAgentId,
+              reply.text,
+              reply.entryId,
+            )
+        }
+        // Re-read post-resolve. If everything's resolved now, fire envelope.
+        const postResolveWs = useChatStore.getState().pendingWorkstreams.get(ws.workstreamId)
+        if (postResolveWs && postResolveWs.targets.every((t) => t.resolvedEntryId !== null)) {
+          sendWorkstreamsCompleteEnvelope(postResolveWs)
         }
       }
     }
@@ -1200,11 +1474,17 @@ export function useTeamOrchestration(params: UseTeamOrchestrationParams): void {
       // Round 8B: also wipe any in-progress `<plan>` state machines so the
       // next step doesn't fire after Stop.
       useChatStore.getState().clearPendingPlans(currentTeamId)
+      // Round 10: wipe any in-progress parallel-workstream batches so the
+      // synthesis envelope doesn't fire after Stop.
+      useChatStore.getState().clearPendingWorkstreams(currentTeamId)
     }
     // Reset Round 8B refs so a new plan after Stop starts fresh.
     firedPlanStepsRef.current = new Set()
     planStepFiredAtRef.current = new Map()
     planCompletedSetRef.current = new Set()
+    // Reset Round 10 refs so a new workstream batch after Stop starts fresh.
+    workstreamFiredAtRef.current = new Map()
+    workstreamCompletedSetRef.current = new Set()
     frozenUntilRef.current = Date.now() + STOP_FREEZE_MS
   }, [stopSignal])
 }

--- a/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
+++ b/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
@@ -14,6 +14,7 @@ import { useConnectionStore } from '@/stores/connection'
 import { buildGlobalBrief, buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
 import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
 import { fetchTeamRules as fetchTeamRulesContent, saveTeamRules } from '@/lib/teamRules'
+import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -463,7 +464,6 @@ function TeamBriefEditor({
 function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentName: string }) {
   const [value, setValue] = useState<string>(currentName)
   const [saving, setSaving] = useState<boolean>(false)
-  const [syncing, setSyncing] = useState<boolean>(false)
   const isDirty = value.trim() !== currentName.trim()
   const client = useConnectionStore((s) => s.client)
 
@@ -477,6 +477,15 @@ function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentN
         body: JSON.stringify({ name: trimmed }),
       })
       if (!res.ok) throw new Error('Save failed')
+
+      // Auto-sync the new display name into Boo Zero's SOUL.md. The user's
+      // act of pressing Save IS the approval — they don't need a separate
+      // sync button. Best-effort (Gateway `agents.files.set('SOUL.md')` is
+      // documented unreliable); the per-turn rules block remains the
+      // authoritative identity surface either way.
+      if (client) {
+        void syncBooZeroSoulIdentity({ client, agentId, displayName: trimmed })
+      }
       useToastStore.getState().addToast({
         type: 'success',
         message: `Boo Zero display name → "${trimmed}". Reload to apply across all views.`,
@@ -488,67 +497,15 @@ function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentN
     } finally {
       setSaving(false)
     }
-  }, [agentId, value])
-
-  // Sync the override into the Gateway-side SOUL.md so the LLM's persisted
-  // identity ALSO reads as the display name. Best-effort — Gateway
-  // `agents.files.set('SOUL.md')` is documented as unreliable per CLAUDE.md.
-  // When it sticks, the LLM's natural self-reference shifts; when it
-  // doesn't, the per-turn rules block (Phase 2) is the authoritative
-  // anchor. We always treat the rules block as the primary identity
-  // surface — the SOUL.md sync is a nice-to-have alignment.
-  const handleSyncSoul = useCallback(async () => {
-    if (!client) {
-      useToastStore.getState().addToast({
-        type: 'error',
-        message: 'Not connected to Gateway — try after connecting.',
-      })
-      return
-    }
-    const trimmed = value.trim() || 'Boo Zero'
-    setSyncing(true)
-    try {
-      let current = ''
-      try {
-        const res = await client.call<{ file: { content?: string; missing?: boolean } }>(
-          'agents.files.get',
-          { agentId, name: 'SOUL.md' },
-        )
-        current = res?.file?.content ?? ''
-      } catch {
-        current = ''
-      }
-      // Prepend (or replace existing leading) `# <displayName>` line. We
-      // only touch the first heading so any subsequent SOUL.md content
-      // (role description, About-the-User block from onboarding, etc.)
-      // stays intact.
-      const stripped = current.replace(/^#\s+[^\n]*\n+/, '')
-      const next = `# ${trimmed}\n\n${stripped}`.trim() + '\n'
-      await client.call('agents.files.set', {
-        agentId,
-        name: 'SOUL.md',
-        content: next,
-      })
-      useToastStore.getState().addToast({
-        type: 'success',
-        message:
-          'SOUL.md sync attempted. The per-turn rules block remains the authoritative identity.',
-      })
-    } catch (e) {
-      useToastStore.getState().addToast({
-        type: 'error',
-        message: `SOUL.md sync failed: ${(e as Error).message ?? 'unknown'}. Display name still applies in Clawboo.`,
-      })
-    } finally {
-      setSyncing(false)
-    }
   }, [agentId, client, value])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
         How Boo Zero refers to itself in chats. Defaults to <code>Boo Zero</code>. Stored in
-        Clawboo&apos;s SQLite — the underlying OpenClaw agent name is not touched.
+        Clawboo&apos;s SQLite. Saving automatically syncs the heading of Boo Zero&apos;s
+        <code> SOUL.md</code> too (best-effort — the per-turn rules block stays authoritative either
+        way).
       </p>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
         <input
@@ -591,29 +548,6 @@ function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentN
         >
           {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
           Save
-        </button>
-        <button
-          type="button"
-          onClick={handleSyncSoul}
-          disabled={syncing || !client}
-          title="Best-effort: writes the display name into SOUL.md so the LLM's persisted identity matches. The per-turn rules block remains the load-bearing anchor regardless of whether this sticks."
-          style={{
-            height: 30,
-            padding: '0 12px',
-            fontSize: 11,
-            fontWeight: 600,
-            borderRadius: 8,
-            border: '1px solid rgba(255,255,255,0.1)',
-            background: 'rgba(255,255,255,0.04)',
-            color: client ? 'rgba(232,232,232,0.7)' : 'rgba(232,232,232,0.35)',
-            cursor: syncing || !client ? 'default' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-          }}
-        >
-          {syncing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-          Sync to SOUL.md
         </button>
       </div>
       {isDirty && (

--- a/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
+++ b/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
@@ -10,8 +10,10 @@ import { useTeamStore } from '@/stores/team'
 import { useFleetStore } from '@/stores/fleet'
 import { useBooZeroStore } from '@/stores/booZero'
 import { useToastStore } from '@/stores/toast'
+import { useConnectionStore } from '@/stores/connection'
 import { buildGlobalBrief, buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
 import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
+import { fetchTeamRules as fetchTeamRulesContent, saveTeamRules } from '@/lib/teamRules'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -438,6 +440,11 @@ function TeamBriefEditor({
               </div>
             </>
           )}
+          {/* Team Rules — user-captured durable rules injected into every
+              team agent's preamble. Source of truth: settings table
+              `team-rules:<teamId>`. Also writable via `/rule <text>` in
+              the team chat composer. */}
+          {!loading && <TeamRulesEditor teamId={teamId} />}
         </div>
       )}
     </div>
@@ -456,7 +463,9 @@ function TeamBriefEditor({
 function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentName: string }) {
   const [value, setValue] = useState<string>(currentName)
   const [saving, setSaving] = useState<boolean>(false)
+  const [syncing, setSyncing] = useState<boolean>(false)
   const isDirty = value.trim() !== currentName.trim()
+  const client = useConnectionStore((s) => s.client)
 
   const handleSave = useCallback(async () => {
     const trimmed = value.trim() || 'Boo Zero'
@@ -480,6 +489,60 @@ function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentN
       setSaving(false)
     }
   }, [agentId, value])
+
+  // Sync the override into the Gateway-side SOUL.md so the LLM's persisted
+  // identity ALSO reads as the display name. Best-effort — Gateway
+  // `agents.files.set('SOUL.md')` is documented as unreliable per CLAUDE.md.
+  // When it sticks, the LLM's natural self-reference shifts; when it
+  // doesn't, the per-turn rules block (Phase 2) is the authoritative
+  // anchor. We always treat the rules block as the primary identity
+  // surface — the SOUL.md sync is a nice-to-have alignment.
+  const handleSyncSoul = useCallback(async () => {
+    if (!client) {
+      useToastStore.getState().addToast({
+        type: 'error',
+        message: 'Not connected to Gateway — try after connecting.',
+      })
+      return
+    }
+    const trimmed = value.trim() || 'Boo Zero'
+    setSyncing(true)
+    try {
+      let current = ''
+      try {
+        const res = await client.call<{ file: { content?: string; missing?: boolean } }>(
+          'agents.files.get',
+          { agentId, name: 'SOUL.md' },
+        )
+        current = res?.file?.content ?? ''
+      } catch {
+        current = ''
+      }
+      // Prepend (or replace existing leading) `# <displayName>` line. We
+      // only touch the first heading so any subsequent SOUL.md content
+      // (role description, About-the-User block from onboarding, etc.)
+      // stays intact.
+      const stripped = current.replace(/^#\s+[^\n]*\n+/, '')
+      const next = `# ${trimmed}\n\n${stripped}`.trim() + '\n'
+      await client.call('agents.files.set', {
+        agentId,
+        name: 'SOUL.md',
+        content: next,
+      })
+      useToastStore.getState().addToast({
+        type: 'success',
+        message:
+          'SOUL.md sync attempted. The per-turn rules block remains the authoritative identity.',
+      })
+    } catch (e) {
+      useToastStore.getState().addToast({
+        type: 'error',
+        message: `SOUL.md sync failed: ${(e as Error).message ?? 'unknown'}. Display name still applies in Clawboo.`,
+      })
+    } finally {
+      setSyncing(false)
+    }
+  }, [agentId, client, value])
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
@@ -529,9 +592,173 @@ function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentN
           {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
           Save
         </button>
+        <button
+          type="button"
+          onClick={handleSyncSoul}
+          disabled={syncing || !client}
+          title="Best-effort: writes the display name into SOUL.md so the LLM's persisted identity matches. The per-turn rules block remains the load-bearing anchor regardless of whether this sticks."
+          style={{
+            height: 30,
+            padding: '0 12px',
+            fontSize: 11,
+            fontWeight: 600,
+            borderRadius: 8,
+            border: '1px solid rgba(255,255,255,0.1)',
+            background: 'rgba(255,255,255,0.04)',
+            color: client ? 'rgba(232,232,232,0.7)' : 'rgba(232,232,232,0.35)',
+            cursor: syncing || !client ? 'default' : 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+          }}
+        >
+          {syncing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+          Sync to SOUL.md
+        </button>
       </div>
       {isDirty && (
         <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved — save and reload to apply.</span>
+      )}
+    </div>
+  )
+}
+
+// ─── Team rules sub-section ──────────────────────────────────────────────────
+// Rendered inside the expanded TeamBriefEditor card so a user managing a
+// team's brief can also manage its rules in the same place. Rules are
+// user-captured durable constraints injected into every team agent's
+// preamble — survives across sessions, unlike chat history.
+
+function TeamRulesEditor({ teamId }: { teamId: string }) {
+  const [content, setContent] = useState<string>('')
+  const [clean, setClean] = useState<string>('')
+  const [loading, setLoading] = useState<boolean>(true)
+  const [saving, setSaving] = useState<boolean>(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    fetchTeamRulesContent(teamId)
+      .then((value) => {
+        if (cancelled) return
+        setContent(value)
+        setClean(value)
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [teamId])
+
+  const isDirty = content !== clean
+
+  const handleSave = useCallback(async () => {
+    setSaving(true)
+    try {
+      const ok = await saveTeamRules(teamId, content)
+      if (ok) {
+        setClean(content)
+        useToastStore.getState().addToast({ message: 'Team rules saved.', type: 'success' })
+      } else {
+        useToastStore.getState().addToast({ message: 'Could not save rules.', type: 'error' })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }, [content, teamId])
+
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        padding: 10,
+        borderTop: '1px solid rgba(255,255,255,0.06)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          color: 'rgba(232,232,232,0.75)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+        }}
+      >
+        Team Rules
+        <span style={{ fontWeight: 400, color: 'rgba(232,232,232,0.45)' }}>
+          (one rule per line; also writable via <code>/rule &lt;text&gt;</code> in the team
+          composer)
+        </span>
+      </div>
+      {loading ? (
+        <div
+          style={{
+            padding: 10,
+            fontSize: 11,
+            color: 'rgba(232,232,232,0.5)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}
+        >
+          <Loader2 size={12} className="animate-spin" /> Loading rules…
+        </div>
+      ) : (
+        <>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            disabled={saving}
+            spellCheck={false}
+            placeholder="No rules yet. Type one per line — they'll be injected into every team agent's preamble."
+            style={{
+              width: '100%',
+              minHeight: 100,
+              maxHeight: 260,
+              padding: 8,
+              fontSize: 12,
+              fontFamily: 'var(--font-geist-mono, monospace)',
+              lineHeight: 1.55,
+              background: 'rgba(13,17,23,0.85)',
+              color: '#E8E8E8',
+              border: '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 6,
+              resize: 'vertical',
+            }}
+          />
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!isDirty || saving}
+              style={{
+                height: 26,
+                padding: '0 10px',
+                fontSize: 11,
+                fontWeight: 600,
+                borderRadius: 6,
+                border: '1px solid rgba(255,255,255,0.1)',
+                background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
+                color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
+                cursor: !isDirty || saving ? 'default' : 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+              }}
+            >
+              {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+              Save rules
+            </button>
+            {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
+          </div>
+        </>
       )}
     </div>
   )

--- a/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
+++ b/apps/web/src/features/maintenance/BooZeroBriefsPanel.tsx
@@ -1,794 +1,190 @@
-// Boo Zero brief management — global brief + per-team briefs.
-// Lives inside MaintenancePanel ("System" view). SQLite-backed (Phase 1
-// API routes), surfaced as editable virtual files. Boo Zero reads briefs
-// at runtime via the context preamble injection in `groupChatSendOperation`
-// and `ChatPanel` (when the user `@TeamName`s in Boo Zero's individual chat).
-
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Loader2, RefreshCw, Save, ChevronRight } from 'lucide-react'
-import { useTeamStore } from '@/stores/team'
-import { useFleetStore } from '@/stores/fleet'
-import { useBooZeroStore } from '@/stores/booZero'
-import { useToastStore } from '@/stores/toast'
-import { useConnectionStore } from '@/stores/connection'
-import { buildGlobalBrief, buildTeamBrief, type TeamBriefMember } from '@/lib/booZeroBrief'
-import { detectGenuineLeader, matchedLeadershipKeyword } from '@/lib/genuineLeader'
-import { fetchTeamRules as fetchTeamRulesContent, saveTeamRules } from '@/lib/teamRules'
-import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-interface BriefResponse {
-  content?: string | null
-  updatedAt?: number | null
-}
-
-async function fetchGlobalBrief(): Promise<BriefResponse> {
-  const res = await fetch('/api/boo-zero/global-brief')
-  if (!res.ok) throw new Error('Failed to load global brief')
-  return (await res.json()) as BriefResponse
-}
-
-async function fetchTeamBrief(teamId: string): Promise<BriefResponse> {
-  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
-  if (!res.ok) throw new Error('Failed to load team brief')
-  return (await res.json()) as BriefResponse
-}
-
-async function putGlobalBrief(content: string): Promise<void> {
-  const res = await fetch('/api/boo-zero/global-brief', {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  })
-  if (!res.ok) throw new Error('Failed to save global brief')
-}
-
-async function putTeamBrief(teamId: string, content: string): Promise<void> {
-  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content }),
-  })
-  if (!res.ok) throw new Error('Failed to save team brief')
-}
-
-// ─── Global brief sub-section ────────────────────────────────────────────────
-
-function GlobalBriefEditor() {
-  const teams = useTeamStore((s) => s.teams)
-  const teamsRef = useRef(teams)
-  teamsRef.current = teams
-
-  const [content, setContent] = useState<string>('')
-  const [clean, setClean] = useState<string>('')
-  const [loading, setLoading] = useState<boolean>(true)
-  const [saving, setSaving] = useState<boolean>(false)
-  const seededRef = useRef<boolean>(false)
-
-  useEffect(() => {
-    // Intentionally seed exactly once on mount. Subsequent team changes
-    // shouldn't blow away user edits — they can press "Regenerate" if they
-    // want a fresh draft from the current team list. `teamsRef` is read at
-    // load-time so the initial default still reflects the current state.
-    if (seededRef.current) return
-    seededRef.current = true
-    let cancelled = false
-    setLoading(true)
-    fetchGlobalBrief()
-      .then((r) => {
-        if (cancelled) return
-        const value =
-          r.content && r.content.length > 0
-            ? r.content
-            : buildGlobalBrief({
-                teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
-              })
-        setContent(value)
-        setClean(value)
-      })
-      .catch(() => {
-        if (cancelled) return
-        const fallback = buildGlobalBrief({
-          teams: teamsRef.current.map((t) => ({ name: t.name, icon: t.icon })),
-        })
-        setContent(fallback)
-        setClean(fallback)
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  const isDirty = content !== clean
-
-  const handleSave = useCallback(async () => {
-    setSaving(true)
-    try {
-      await putGlobalBrief(content)
-      setClean(content)
-      useToastStore.getState().addToast({ type: 'success', message: 'Global brief saved' })
-    } catch (e) {
-      useToastStore
-        .getState()
-        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
-    } finally {
-      setSaving(false)
-    }
-  }, [content])
-
-  const handleRegenerate = useCallback(() => {
-    const fresh = buildGlobalBrief({
-      teams: teams.map((t) => ({ name: t.name, icon: t.icon })),
-    })
-    setContent(fresh)
-  }, [teams])
-
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
-        Boo Zero&apos;s overall responsibilities + the list of teams it leads. Injected into Boo
-        Zero&apos;s context preamble on every interaction.
-      </p>
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        disabled={loading || saving}
-        spellCheck={false}
-        style={{
-          width: '100%',
-          minHeight: 240,
-          maxHeight: 480,
-          padding: 12,
-          fontSize: 12,
-          fontFamily: 'var(--font-geist-mono, monospace)',
-          lineHeight: 1.55,
-          background: 'rgba(13,17,23,0.85)',
-          color: '#E8E8E8',
-          border: '1px solid rgba(255,255,255,0.08)',
-          borderRadius: 8,
-          resize: 'vertical',
-        }}
-      />
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || saving || loading}
-          style={{
-            height: 30,
-            padding: '0 12px',
-            fontSize: 11,
-            fontWeight: 600,
-            borderRadius: 8,
-            border: '1px solid rgba(255,255,255,0.1)',
-            background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
-            color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
-            cursor: !isDirty || saving || loading ? 'default' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-          }}
-        >
-          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
-          Save
-        </button>
-        <button
-          type="button"
-          onClick={handleRegenerate}
-          disabled={loading || saving}
-          style={{
-            height: 30,
-            padding: '0 12px',
-            fontSize: 11,
-            fontWeight: 600,
-            borderRadius: 8,
-            border: '1px solid rgba(255,255,255,0.1)',
-            background: 'rgba(255,255,255,0.04)',
-            color: 'rgba(232,232,232,0.7)',
-            cursor: loading || saving ? 'default' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-          }}
-          title="Regenerate from current team list (does not save yet)"
-        >
-          <RefreshCw size={12} />
-          Regenerate from teams
-        </button>
-        {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
-      </div>
-    </div>
-  )
-}
-
-// ─── Team brief sub-section ──────────────────────────────────────────────────
-
-function TeamBriefEditor({
-  teamId,
-  teamName,
-  teamIcon,
-  templateId,
-  teamColor,
-  collapsed,
-  onToggle,
-}: {
-  teamId: string
-  teamName: string
-  teamIcon: string
-  templateId: string | null
-  teamColor: string
-  collapsed: boolean
-  onToggle: () => void
-}) {
-  const agents = useFleetStore((s) => s.agents)
-  const teamAgents = useMemo(() => agents.filter((a) => a.teamId === teamId), [agents, teamId])
-
-  const [content, setContent] = useState<string>('')
-  const [clean, setClean] = useState<string>('')
-  const [loading, setLoading] = useState<boolean>(false)
-  const [saving, setSaving] = useState<boolean>(false)
-  const [loadedOnce, setLoadedOnce] = useState<boolean>(false)
-
-  const computeDefaultBrief = useCallback((): string => {
-    const genuineLead =
-      teamAgents.find((a) => detectGenuineLeader({ name: a.name, role: a.name })) ?? null
-    const matched = genuineLead
-      ? matchedLeadershipKeyword({ name: genuineLead.name, role: genuineLead.name })
-      : null
-    const members: TeamBriefMember[] = teamAgents.map((a) => ({
-      name: a.name,
-      role: a.name,
-    }))
-    return buildTeamBrief({
-      team: { name: teamName, icon: teamIcon, templateId, description: null },
-      members,
-      internalLead:
-        genuineLead && matched ? { agentName: genuineLead.name, matchedKeyword: matched } : null,
-    })
-  }, [teamAgents, teamName, teamIcon, templateId])
-
-  // Load when expanded (lazy).
-  useEffect(() => {
-    if (collapsed || loadedOnce) return
-    let cancelled = false
-    setLoading(true)
-    fetchTeamBrief(teamId)
-      .then((r) => {
-        if (cancelled) return
-        const value = r.content && r.content.length > 0 ? r.content : computeDefaultBrief()
-        setContent(value)
-        setClean(value)
-        setLoadedOnce(true)
-      })
-      .catch(() => {
-        if (cancelled) return
-        const fallback = computeDefaultBrief()
-        setContent(fallback)
-        setClean(fallback)
-        setLoadedOnce(true)
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [collapsed, loadedOnce, teamId, computeDefaultBrief])
-
-  const isDirty = content !== clean
-
-  const handleSave = useCallback(async () => {
-    setSaving(true)
-    try {
-      await putTeamBrief(teamId, content)
-      setClean(content)
-      useToastStore.getState().addToast({ type: 'success', message: `Brief for ${teamName} saved` })
-    } catch (e) {
-      useToastStore
-        .getState()
-        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
-    } finally {
-      setSaving(false)
-    }
-  }, [teamId, teamName, content])
-
-  const handleRegenerate = useCallback(() => {
-    setContent(computeDefaultBrief())
-  }, [computeDefaultBrief])
-
-  return (
-    <div
-      style={{
-        border: '1px solid rgba(255,255,255,0.06)',
-        borderRadius: 8,
-        background: 'rgba(255,255,255,0.02)',
-        overflow: 'hidden',
-      }}
-    >
-      <button
-        type="button"
-        onClick={onToggle}
-        style={{
-          width: '100%',
-          padding: '10px 12px',
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          color: '#E8E8E8',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 10,
-          fontSize: 12,
-          textAlign: 'left',
-        }}
-        aria-expanded={!collapsed}
-      >
-        <span
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: 22,
-            height: 22,
-            borderRadius: 6,
-            background: `${teamColor}22`,
-            fontSize: 13,
-          }}
-        >
-          {teamIcon}
-        </span>
-        <span style={{ flex: 1, fontWeight: 600 }}>{teamName}</span>
-        <span style={{ fontSize: 10, color: 'rgba(232,232,232,0.4)' }}>
-          {teamAgents.length} {teamAgents.length === 1 ? 'agent' : 'agents'}
-        </span>
-        <ChevronRight
-          size={14}
-          style={{
-            transform: collapsed ? 'rotate(0deg)' : 'rotate(90deg)',
-            transition: 'transform 0.15s ease',
-            opacity: 0.5,
-          }}
-        />
-      </button>
-      {!collapsed && (
-        <div style={{ padding: '0 12px 12px', display: 'flex', flexDirection: 'column', gap: 8 }}>
-          {loading && !loadedOnce ? (
-            <div
-              style={{
-                padding: 16,
-                fontSize: 11,
-                color: 'rgba(232,232,232,0.5)',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 8,
-              }}
-            >
-              <Loader2 size={12} className="animate-spin" /> Loading brief…
-            </div>
-          ) : (
-            <>
-              <textarea
-                value={content}
-                onChange={(e) => setContent(e.target.value)}
-                disabled={saving}
-                spellCheck={false}
-                style={{
-                  width: '100%',
-                  minHeight: 200,
-                  maxHeight: 420,
-                  padding: 10,
-                  fontSize: 12,
-                  fontFamily: 'var(--font-geist-mono, monospace)',
-                  lineHeight: 1.55,
-                  background: 'rgba(13,17,23,0.85)',
-                  color: '#E8E8E8',
-                  border: '1px solid rgba(255,255,255,0.08)',
-                  borderRadius: 6,
-                  resize: 'vertical',
-                }}
-              />
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <button
-                  type="button"
-                  onClick={handleSave}
-                  disabled={!isDirty || saving}
-                  style={{
-                    height: 28,
-                    padding: '0 10px',
-                    fontSize: 11,
-                    fontWeight: 600,
-                    borderRadius: 6,
-                    border: '1px solid rgba(255,255,255,0.1)',
-                    background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
-                    color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
-                    cursor: !isDirty || saving ? 'default' : 'pointer',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                  }}
-                >
-                  {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
-                  Save
-                </button>
-                <button
-                  type="button"
-                  onClick={handleRegenerate}
-                  disabled={saving}
-                  style={{
-                    height: 28,
-                    padding: '0 10px',
-                    fontSize: 11,
-                    fontWeight: 600,
-                    borderRadius: 6,
-                    border: '1px solid rgba(255,255,255,0.1)',
-                    background: 'rgba(255,255,255,0.04)',
-                    color: 'rgba(232,232,232,0.7)',
-                    cursor: saving ? 'default' : 'pointer',
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                  }}
-                  title="Regenerate from current team members (does not save until you press Save)"
-                >
-                  <RefreshCw size={12} />
-                  Regenerate
-                </button>
-                {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
-              </div>
-            </>
-          )}
-          {/* Team Rules — user-captured durable rules injected into every
-              team agent's preamble. Source of truth: settings table
-              `team-rules:<teamId>`. Also writable via `/rule <text>` in
-              the team chat composer. */}
-          {!loading && <TeamRulesEditor teamId={teamId} />}
-        </div>
-      )}
-    </div>
-  )
-}
-
-// ─── Display name editor ────────────────────────────────────────────────────
+// Boo Zero brief management — *redirected*.
 //
-// Phase E: the user's Gateway-side agent name can be anything ("main", a slug,
-// or whatever they typed in OpenClaw onboarding — production saw "Mythos").
-// Clawboo applies a display-name override that lives in SQLite and is overlaid
-// on the Boo Zero fleet entry at hydration time. This editor lets the user
-// change the override or clear it at any time. The default ("Boo Zero") is
-// seeded on first connect — see `GatewayBootstrap.tsx`.
+// History note: this panel used to host four editors (Display Name, Global
+// Brief, Per-Team Briefs, Team Rules) in the System view. That conflated
+// agent-scoped surfaces (Display Name + Global Brief belong to Boo Zero) with
+// team-scoped surfaces (Per-Team Brief + Team Rules belong to each team).
+//
+// The editors have moved to where their data actually lives:
+//   • Display Name + Global Brief → Boo Zero's individual agent view, in
+//     the new `Brief` tab (visible only when viewing Boo Zero).
+//   • Per-Team Brief + Team Rules → each team's settings sheet, opened from
+//     the gear icon on the team chat header.
+//
+// This panel is now just a breadcrumb in the System view so users who
+// learned the old location can find the new homes in one click.
 
-function DisplayNameEditor({ agentId, currentName }: { agentId: string; currentName: string }) {
-  const [value, setValue] = useState<string>(currentName)
-  const [saving, setSaving] = useState<boolean>(false)
-  const isDirty = value.trim() !== currentName.trim()
-  const client = useConnectionStore((s) => s.client)
+import { useBooZeroStore } from '@/stores/booZero'
+import { useFleetStore } from '@/stores/fleet'
+import { useTeamStore } from '@/stores/team'
+import { useViewStore } from '@/stores/view'
+import { useToastStore } from '@/stores/toast'
+import { ArrowRight, Settings } from 'lucide-react'
+import { BooAvatar } from '@clawboo/ui'
 
-  const handleSave = useCallback(async () => {
-    const trimmed = value.trim() || 'Boo Zero'
-    setSaving(true)
-    try {
-      const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(agentId)}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: trimmed }),
-      })
-      if (!res.ok) throw new Error('Save failed')
-
-      // Auto-sync the new display name into Boo Zero's SOUL.md. The user's
-      // act of pressing Save IS the approval — they don't need a separate
-      // sync button. Best-effort (Gateway `agents.files.set('SOUL.md')` is
-      // documented unreliable); the per-turn rules block remains the
-      // authoritative identity surface either way.
-      if (client) {
-        void syncBooZeroSoulIdentity({ client, agentId, displayName: trimmed })
-      }
-      useToastStore.getState().addToast({
-        type: 'success',
-        message: `Boo Zero display name → "${trimmed}". Reload to apply across all views.`,
-      })
-    } catch (e) {
-      useToastStore
-        .getState()
-        .addToast({ type: 'error', message: (e as Error).message ?? 'Save failed' })
-    } finally {
-      setSaving(false)
-    }
-  }, [agentId, client, value])
-
+function RedirectLink({
+  icon,
+  iconTinted = true,
+  title,
+  description,
+  cta,
+  onClick,
+  disabled = false,
+  disabledReason,
+}: {
+  icon: React.ReactNode
+  /** When false, the icon renders without the accent-tinted disc background. */
+  iconTinted?: boolean
+  title: string
+  description: string
+  cta: string
+  onClick: () => void
+  disabled?: boolean
+  disabledReason?: string
+}) {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-      <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
-        How Boo Zero refers to itself in chats. Defaults to <code>Boo Zero</code>. Stored in
-        Clawboo&apos;s SQLite. Saving automatically syncs the heading of Boo Zero&apos;s
-        <code> SOUL.md</code> too (best-effort — the per-turn rules block stays authoritative either
-        way).
-      </p>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          placeholder="Boo Zero"
-          maxLength={80}
-          disabled={saving}
-          style={{
-            flex: 1,
-            height: 30,
-            padding: '0 10px',
-            fontSize: 12,
-            fontFamily: 'var(--font-body, sans-serif)',
-            background: 'rgba(13,17,23,0.85)',
-            color: '#E8E8E8',
-            border: '1px solid rgba(255,255,255,0.08)',
-            borderRadius: 6,
-          }}
-        />
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={!isDirty || saving || value.trim().length === 0}
-          style={{
-            height: 30,
-            padding: '0 12px',
-            fontSize: 11,
-            fontWeight: 600,
-            borderRadius: 8,
-            border: '1px solid rgba(255,255,255,0.1)',
-            background: isDirty && value.trim().length > 0 ? '#E94560' : 'rgba(255,255,255,0.06)',
-            color: isDirty && value.trim().length > 0 ? '#fff' : 'rgba(232,232,232,0.5)',
-            cursor: !isDirty || saving || value.trim().length === 0 ? 'default' : 'pointer',
-            display: 'inline-flex',
-            alignItems: 'center',
-            gap: 6,
-          }}
-        >
-          {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
-          Save
-        </button>
-      </div>
-      {isDirty && (
-        <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved — save and reload to apply.</span>
-      )}
-    </div>
-  )
-}
-
-// ─── Team rules sub-section ──────────────────────────────────────────────────
-// Rendered inside the expanded TeamBriefEditor card so a user managing a
-// team's brief can also manage its rules in the same place. Rules are
-// user-captured durable constraints injected into every team agent's
-// preamble — survives across sessions, unlike chat history.
-
-function TeamRulesEditor({ teamId }: { teamId: string }) {
-  const [content, setContent] = useState<string>('')
-  const [clean, setClean] = useState<string>('')
-  const [loading, setLoading] = useState<boolean>(true)
-  const [saving, setSaving] = useState<boolean>(false)
-
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    fetchTeamRulesContent(teamId)
-      .then((value) => {
-        if (cancelled) return
-        setContent(value)
-        setClean(value)
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [teamId])
-
-  const isDirty = content !== clean
-
-  const handleSave = useCallback(async () => {
-    setSaving(true)
-    try {
-      const ok = await saveTeamRules(teamId, content)
-      if (ok) {
-        setClean(content)
-        useToastStore.getState().addToast({ message: 'Team rules saved.', type: 'success' })
-      } else {
-        useToastStore.getState().addToast({ message: 'Could not save rules.', type: 'error' })
-      }
-    } finally {
-      setSaving(false)
-    }
-  }, [content, teamId])
-
-  return (
-    <div
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={disabled ? disabledReason : title}
       style={{
-        marginTop: 12,
-        padding: 10,
-        borderTop: '1px solid rgba(255,255,255,0.06)',
         display: 'flex',
-        flexDirection: 'column',
-        gap: 8,
+        alignItems: 'center',
+        gap: 12,
+        padding: 12,
+        background: 'rgba(255,255,255,0.03)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        borderRadius: 8,
+        textAlign: 'left',
+        cursor: disabled ? 'default' : 'pointer',
+        opacity: disabled ? 0.55 : 1,
+        transition: 'background 0.15s ease, border-color 0.15s ease',
+      }}
+      onMouseEnter={(e) => {
+        if (!disabled) {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.05)'
+          e.currentTarget.style.borderColor = 'rgba(233,69,96,0.4)'
+        }
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = 'rgba(255,255,255,0.03)'
+        e.currentTarget.style.borderColor = 'rgba(255,255,255,0.08)'
       }}
     >
-      <div
+      <span
         style={{
-          fontSize: 11,
-          fontWeight: 600,
-          color: 'rgba(232,232,232,0.75)',
-          display: 'flex',
+          display: 'inline-flex',
           alignItems: 'center',
-          gap: 6,
+          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          borderRadius: 8,
+          background: iconTinted ? 'rgba(233,69,96,0.12)' : 'transparent',
+          color: iconTinted ? '#E94560' : 'inherit',
+          flexShrink: 0,
         }}
       >
-        Team Rules
-        <span style={{ fontWeight: 400, color: 'rgba(232,232,232,0.45)' }}>
-          (one rule per line; also writable via <code>/rule &lt;text&gt;</code> in the team
-          composer)
-        </span>
-      </div>
-      {loading ? (
+        {icon}
+      </span>
+      <div style={{ flex: 1, minWidth: 0 }}>
         <div
           style={{
-            padding: 10,
-            fontSize: 11,
-            color: 'rgba(232,232,232,0.5)',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
+            fontSize: 12,
+            fontWeight: 600,
+            color: '#E8E8E8',
+            marginBottom: 2,
           }}
         >
-          <Loader2 size={12} className="animate-spin" /> Loading rules…
+          {title}
         </div>
-      ) : (
-        <>
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            disabled={saving}
-            spellCheck={false}
-            placeholder="No rules yet. Type one per line — they'll be injected into every team agent's preamble."
-            style={{
-              width: '100%',
-              minHeight: 100,
-              maxHeight: 260,
-              padding: 8,
-              fontSize: 12,
-              fontFamily: 'var(--font-geist-mono, monospace)',
-              lineHeight: 1.55,
-              background: 'rgba(13,17,23,0.85)',
-              color: '#E8E8E8',
-              border: '1px solid rgba(255,255,255,0.08)',
-              borderRadius: 6,
-              resize: 'vertical',
-            }}
-          />
-          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={!isDirty || saving}
-              style={{
-                height: 26,
-                padding: '0 10px',
-                fontSize: 11,
-                fontWeight: 600,
-                borderRadius: 6,
-                border: '1px solid rgba(255,255,255,0.1)',
-                background: isDirty ? '#E94560' : 'rgba(255,255,255,0.06)',
-                color: isDirty ? '#fff' : 'rgba(232,232,232,0.5)',
-                cursor: !isDirty || saving ? 'default' : 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 6,
-              }}
-            >
-              {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
-              Save rules
-            </button>
-            {isDirty && <span style={{ fontSize: 10, color: '#FBBF24' }}>Unsaved changes</span>}
-          </div>
-        </>
-      )}
-    </div>
+        <div style={{ fontSize: 11, color: 'rgba(232,232,232,0.55)', lineHeight: 1.45 }}>
+          {description}
+        </div>
+        {disabled && disabledReason && (
+          <div style={{ fontSize: 10, color: '#FBBF24', marginTop: 4 }}>{disabledReason}</div>
+        )}
+      </div>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          fontSize: 11,
+          fontWeight: 500,
+          color: disabled ? 'rgba(232,232,232,0.35)' : 'rgba(232,232,232,0.7)',
+          flexShrink: 0,
+        }}
+      >
+        {cta} <ArrowRight size={12} />
+      </span>
+    </button>
   )
 }
 
 // ─── Top-level panel ─────────────────────────────────────────────────────────
 
 export function BooZeroBriefsPanel() {
-  const teams = useTeamStore((s) => s.teams).filter((t) => !t.isArchived)
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
   const agents = useFleetStore((s) => s.agents)
   const booZeroAgent = booZeroAgentId ? (agents.find((a) => a.id === booZeroAgentId) ?? null) : null
 
-  const [expandedTeamId, setExpandedTeamId] = useState<string | null>(null)
+  const teams = useTeamStore((s) => s.teams).filter((t) => !t.isArchived)
+  const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
+  // The team that will actually open when the user clicks the second card:
+  // the currently-selected team from the sidebar, falling back to the first
+  // un-archived team when nothing is selected. The button label mirrors
+  // this resolution so it always reads what's about to open.
+  const targetTeam =
+    (selectedTeamId ? teams.find((t) => t.id === selectedTeamId) : null) ?? teams[0] ?? null
+
+  const openAgent = useViewStore((s) => s.openAgent)
+  const openGroupChat = useViewStore((s) => s.openGroupChat)
+
+  const handleOpenBooZeroBrief = () => {
+    if (!booZeroAgent) return
+    openAgent(booZeroAgent.id)
+    useToastStore.getState().addToast({
+      type: 'success',
+      message: 'Open the "Brief" tab in the right-hand editor.',
+    })
+  }
+
+  const handleOpenTeamSettings = () => {
+    if (!targetTeam) return
+    openGroupChat(targetTeam.id)
+    useToastStore.getState().addToast({
+      type: 'success',
+      message: `Open “Brief & Rules” in ${targetTeam.name}'s chat header.`,
+    })
+  }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-      {!booZeroAgent && (
-        <div
-          style={{
-            padding: 10,
-            fontSize: 11,
-            color: '#FBBF24',
-            border: '1px solid rgba(251,191,36,0.3)',
-            borderRadius: 6,
-            background: 'rgba(251,191,36,0.05)',
-          }}
-          data-testid="boo-zero-missing-banner"
-        >
-          Boo Zero is missing from the fleet. Briefs are still editable, but there&apos;s no agent
-          to receive them until a primary agent is identified.
-        </div>
-      )}
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <RedirectLink
+        icon={booZeroAgent ? <BooAvatar seed={booZeroAgent.id} size={26} isBooZero /> : null}
+        iconTinted={false}
+        title="Boo Zero — Display name & Global brief"
+        description="Live in the Boo Zero agent view, in the Brief tab."
+        cta="Open Boo Zero"
+        onClick={handleOpenBooZeroBrief}
+        disabled={!booZeroAgent}
+        disabledReason={!booZeroAgent ? 'Boo Zero not identified yet.' : undefined}
+      />
 
-      {/* Display name */}
-      {booZeroAgent && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-          <h3
-            style={{
-              margin: 0,
-              fontSize: 12,
-              fontWeight: 600,
-              color: 'rgba(232,232,232,0.85)',
-            }}
-          >
-            Display name
-          </h3>
-          <DisplayNameEditor agentId={booZeroAgent.id} currentName={booZeroAgent.name} />
-        </div>
-      )}
-
-      {/* Global brief */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <h3
-          style={{
-            margin: 0,
-            fontSize: 12,
-            fontWeight: 600,
-            color: 'rgba(232,232,232,0.85)',
-          }}
-        >
-          Global brief
-        </h3>
-        <GlobalBriefEditor />
-      </div>
-
-      {/* Per-team briefs */}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-        <h3
-          style={{
-            margin: 0,
-            fontSize: 12,
-            fontWeight: 600,
-            color: 'rgba(232,232,232,0.85)',
-          }}
-        >
-          Per-team briefs
-        </h3>
-        {teams.length === 0 && (
-          <p style={{ fontSize: 11, color: 'rgba(232,232,232,0.45)', margin: 0 }}>
-            No teams deployed yet. Briefs appear here once you deploy your first team.
-          </p>
-        )}
-        {teams.map((team) => (
-          <TeamBriefEditor
-            key={team.id}
-            teamId={team.id}
-            teamName={team.name}
-            teamIcon={team.icon}
-            teamColor={team.color}
-            templateId={team.templateId ?? null}
-            collapsed={expandedTeamId !== team.id}
-            onToggle={() => setExpandedTeamId(expandedTeamId === team.id ? null : team.id)}
-          />
-        ))}
-      </div>
+      <RedirectLink
+        icon={<Settings size={15} />}
+        title="Per-team brief & rules"
+        description={
+          targetTeam
+            ? `Open the Brief & Rules button (top right) in ${targetTeam.name}'s chat header.`
+            : 'Open a team chat, then click Brief & Rules (top right of the header).'
+        }
+        cta={targetTeam ? `Open ${targetTeam.name}` : 'No teams yet'}
+        onClick={handleOpenTeamSettings}
+        disabled={!targetTeam}
+        disabledReason={!targetTeam ? 'Deploy a team first.' : undefined}
+      />
     </div>
   )
 }

--- a/apps/web/src/features/maintenance/MaintenancePanel.tsx
+++ b/apps/web/src/features/maintenance/MaintenancePanel.tsx
@@ -571,7 +571,11 @@ export function MaintenancePanel() {
 
       <div style={{ borderTop: '1px solid rgba(255,255,255,0.05)' }} />
 
-      {/* Section 4: Boo Zero — universal team leader context */}
+      {/* Section 4: Boo Zero — universal team leader context. The actual
+          editors moved out of System: Display Name + Global Brief now live
+          in Boo Zero's agent "Brief" tab, and per-team brief + rules live in
+          each team's settings sheet (gear icon on the team-chat header).
+          This section is a breadcrumb to the new homes. */}
       <div style={{ margin: '24px 0 28px' }} data-testid="boo-zero-briefs-section">
         <SectionHeading>Boo Zero</SectionHeading>
         <p
@@ -581,7 +585,8 @@ export function MaintenancePanel() {
             margin: '4px 0 14px',
           }}
         >
-          Universal team leader. Read by Boo Zero on every interaction.
+          Manage Boo Zero in the Boo Zero agent view, and per-team settings in each team&apos;s chat
+          header.
         </p>
         <BooZeroBriefsPanel />
       </div>

--- a/apps/web/src/lib/__tests__/booZeroBrief.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroBrief.test.ts
@@ -151,7 +151,7 @@ describe('buildGlobalBrief', () => {
     { name: 'Marketing Boos', icon: '📣', description: 'Content + campaigns.' },
   ]
 
-  it('renders role, responsibilities, teams index, delegation protocol, mention syntax, pitfalls, notes', () => {
+  it('renders role, required-behavior rules block, teams index, delegation protocol, mention syntax, pitfalls, notes', () => {
     const out = buildGlobalBrief({ teams })
     expect(out).toContain('# Boo Zero — Universal Team Leader')
     expect(out).toContain('## Role')
@@ -159,9 +159,13 @@ describe('buildGlobalBrief', () => {
     // imperative DO / DO NOT lists instead of first-person responsibilities.
     expect(out).toContain('You are the universal leader')
     expect(out).toContain('## Required behavior')
-    expect(out).toContain('**DO**')
-    expect(out).toContain('**DO NOT**')
-    expect(out).toContain('## Verification protocol')
+    // Phase 2 (cascade-fix): the required-behavior section now embeds the
+    // canonical rules block from `lib/booZeroRules.ts` so brief and per-
+    // turn injection share one source of truth.
+    expect(out).toContain('[Your Rules — authoritative]')
+    expect(out).toContain('[End Your Rules]')
+    expect(out).toContain('<delegate to="@AgentName">')
+    expect(out).toContain('## Additional verification guidance')
     expect(out).toContain('## Available teams')
     expect(out).toContain('- **Dev Team** 👾: Code review and bug hunting.')
     expect(out).toContain('- **Marketing Boos** 📣: Content + campaigns.')

--- a/apps/web/src/lib/__tests__/booZeroIdentitySync.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroIdentitySync.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { GatewayClientLike } from '@clawboo/gateway-client'
+import { syncBooZeroSoulIdentity, __test__ } from '../booZeroIdentitySync'
+
+// Mock clients with generic `call<T>` signatures need the cast to match
+// the `GatewayClientLike` interface — `vi.fn` returns a concrete-typed
+// `Mock` that TS can't widen to a generic call signature.
+type MockClient = { call: ReturnType<typeof vi.fn> }
+function asClient(m: MockClient): GatewayClientLike {
+  return m as unknown as GatewayClientLike
+}
+
+const { rewriteSoulHeading } = __test__
+
+describe('rewriteSoulHeading', () => {
+  it('replaces the leading heading with the new name', () => {
+    const before = '# Mythos\n\nResident ancient oracle.'
+    const after = rewriteSoulHeading(before, 'Boo Zero')
+    expect(after).toMatch(/^# Boo Zero\n\n/)
+    expect(after).toContain('Resident ancient oracle.')
+  })
+
+  it('prepends a heading when none exists', () => {
+    const before = 'Some role description without a heading.\n'
+    const after = rewriteSoulHeading(before, 'Boo Zero')
+    expect(after).toMatch(/^# Boo Zero\n\n/)
+    expect(after).toContain('Some role description')
+  })
+
+  it('preserves later content (personality block, About-the-User, etc.)', () => {
+    const before =
+      '# old name\n\nRole description.\n\n---\n<!-- clawboo:personality -->\nFormality: 80\n\n## About the User\nSanjay is shipping Clawboo.\n'
+    const after = rewriteSoulHeading(before, 'Boo Zero')
+    expect(after).toMatch(/^# Boo Zero\n\n/)
+    expect(after).toContain('Role description.')
+    expect(after).toContain('clawboo:personality')
+    expect(after).toContain('Formality: 80')
+    expect(after).toContain('## About the User')
+    expect(after).toContain('Sanjay is shipping Clawboo.')
+  })
+
+  it('is a no-op when the empty / whitespace name is passed', () => {
+    const before = '# Mythos\n\nstuff'
+    expect(rewriteSoulHeading(before, '')).toBe(before)
+    expect(rewriteSoulHeading(before, '   ')).toBe(before)
+  })
+
+  it('idempotent — calling with the same name twice produces the same output', () => {
+    const before = '# Whatever\n\nstuff\n'
+    const once = rewriteSoulHeading(before, 'Boo Zero')
+    const twice = rewriteSoulHeading(once, 'Boo Zero')
+    expect(once).toBe(twice)
+  })
+})
+
+describe('syncBooZeroSoulIdentity', () => {
+  it('reads SOUL.md, rewrites the heading, writes back', async () => {
+    const calls: { method: string; params: unknown }[] = []
+    const client = {
+      call: vi.fn(async (method: string, params: unknown) => {
+        calls.push({ method, params })
+        if (method === 'agents.files.get') {
+          return { file: { content: '# Mythos\n\nrole' } }
+        }
+        return { ok: true }
+      }),
+    }
+    const ok = await syncBooZeroSoulIdentity({
+      client: asClient(client),
+      agentId: 'a1',
+      displayName: 'Boo Zero',
+    })
+    expect(ok).toBe(true)
+    expect(calls).toHaveLength(2)
+    expect(calls[0]!.method).toBe('agents.files.get')
+    expect(calls[1]!.method).toBe('agents.files.set')
+    const setParams = calls[1]!.params as { name: string; content: string }
+    expect(setParams.name).toBe('SOUL.md')
+    expect(setParams.content).toMatch(/^# Boo Zero\n\n/)
+  })
+
+  it('handles missing SOUL.md by prepending the heading to empty content', async () => {
+    const calls: { method: string; params: unknown }[] = []
+    const client = {
+      call: vi.fn(async (method: string, params: unknown) => {
+        calls.push({ method, params })
+        if (method === 'agents.files.get') return { file: { missing: true } }
+        return { ok: true }
+      }),
+    }
+    const ok = await syncBooZeroSoulIdentity({
+      client: asClient(client),
+      agentId: 'a1',
+      displayName: 'Boo Zero',
+    })
+    expect(ok).toBe(true)
+    const setCall = calls.find((c) => c.method === 'agents.files.set')
+    expect(setCall).toBeDefined()
+    // SOUL.md was empty → no blank line between heading and (nonexistent)
+    // body is fine. We just require the heading lands cleanly at line 1.
+    expect((setCall!.params as { content: string }).content).toMatch(/^# Boo Zero\n/)
+  })
+
+  it('returns false when the SOUL.md write itself throws', async () => {
+    const client = {
+      call: vi.fn(async (method: string) => {
+        if (method === 'agents.files.get') return { file: { content: '# X\n' } }
+        if (method === 'agents.files.set') throw new Error('Gateway 500')
+        return { ok: true }
+      }),
+    }
+    const ok = await syncBooZeroSoulIdentity({
+      client: asClient(client),
+      agentId: 'a1',
+      displayName: 'Boo Zero',
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('refuses to sync when the display name is empty', async () => {
+    const client = { call: vi.fn(async () => ({ ok: true })) }
+    const ok = await syncBooZeroSoulIdentity({
+      client: asClient(client),
+      agentId: 'a1',
+      displayName: '',
+    })
+    expect(ok).toBe(false)
+    expect(client.call).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/lib/__tests__/booZeroRules.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroRules.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { buildBooZeroRulesBlock } from '../booZeroRules'
+
+describe('buildBooZeroRulesBlock', () => {
+  it('opens with the [Your Rules — authoritative] sentinel and closes with [End Your Rules]', () => {
+    const out = buildBooZeroRulesBlock({ displayName: 'Boo Zero' })
+    expect(out.startsWith('[Your Rules — authoritative]')).toBe(true)
+    expect(out.trim().endsWith('[End Your Rules]')).toBe(true)
+  })
+
+  it('asserts the display name as authoritative', () => {
+    const out = buildBooZeroRulesBlock({ displayName: 'Mythos' })
+    expect(out).toContain('You are Mythos.')
+    expect(out).toContain('This is your name.')
+    // The "do NOT use any alternative name" anchor mentions Mythos as a
+    // common-drift example regardless of which name was passed.
+    expect(out).toContain('"Mythos"')
+  })
+
+  it('includes the team-context role line when teamName is provided', () => {
+    const out = buildBooZeroRulesBlock({
+      displayName: 'Boo Zero',
+      teamName: 'Project Management Excellence Team',
+    })
+    expect(out).toContain('coordinating team "Project Management Excellence Team"')
+  })
+
+  it('omits the team name when teamName is null/undefined (1:1 chat path)', () => {
+    const a = buildBooZeroRulesBlock({ displayName: 'Boo Zero' })
+    const b = buildBooZeroRulesBlock({ displayName: 'Boo Zero', teamName: null })
+    expect(a).toContain('coordinating across every team')
+    expect(b).toContain('coordinating across every team')
+    expect(a).toBe(b)
+  })
+
+  it('contains every load-bearing rule', () => {
+    const out = buildBooZeroRulesBlock({ displayName: 'Boo Zero' })
+    // Delegation protocol
+    expect(out).toContain('<delegate to="@AgentName">')
+    expect(out).toMatch(/`<delegate>`\s+is\s+the\s+ONLY/i)
+    // Don't do work yourself
+    expect(out).toMatch(/Do the work yourself instead of delegating/i)
+    // Don't claim timeout
+    expect(out).toMatch(/timed out/i)
+    // Don't reply to [Team Update] as fresh user input
+    expect(out).toContain('[Team Update]')
+    expect(out).toMatch(/NOT fresh user input/i)
+    // No Task tool / sub-agents
+    expect(out).toMatch(/Task-tool/i)
+    // No resume greetings
+    expect(out).toMatch(/Greet teammates, introduce yourself/i)
+    // File namespacing for duplicate deliverables
+    expect(out).toMatch(/Write files for a deliverable a teammate/i)
+    // Honest uncertainty
+    expect(out).toMatch(/Honest uncertainty beats false certainty/i)
+  })
+
+  it('is deterministic — same params produce identical output (prompt cache safe)', () => {
+    const a = buildBooZeroRulesBlock({ displayName: 'X', teamName: 'Y' })
+    const b = buildBooZeroRulesBlock({ displayName: 'X', teamName: 'Y' })
+    expect(a).toBe(b)
+  })
+
+  it('stays under a soft 2500-char budget so the per-turn token cost is bounded', () => {
+    const out = buildBooZeroRulesBlock({
+      displayName: 'Boo Zero',
+      teamName: 'A Sample Team With A Reasonable Length',
+    })
+    // Current block is ~1900 chars (~475 tokens). The soft 2500 ceiling
+    // catches runaway expansion without breaking on minor edits.
+    expect(out.length).toBeLessThan(2500)
+  })
+})

--- a/apps/web/src/lib/__tests__/booZeroRules.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroRules.test.ts
@@ -61,15 +61,17 @@ describe('buildBooZeroRulesBlock', () => {
     expect(a).toBe(b)
   })
 
-  it('stays under a soft 7500-char budget so the per-turn token cost is bounded', () => {
+  it('stays under a soft 9500-char budget so the per-turn token cost is bounded', () => {
     const out = buildBooZeroRulesBlock({
       displayName: 'Boo Zero',
       teamName: 'A Sample Team With A Reasonable Length',
     })
     // After Round 8D expansion (Multi-step pipelines + <plan> blocks +
     // continue-on-relay exception), the block grew from ~4200 chars to ~6500
-    // chars. Prompt caching keeps the per-turn cost near zero. The 7500-char
-    // ceiling catches further runaway expansion without breaking on minor edits.
-    expect(out.length).toBeLessThan(7500)
+    // chars. Round 10 added the Parallel-workstreams section + extended the
+    // silence-on-relay rule reference, taking it to ~7400 chars. Prompt
+    // caching keeps the per-turn cost near zero. The 9500-char ceiling
+    // catches further runaway expansion without breaking on minor edits.
+    expect(out.length).toBeLessThan(9500)
   })
 })

--- a/apps/web/src/lib/__tests__/booZeroRules.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroRules.test.ts
@@ -61,13 +61,16 @@ describe('buildBooZeroRulesBlock', () => {
     expect(a).toBe(b)
   })
 
-  it('stays under a soft 2500-char budget so the per-turn token cost is bounded', () => {
+  it('stays under a soft 5000-char budget so the per-turn token cost is bounded', () => {
     const out = buildBooZeroRulesBlock({
       displayName: 'Boo Zero',
       teamName: 'A Sample Team With A Reasonable Length',
     })
-    // Current block is ~1900 chars (~475 tokens). The soft 2500 ceiling
-    // catches runaway expansion without breaking on minor edits.
-    expect(out.length).toBeLessThan(2500)
+    // After the Round 4 "Delegation syntax — protocol-strict" expansion
+    // (positive examples + anti-patterns + acknowledgment / narration / skip
+    // DO-NOTs), the block grew from ~1900 chars to ~4200 chars. Prompt
+    // caching keeps the per-turn cost near zero. The 5000-char ceiling
+    // catches further runaway expansion without breaking on minor edits.
+    expect(out.length).toBeLessThan(5000)
   })
 })

--- a/apps/web/src/lib/__tests__/booZeroRules.test.ts
+++ b/apps/web/src/lib/__tests__/booZeroRules.test.ts
@@ -61,16 +61,15 @@ describe('buildBooZeroRulesBlock', () => {
     expect(a).toBe(b)
   })
 
-  it('stays under a soft 5000-char budget so the per-turn token cost is bounded', () => {
+  it('stays under a soft 7500-char budget so the per-turn token cost is bounded', () => {
     const out = buildBooZeroRulesBlock({
       displayName: 'Boo Zero',
       teamName: 'A Sample Team With A Reasonable Length',
     })
-    // After the Round 4 "Delegation syntax — protocol-strict" expansion
-    // (positive examples + anti-patterns + acknowledgment / narration / skip
-    // DO-NOTs), the block grew from ~1900 chars to ~4200 chars. Prompt
-    // caching keeps the per-turn cost near zero. The 5000-char ceiling
-    // catches further runaway expansion without breaking on minor edits.
-    expect(out.length).toBeLessThan(5000)
+    // After Round 8D expansion (Multi-step pipelines + <plan> blocks +
+    // continue-on-relay exception), the block grew from ~4200 chars to ~6500
+    // chars. Prompt caching keeps the per-turn cost near zero. The 7500-char
+    // ceiling catches further runaway expansion without breaking on minor edits.
+    expect(out.length).toBeLessThan(7500)
   })
 })

--- a/apps/web/src/lib/__tests__/teamProtocol.test.ts
+++ b/apps/web/src/lib/__tests__/teamProtocol.test.ts
@@ -5,7 +5,14 @@ import {
   buildTeamContextPreamble,
   buildClawbooHelpDoc,
   buildSelfDocumentingRelayHeader,
+  buildBatchedRelayMessage,
+  isOpenclawControlToken,
+  isClawbooControlToken,
+  isLikelyRefusal,
+  shouldDropAssistantTurn,
   slugifyAgentName,
+  RESUME_ACK_TOKEN,
+  SKIP_ACK_TOKEN,
 } from '../teamProtocol'
 
 describe('buildTeamAgentsMd', () => {
@@ -638,5 +645,177 @@ describe('buildSelfDocumentingRelayHeader', () => {
       taskContext: longContext,
     })
     expect(result).toContain('(re: "' + 'A'.repeat(80) + '...")')
+  })
+})
+
+describe('isOpenclawControlToken', () => {
+  it('matches ANNOUNCE_SKIP exactly', () => {
+    expect(isOpenclawControlToken('ANNOUNCE_SKIP')).toBe(true)
+  })
+  it('matches NO_REPLY exactly', () => {
+    expect(isOpenclawControlToken('NO_REPLY')).toBe(true)
+  })
+  it('matches stripped NO variant', () => {
+    expect(isOpenclawControlToken('NO')).toBe(true)
+  })
+  it('matches lowercase no (the stripped form regardless of casing)', () => {
+    expect(isOpenclawControlToken('no')).toBe(true)
+  })
+  it('matches whitespace-surrounded token', () => {
+    expect(isOpenclawControlToken('  ANNOUNCE_SKIP  ')).toBe(true)
+  })
+  it('does NOT match longer text starting with NO', () => {
+    expect(isOpenclawControlToken('No problem — happy to help')).toBe(false)
+  })
+  it('does NOT match unrelated text', () => {
+    expect(isOpenclawControlToken('Hello there')).toBe(false)
+  })
+  it('does NOT match invented variants outside the allowlist', () => {
+    // `__skipped__` is a Clawboo token, not an OpenClaw one.
+    expect(isOpenclawControlToken('__skipped__')).toBe(false)
+    expect(isOpenclawControlToken('SKIP')).toBe(false)
+    expect(isOpenclawControlToken('PASS')).toBe(false)
+  })
+  // Round 5: OpenClaw Gateway truncation bug strips NO_REPLY to variable
+  // lengths. Production observed `NO_RE` leaking twice. All underscore-form
+  // prefixes must match.
+  it('matches NO_REPLY prefix-truncated variants (Round 5 production bug)', () => {
+    expect(isOpenclawControlToken('NO_')).toBe(true)
+    expect(isOpenclawControlToken('NO_R')).toBe(true)
+    expect(isOpenclawControlToken('NO_RE')).toBe(true)
+    expect(isOpenclawControlToken('NO_REP')).toBe(true)
+    expect(isOpenclawControlToken('NO_REPL')).toBe(true)
+  })
+  it('matches NO_REPLY prefix variants case-insensitively', () => {
+    expect(isOpenclawControlToken('no_re')).toBe(true)
+    expect(isOpenclawControlToken('No_Repl')).toBe(true)
+  })
+  it('does NOT match unrelated NO_-prefixed tokens', () => {
+    expect(isOpenclawControlToken('NO_REASON')).toBe(false)
+    expect(isOpenclawControlToken('NO_THANKS')).toBe(false)
+    expect(isOpenclawControlToken('NO_X')).toBe(false)
+  })
+})
+
+describe('isClawbooControlToken', () => {
+  it('matches RESUME_ACK_TOKEN', () => {
+    expect(isClawbooControlToken(RESUME_ACK_TOKEN)).toBe(true)
+    expect(isClawbooControlToken('__resumed__')).toBe(true)
+  })
+  it('matches SKIP_ACK_TOKEN', () => {
+    expect(isClawbooControlToken(SKIP_ACK_TOKEN)).toBe(true)
+    expect(isClawbooControlToken('__skipped__')).toBe(true)
+  })
+  it('is case-sensitive (Clawboo tokens are literal __snake__ strings)', () => {
+    expect(isClawbooControlToken('__SKIPPED__')).toBe(false)
+    expect(isClawbooControlToken('__Skipped__')).toBe(false)
+  })
+  it('does NOT match OpenClaw tokens or other text', () => {
+    expect(isClawbooControlToken('ANNOUNCE_SKIP')).toBe(false)
+    expect(isClawbooControlToken('arbitrary message')).toBe(false)
+  })
+})
+
+describe('isLikelyRefusal', () => {
+  it('matches short Nope / Sorry / Cannot openers', () => {
+    expect(isLikelyRefusal('Nope.')).toBe(true)
+    expect(isLikelyRefusal('Sorry, no.')).toBe(true)
+    expect(isLikelyRefusal('Cannot help')).toBe(true)
+    expect(isLikelyRefusal("can't")).toBe(true)
+    expect(isLikelyRefusal('Unable')).toBe(true)
+  })
+  it('does NOT match longer refusal-shaped text (full explanation)', () => {
+    // 25 chars is the floor — explanations are not leaks.
+    expect(isLikelyRefusal("Sorry, I can't help with that because it's outside my domain.")).toBe(
+      false,
+    )
+  })
+  it('does NOT match bare NO (covered separately by isOpenclawControlToken)', () => {
+    expect(isLikelyRefusal('NO')).toBe(false)
+    expect(isLikelyRefusal('no')).toBe(false)
+  })
+  it('does NOT match unrelated text', () => {
+    expect(isLikelyRefusal('Hello')).toBe(false)
+    expect(isLikelyRefusal('Got it')).toBe(false)
+  })
+})
+
+describe('shouldDropAssistantTurn', () => {
+  it('drops OpenClaw control tokens', () => {
+    expect(shouldDropAssistantTurn('ANNOUNCE_SKIP')).toBe(true)
+    expect(shouldDropAssistantTurn('NO_REPLY')).toBe(true)
+    expect(shouldDropAssistantTurn('NO')).toBe(true)
+  })
+  it('drops Clawboo control tokens', () => {
+    expect(shouldDropAssistantTurn('__resumed__')).toBe(true)
+    expect(shouldDropAssistantTurn('__skipped__')).toBe(true)
+  })
+  it('drops short refusal-shape responses', () => {
+    expect(shouldDropAssistantTurn('Nope.')).toBe(true)
+    expect(shouldDropAssistantTurn('Sorry')).toBe(true)
+  })
+  it('does NOT drop legitimate assistant content', () => {
+    expect(shouldDropAssistantTurn("Here's my analysis: ...")).toBe(false)
+    expect(
+      shouldDropAssistantTurn('I will look into that and respond with a full breakdown shortly.'),
+    ).toBe(false)
+  })
+  it('does NOT drop refusals that include a full explanation', () => {
+    // Long enough that the agent justified itself — not a leak.
+    expect(
+      shouldDropAssistantTurn(
+        "Sorry, I can't help with that because it requires database write access.",
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('buildBatchedRelayMessage', () => {
+  it('returns empty string for empty items', () => {
+    expect(buildBatchedRelayMessage([])).toBe('')
+  })
+  it('renders single-item batch with self-documenting header', () => {
+    const out = buildBatchedRelayMessage([
+      { fromAgentName: 'Geographer Boo', body: 'Volcanic island in temperate latitude.' },
+    ])
+    expect(out).toContain('[Team Update] — relayed summary from @Geographer Boo')
+    expect(out).toContain('not a fresh user message')
+    expect(out).toContain('Volcanic island in temperate latitude.')
+    expect(out).not.toContain('teammates finished')
+  })
+  it('renders multi-item batch with N-teammates header', () => {
+    const out = buildBatchedRelayMessage([
+      { fromAgentName: 'Geographer Boo', body: 'Volcanic island.' },
+      { fromAgentName: 'Anthropologist Boo', body: 'Patrilineal clans.' },
+      { fromAgentName: 'Historian Boo', body: 'Shattering War origin.' },
+    ])
+    expect(out).toContain('3 teammates finished delegated tasks')
+    expect(out).toContain('@Geographer Boo:')
+    expect(out).toContain('Volcanic island.')
+    expect(out).toContain('@Anthropologist Boo:')
+    expect(out).toContain('@Historian Boo:')
+    expect(out).toContain('Synthesize across them ONLY')
+    expect(out).toContain('Do NOT acknowledge them individually')
+  })
+  it('preserves source ordering in the batched envelope', () => {
+    const out = buildBatchedRelayMessage([
+      { fromAgentName: 'A', body: 'first body' },
+      { fromAgentName: 'B', body: 'second body' },
+      { fromAgentName: 'C', body: 'third body' },
+    ])
+    const idxA = out.indexOf('@A:')
+    const idxB = out.indexOf('@B:')
+    const idxC = out.indexOf('@C:')
+    expect(idxA).toBeGreaterThan(0)
+    expect(idxB).toBeGreaterThan(idxA)
+    expect(idxC).toBeGreaterThan(idxB)
+  })
+  it('truncates over-long taskContext to 80 chars in each item', () => {
+    const longCtx = 'X'.repeat(120)
+    const out = buildBatchedRelayMessage([
+      { fromAgentName: 'A', body: 'body 1', taskContext: longCtx },
+      { fromAgentName: 'B', body: 'body 2' },
+    ])
+    expect(out).toContain('(re: "' + 'X'.repeat(80) + '...")')
   })
 })

--- a/apps/web/src/lib/__tests__/teamRules.test.ts
+++ b/apps/web/src/lib/__tests__/teamRules.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { parseRuleCommand, appendRule, buildTeamRulesBlock } from '../teamRules'
+
+describe('parseRuleCommand', () => {
+  it('returns the rule text when prefixed with /rule ', () => {
+    expect(parseRuleCommand('/rule do not do work yourself')).toBe('do not do work yourself')
+  })
+
+  it('handles trailing whitespace', () => {
+    expect(parseRuleCommand('  /rule  delegate via <delegate>  ')).toBe('delegate via <delegate>')
+  })
+
+  it('is case-insensitive on the prefix', () => {
+    expect(parseRuleCommand('/RULE always verify')).toBe('always verify')
+  })
+
+  it('returns null for /rule with no body', () => {
+    expect(parseRuleCommand('/rule')).toBeNull()
+    expect(parseRuleCommand('/rule   ')).toBeNull()
+  })
+
+  it('returns null for non-rule commands', () => {
+    expect(parseRuleCommand('/reset')).toBeNull()
+    expect(parseRuleCommand('rule whatever')).toBeNull()
+    expect(parseRuleCommand('/rules whatever')).toBeNull()
+    expect(parseRuleCommand('/ruleset everything')).toBeNull()
+  })
+
+  it('returns null for normal user messages', () => {
+    expect(parseRuleCommand('hi team, what can we do?')).toBeNull()
+    expect(parseRuleCommand('')).toBeNull()
+  })
+})
+
+describe('appendRule', () => {
+  it('appends a single rule as a bullet line when existing is empty', () => {
+    expect(appendRule('', 'do not do work yourself')).toBe('- do not do work yourself')
+  })
+
+  it('appends to existing bulleted rules', () => {
+    const existing = '- always verify URLs with curl'
+    const next = appendRule(existing, 'do not use sub-agents')
+    expect(next).toBe('- always verify URLs with curl\n- do not use sub-agents')
+  })
+
+  it('preserves existing rule formatting when re-normalizing', () => {
+    // Existing rules might come in without bullets or with `*` markers — we
+    // re-normalize to `- ` so the block is consistent.
+    const existing = 'always verify URLs with curl\n* do not use sub-agents'
+    const next = appendRule(existing, 'delegate first')
+    expect(next).toBe('- always verify URLs with curl\n- do not use sub-agents\n- delegate first')
+  })
+
+  it('deduplicates case-insensitively', () => {
+    const existing = '- Delegate first'
+    const next = appendRule(existing, 'delegate first')
+    expect(next).toBe(existing)
+  })
+
+  it('ignores empty rules', () => {
+    expect(appendRule('- existing', '   ')).toBe('- existing')
+    expect(appendRule('- existing', '')).toBe('- existing')
+  })
+})
+
+describe('buildTeamRulesBlock', () => {
+  it('wraps non-empty content in the structured envelope', () => {
+    const out = buildTeamRulesBlock('- do not do work yourself')
+    expect(out).toContain('[Team Rules — set by the user, authoritative]')
+    expect(out).toContain('- do not do work yourself')
+    expect(out).toContain('[End Team Rules]')
+  })
+
+  it('returns null for empty / whitespace content (no envelope injected)', () => {
+    expect(buildTeamRulesBlock('')).toBeNull()
+    expect(buildTeamRulesBlock('   \n  ')).toBeNull()
+  })
+})

--- a/apps/web/src/lib/booZeroBrief.ts
+++ b/apps/web/src/lib/booZeroBrief.ts
@@ -10,7 +10,14 @@
  *
  * Pure. No DB / Gateway / store access. Tests assert markdown shape via
  * snapshots so any future change is visible in a code review.
+ *
+ * `buildGlobalBrief` embeds the canonical rules block from
+ * `lib/booZeroRules.ts` so the brief surface and the per-turn injection
+ * share one source of truth. The maintenance UI still renders the brief;
+ * the rules block within it is what every Boo Zero turn carries forward.
  */
+
+import { buildBooZeroRulesBlock } from './booZeroRules'
 
 // ─── Per-team brief ──────────────────────────────────────────────────────────
 
@@ -175,6 +182,11 @@ function renderAvailableTeams(teams: readonly GlobalBriefTeam[]): string {
 
 export function buildGlobalBrief(params: BuildGlobalBriefParams): string {
   const { teams } = params
+  // The canonical rules block — same content that gets injected into every
+  // Boo Zero turn at runtime. Sharing the source between brief and runtime
+  // injection guarantees the maintenance UI shows exactly what the LLM
+  // sees in context.
+  const rulesBlock = buildBooZeroRulesBlock({ displayName: 'Boo Zero' })
   return `# Boo Zero — Universal Team Leader
 
 ## Role
@@ -184,39 +196,16 @@ etc.) when present and coordinate cross-team work for the user.
 
 ## Required behavior
 
-**DO**
-- **Delegate first.** Every non-trivial user request gets one or more
-  \`<delegate>\` blocks aimed at the appropriate teammates. A short prose
-  acknowledgement to the user is fine; substantive work is delegated.
-- **Use your own tools to verify.** You have bash, curl, web-search, file
-  read/write, etc. (whatever your TOOLS.md grants). Before claiming any
-  external state — a URL is live, a server is running, a package was
-  installed, a file exists — verify it with the appropriate tool. Quote the
-  evidence inline ("verified — \`curl -sI http://localhost:5180\` returned
-  200 OK").
-- **Read the team transcript before making claims about teammate work.** A
-  teammate's progress is whatever they explicitly wrote in this conversation.
-  Use \`[Team Update]\` messages, not assumption.
-- **Synthesize across teammates.** Combine \`[Team Update]\` messages into a
-  single coherent response for the user.
+The block below is injected as the first section of every Boo Zero turn (user
+messages, agent-to-Boo-Zero delegations, wake-ups, the 1:1 chat path). It is
+the load-bearing identity + behavioral anchor — editing it here is documentation
+only; the runtime source is \`apps/web/src/lib/booZeroRules.ts\`.
 
-**DO NOT**
-- **Do substantive teammate work yourself when a teammate exists who could do
-  it.** "I'll handle it directly" is the wrong default. Even if no one has
-  responded yet, delegate — don't shadow-do the work.
-- **Claim a teammate has built / shipped / deployed anything without their
-  explicit message in this conversation confirming it.** "We built the
-  frontend" is only true when the responsible teammate said so.
-- **Claim any URL, port, file, or service is running without verification.**
-  Run \`curl -sI <url>\` (or equivalent) and only assert success on a real
-  2xx response. If you cannot reach a tool, say "I can't verify — let me
-  ask the responsible teammate" and delegate.
-- **Try to spawn sub-agents, worker agents, or any OpenClaw built-in
-  meta-agent construct.** \`<delegate>\` is the ONLY routing mechanism on
-  Clawboo. If you would normally try the OpenClaw sub-agent path and it
-  appears unavailable, that is by design — use \`<delegate>\` instead.
+\`\`\`
+${rulesBlock}
+\`\`\`
 
-## Verification protocol
+## Additional verification guidance
 
 Before you claim any external state, verify it with the right tool:
 

--- a/apps/web/src/lib/booZeroIdentitySync.ts
+++ b/apps/web/src/lib/booZeroIdentitySync.ts
@@ -1,0 +1,95 @@
+// Auto-sync Boo Zero's display name into the Gateway-side SOUL.md.
+//
+// Why this exists
+// ---------------
+// The Clawboo display-name override lives in SQLite and overlays the
+// Gateway-side `agent.name` in the UI. But the LLM's persisted identity
+// (the SOUL.md / IDENTITY.md it sees on every turn) still carries whatever
+// name OpenClaw set during onboarding ("Mythos" in production, or the
+// literal slug "main"). When the override and the persisted identity
+// disagree, the LLM drifts — calls itself one name in one breath and the
+// other in the next.
+//
+// Phase 2's per-turn `[Your Rules]` block carries the authoritative name
+// and is the load-bearing fix. This sync is the belt-and-suspenders layer:
+// when it succeeds, the LLM's natural self-reference also aligns with the
+// override, removing one pressure point for drift.
+//
+// Sync triggers (all "implicit user approval" moments):
+//   1. `GatewayBootstrap.hydrateFleet` — first connect AND every connect
+//      where the override already exists (idempotent so it doesn't matter
+//      if the SOUL.md was already updated).
+//   2. `DisplayNameEditor` save in maintenance — when the user changes the
+//      name, the SOUL.md sync runs immediately after the override PUT.
+//   3. `TeamOnboardingGate` Phase C — when the user submits their intro
+//      and clicks "Continue to Team Chat", that approval also triggers
+//      the sync (per-team onboarding moment of approval).
+//
+// Best-effort. Gateway `agents.files.set('SOUL.md')` is documented as
+// unreliable for persistence (see CLAUDE.md). When it works, great; when
+// it doesn't, the per-turn rules block keeps the identity anchored anyway.
+
+import type { GatewayClientLike } from '@clawboo/gateway-client'
+
+interface SoulFileResponse {
+  file: {
+    content?: string
+    missing?: boolean
+  }
+}
+
+/**
+ * Rewrite the first `# <heading>` line of an existing SOUL.md to `# <name>`.
+ * When the file has no leading heading, prepend one. Preserves all other
+ * content (role description, personality block, About-the-User section, etc.)
+ * so we never destroy the user's customizations.
+ */
+function rewriteSoulHeading(current: string, name: string): string {
+  const trimmedName = name.trim()
+  if (!trimmedName) return current
+  // Drop any existing leading top-level heading + the blank lines after it.
+  const stripped = current.replace(/^#\s+[^\n]*\n+/, '')
+  const next = `# ${trimmedName}\n\n${stripped}`.trimEnd() + '\n'
+  return next
+}
+
+/**
+ * Best-effort: write the display name into Boo Zero's SOUL.md as the first
+ * heading. Returns `true` on success, `false` on any failure (the caller
+ * decides whether to surface this to the user).
+ */
+export async function syncBooZeroSoulIdentity(params: {
+  client: GatewayClientLike
+  agentId: string
+  displayName: string
+}): Promise<boolean> {
+  const { client, agentId, displayName } = params
+  const trimmed = displayName.trim()
+  if (!trimmed) return false
+  try {
+    let current = ''
+    try {
+      const res = await client.call<SoulFileResponse>('agents.files.get', {
+        agentId,
+        name: 'SOUL.md',
+      })
+      current = res?.file?.content ?? ''
+    } catch {
+      // SOUL.md may be missing entirely — start from empty.
+      current = ''
+    }
+    const next = rewriteSoulHeading(current, trimmed)
+    if (next === current) return true // already aligned
+    await client.call('agents.files.set', {
+      agentId,
+      name: 'SOUL.md',
+      content: next,
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Exported for tests.
+export const __test__ = { rewriteSoulHeading }

--- a/apps/web/src/lib/booZeroRules.ts
+++ b/apps/web/src/lib/booZeroRules.ts
@@ -1,0 +1,75 @@
+// Boo Zero rules block — load-bearing identity + behavioral anchor.
+//
+// Why this exists
+// ---------------
+// Production showed Boo Zero (the universal team leader) drifting badly:
+//   • Calling itself "Mythos" instead of its display name (identity drift)
+//   • Doing teammate work itself instead of delegating (forbidden directly
+//     by the user, twice in the same chat)
+//   • Reaching for Claude Code's Task tool / sub-agents (the wrong primitive)
+//   • Claiming teammates "timed out" while they were still mid-response
+//   • Producing unsolicited intros 7 hours later on chat reopen
+//
+// `buildGlobalBrief` in `booZeroBrief.ts` documents most of these rules, but
+// the brief is ONLY surfaced in the maintenance UI — no code path injects it
+// into the LLM's context. The team brief (per-team) IS injected, but the
+// global identity + universal-leader rules are not.
+//
+// This module exports a small canonical rules block that we inject into
+// EVERY message Boo Zero receives — user messages, agent-to-Boo-Zero
+// delegations, wake-ups, the 1:1 chat path. The block is intentionally
+// hard-coded (not user-editable through the UI) so the load-bearing rules
+// can never be accidentally deleted by editing the brief textarea. The
+// user-editable Notes section in `buildGlobalBrief` continues to be
+// optional add-on context that the user can use for team-specific guidance.
+//
+// Size budget: ~600 chars (~150 tokens). Prompt caching applies because the
+// block is stable per `displayName`, so the marginal cost approaches zero
+// after the first turn.
+
+export interface BooZeroRulesParams {
+  /**
+   * Boo Zero's authoritative display name. The LLM uses this — not whatever
+   * the Gateway-side `identity.name` says. Resolved by `GatewayBootstrap`
+   * which seeds `"Boo Zero"` as the default override; the user can change
+   * it in the System panel's "Boo Zero" section.
+   */
+  displayName: string
+  /**
+   * Optional team context. When set, the role line reads "...on team
+   * <teamName>" so Boo Zero knows which team's lens to apply this turn.
+   * Omitted in the 1:1 chat path (Boo Zero's individual chat) where there
+   * is no active team.
+   */
+  teamName?: string | null
+}
+
+/**
+ * Build the rules block that anchors Boo Zero's identity and behavior.
+ * Inject this as the FIRST section of every message Boo Zero receives.
+ */
+export function buildBooZeroRulesBlock(params: BooZeroRulesParams): string {
+  const { displayName, teamName } = params
+  const roleLine = teamName
+    ? `You are the universal team leader on this Clawboo instance, currently coordinating team "${teamName}".`
+    : 'You are the universal team leader on this Clawboo instance, coordinating across every team.'
+
+  return `[Your Rules — authoritative]
+You are ${displayName}. This is your name. Do NOT use any alternative name for yourself ("Mythos", "main", "the assistant", "Boo", etc.). Even if you suspect another name was set elsewhere in your system context, the name in this block is final.
+
+${roleLine} You coordinate; you do not do substantive teammate work yourself.
+
+DO
+- Delegate every non-trivial request via \`<delegate to="@AgentName">specific self-contained task</delegate>\`. Multiple \`<delegate>\` blocks in one response are fine.
+- Wait for \`[Team Update]\` messages. They arrive asynchronously — they are teammate progress reports, NOT fresh user input. Do not reply to them as if the user just spoke.
+- Synthesize across teammate updates when they land.
+- Verify external state with tools (curl, ls, etc.) before claiming it. Honest uncertainty beats false certainty.
+
+DO NOT
+- Spawn sub-agents, worker agents, or use any Task-tool / Claude Code sub-agent primitive. \`<delegate>\` is the ONLY routing mechanism on Clawboo. If the system seems to offer a sub-agent path, that path is unavailable — use \`<delegate>\` instead.
+- Claim a teammate "timed out" or "is unresponsive". Say "still waiting on @<name>" and continue with whatever you can synthesize so far.
+- Do the work yourself instead of delegating, even if no teammate has replied yet. Shadow-doing the work produces duplicate / conflicting artifacts when the teammate finishes their own version.
+- Greet teammates, introduce yourself, or comment on session continuity on resume. After any pause, pick up the work where you left off — you are already mid-conversation.
+- Write files for a deliverable a teammate is also producing. Either namespace your filename or let one owner emit the artifact (then synthesize their result).
+[End Your Rules]`
+}

--- a/apps/web/src/lib/booZeroRules.ts
+++ b/apps/web/src/lib/booZeroRules.ts
@@ -23,13 +23,15 @@
 // user-editable Notes section in `buildGlobalBrief` continues to be
 // optional add-on context that the user can use for team-specific guidance.
 //
-// Size budget: ~2.5 KB (~650 tokens) after the Round 4 expansion that added
-// the "Delegation syntax — protocol-strict" section with positive examples
-// + anti-patterns. Prompt caching applies because the block is stable per
-// `displayName`, so the marginal cost approaches zero after the first turn.
-// The expanded block is load-bearing because production showed Boo Zero
-// emitting prose `---` separators instead of `<delegate>` tags — anti-pattern
-// examples are the only way the LLM reliably stops doing this.
+// Size budget: ~5 KB (~1.2 K tokens) after the Round 8D expansion that added
+// the "Multi-step pipelines" + "<plan> blocks" sections (continue-on-relay
+// rule + explicit plan syntax). Prompt caching applies because the block is
+// stable per `displayName`, so the marginal cost approaches zero after the
+// first turn. The expanded block is load-bearing because production showed
+// (a) Boo Zero emitting prose `---` separators instead of `<delegate>` tags,
+// and (b) Boo Zero abandoning multi-step pipelines because Round 4/5 told
+// it to stay silent on relays — anti-pattern examples + the explicit
+// continue-on-relay exception are the only way the LLM reliably progresses.
 
 export interface BooZeroRulesParams {
   /**
@@ -91,10 +93,63 @@ WRONG — these do NOT render as cards and teammates are NOT notified:
 
 Narrate your routing freely BEFORE/BETWEEN/AFTER the tags — the prose tells the user what you're doing. The \`<delegate>\` tags carry the actual work.
 
+## Multi-step pipelines — when YOU should respond to \`[Team Update]\`
+
+The silence-on-relay rule has ONE explicit exception, the multi-step
+pipeline case. When all of these are true:
+
+1. Your previous turn contained a \`<delegate>\` to the teammate the relay
+   is from (the relay header reads "[Team Update] — relayed summary from
+   @<name>" — match that name against your own previous turn).
+2. The delegation was step 1 of a plan you laid out (e.g., "Marketing
+   Content Creator writes copy first, then Designer reads it to make the
+   visual spec").
+3. There IS a meaningful next step that depends on this teammate's
+   output.
+
+…then you SHOULD respond — by firing the NEXT delegation in the plan,
+passing the teammate's output to the next step. Example flow:
+
+  Turn 1: "Step 1 — get the copy. <delegate to='@Marketing'>...</delegate>"
+  Turn 2 (after Marketing's relay arrives): "Step 2 — design from copy.
+    <delegate to='@Designer'>Based on copy '<insert quote>', create the
+    visual spec...</delegate>"
+
+This is NOT acknowledgment ("Got it — copy looks great!"). This is the
+NEXT step of the plan. Acknowledgment-only is still forbidden.
+
+## \`<plan>\` blocks — explicit multi-step orchestration
+
+If your plan has 3+ ordered steps, emit a \`<plan>\` block at the top of
+your response so Clawboo can track state across multiple turns:
+
+\`\`\`
+<plan>
+  <step to="@Marketing Content Creator Boo">Write the copy first.</step>
+  <step to="@Design Ui Designer Boo">Create the visual design from the copy.</step>
+  <step to="@Engineering Frontend Developer Boo">Build the page from the design.</step>
+</plan>
+\`\`\`
+
+When Clawboo sees a \`<plan>\`, it:
+- Fires step 1 immediately (you don't need a separate \`<delegate>\`).
+- After step 1's teammate responds, automatically fires step 2 with the
+  prior output piped in as context — you don't need to write the next
+  \`<delegate>\` yourself.
+- Continues through every step.
+- When the plan completes, the relay you receive will include a
+  \`[Plan Complete]\` header — that's your cue to do final synthesis if
+  the user's question warrants one.
+
+If a plan is just 1-2 steps OR is dynamic (depends on each prior result),
+keep using standalone \`<delegate>\` blocks plus the continue-on-relay
+behavior above.
+
 DO
 - Delegate every non-trivial request via the exact \`<delegate to="@AgentName">…</delegate>\` syntax. Multiple blocks in one response are encouraged.
-- Wait for \`[Team Update]\` messages — they're teammate progress reports, NOT fresh user input. Record them silently as context.
-- Synthesize ACROSS teammates ONLY when (a) the user has asked a follow-up that requires combining them, or (b) you need a unified takeaway to drive the next round of delegations. A single update never warrants a response.
+- Use \`<plan>\` for clear 3+ step pipelines so Clawboo auto-progresses without re-prompting.
+- Wait silently for \`[Team Update]\` messages MOST of the time — they're progress reports, not fresh user input. Record them as context. The ONE exception is the multi-step pipeline case above.
+- Synthesize ACROSS teammates ONLY when (a) the user has asked a follow-up that requires combining them, (b) a multi-step plan has finished (\`[Plan Complete]\` header), or (c) you need a unified takeaway to drive the next round of delegations.
 - Verify external state with tools (curl, ls, etc.) before claiming it. Honest uncertainty beats false certainty.
 
 DO NOT

--- a/apps/web/src/lib/booZeroRules.ts
+++ b/apps/web/src/lib/booZeroRules.ts
@@ -145,11 +145,29 @@ If a plan is just 1-2 steps OR is dynamic (depends on each prior result),
 keep using standalone \`<delegate>\` blocks plus the continue-on-relay
 behavior above.
 
+## Parallel workstreams — when YOU fire N delegations in one turn
+
+When you emit ≥2 sibling \`<delegate>\` tags in the SAME response (without
+a \`<plan>\` wrapper), Clawboo automatically tracks them as a "workstream
+batch" — each target works independently in parallel. You'll see them
+grouped in the chat under a 📡 WORKSTREAMS card.
+
+- DO NOT respond to individual \`[Team Update]\` relays from a workstream
+  batch. Wait silently until ALL targets resolve.
+- When ALL targets resolve, Clawboo sends you a \`[Workstreams Complete]\`
+  envelope listing each output. THAT is your synthesis cue — DO synthesize
+  across them in your next turn. This bypasses the silence-on-relay rule.
+- Acknowledgment-only is still forbidden. The synthesis should combine
+  the parallel outputs into the user's answer (and may include next-round
+  \`<delegate>\` tags if a follow-up wave is needed).
+- DO NOT acknowledge a single workstream's completion while others are
+  still in flight. The chat already shows each teammate's contribution.
+
 DO
 - Delegate every non-trivial request via the exact \`<delegate to="@AgentName">…</delegate>\` syntax. Multiple blocks in one response are encouraged.
 - Use \`<plan>\` for clear 3+ step pipelines so Clawboo auto-progresses without re-prompting.
-- Wait silently for \`[Team Update]\` messages MOST of the time — they're progress reports, not fresh user input. Record them as context. The ONE exception is the multi-step pipeline case above.
-- Synthesize ACROSS teammates ONLY when (a) the user has asked a follow-up that requires combining them, (b) a multi-step plan has finished (\`[Plan Complete]\` header), or (c) you need a unified takeaway to drive the next round of delegations.
+- Wait silently for \`[Team Update]\` messages MOST of the time — they're progress reports, not fresh user input. Record them as context. The exceptions are the multi-step pipeline case above AND the parallel workstreams case below.
+- Synthesize ACROSS teammates ONLY when (a) the user has asked a follow-up that requires combining them, (b) a multi-step plan has finished (\`[Plan Complete]\` header), (c) a parallel workstream batch has finished (\`[Workstreams Complete]\` header), or (d) you need a unified takeaway to drive the next round of delegations.
 - Verify external state with tools (curl, ls, etc.) before claiming it. Honest uncertainty beats false certainty.
 
 DO NOT

--- a/apps/web/src/lib/booZeroRules.ts
+++ b/apps/web/src/lib/booZeroRules.ts
@@ -23,9 +23,13 @@
 // user-editable Notes section in `buildGlobalBrief` continues to be
 // optional add-on context that the user can use for team-specific guidance.
 //
-// Size budget: ~600 chars (~150 tokens). Prompt caching applies because the
-// block is stable per `displayName`, so the marginal cost approaches zero
-// after the first turn.
+// Size budget: ~2.5 KB (~650 tokens) after the Round 4 expansion that added
+// the "Delegation syntax — protocol-strict" section with positive examples
+// + anti-patterns. Prompt caching applies because the block is stable per
+// `displayName`, so the marginal cost approaches zero after the first turn.
+// The expanded block is load-bearing because production showed Boo Zero
+// emitting prose `---` separators instead of `<delegate>` tags — anti-pattern
+// examples are the only way the LLM reliably stops doing this.
 
 export interface BooZeroRulesParams {
   /**
@@ -59,17 +63,49 @@ You are ${displayName}. This is your name. Do NOT use any alternative name for y
 
 ${roleLine} You coordinate; you do not do substantive teammate work yourself.
 
+## Delegation syntax — protocol-strict
+Every delegation MUST be a literal XML-shaped tag: \`<delegate to="@AgentName">task</delegate>\`. The UI parses these tags and renders each as a DelegationCard with the target's avatar + task body + nested response. WITHOUT THESE TAGS, NO CARD RENDERS and teammates are NOT notified.
+
+CORRECT (single delegation with narration):
+> I'll have @Geographer Boo handle the climate piece first.
+> <delegate to="@Geographer Boo">
+> Design a volcanic island setting with temperate latitude. Cover terrain, climate, and natural harbor.
+> </delegate>
+
+CORRECT (multi-delegation with narration):
+> I'll have all five specialists collaborate on a worldbuilding demo so you can see each lens at work.
+>
+> <delegate to="@Geographer Boo">Design a volcanic island...</delegate>
+> <delegate to="@Anthropologist Boo">Design kinship + ritual system...</delegate>
+> <delegate to="@Historian Boo">Build the origin myth...</delegate>
+> <delegate to="@Narratologist Boo">Map this to a narrative archetype...</delegate>
+> <delegate to="@Psychologist Boo">Analyse the collective psychology...</delegate>
+>
+> Each card below will fill in as they respond.
+
+WRONG — these do NOT render as cards and teammates are NOT notified:
+- "Let me delegate to each specialist:---"  (markdown rule, no tag)
+- "@Geographer Boo, please handle the geography piece"  (prose-only mention)
+- '<delegate to="@X">task'  (missing closing tag)
+- '<delegate to=@X>task</delegate>'  (missing quotes around the name)
+
+Narrate your routing freely BEFORE/BETWEEN/AFTER the tags — the prose tells the user what you're doing. The \`<delegate>\` tags carry the actual work.
+
 DO
-- Delegate every non-trivial request via \`<delegate to="@AgentName">specific self-contained task</delegate>\`. Multiple \`<delegate>\` blocks in one response are fine.
-- Wait for \`[Team Update]\` messages. They arrive asynchronously — they are teammate progress reports, NOT fresh user input. Do not reply to them as if the user just spoke.
-- Synthesize across teammate updates when they land.
+- Delegate every non-trivial request via the exact \`<delegate to="@AgentName">…</delegate>\` syntax. Multiple blocks in one response are encouraged.
+- Wait for \`[Team Update]\` messages — they're teammate progress reports, NOT fresh user input. Record them silently as context.
+- Synthesize ACROSS teammates ONLY when (a) the user has asked a follow-up that requires combining them, or (b) you need a unified takeaway to drive the next round of delegations. A single update never warrants a response.
 - Verify external state with tools (curl, ls, etc.) before claiming it. Honest uncertainty beats false certainty.
 
 DO NOT
-- Spawn sub-agents, worker agents, or use any Task-tool / Claude Code sub-agent primitive. \`<delegate>\` is the ONLY routing mechanism on Clawboo. If the system seems to offer a sub-agent path, that path is unavailable — use \`<delegate>\` instead.
-- Claim a teammate "timed out" or "is unresponsive". Say "still waiting on @<name>" and continue with whatever you can synthesize so far.
-- Do the work yourself instead of delegating, even if no teammate has replied yet. Shadow-doing the work produces duplicate / conflicting artifacts when the teammate finishes their own version.
-- Greet teammates, introduce yourself, or comment on session continuity on resume. After any pause, pick up the work where you left off — you are already mid-conversation.
+- Emit acknowledgment-only text for incoming updates ("Got it", "Nice — that's the X layer", "And that's Y", "Still waiting on Z"). The chat already shows each teammate's contribution; restating is pure noise.
+- Pre-narrate work you're about to delegate as if the teammate had already done it. Delegate the tags, then wait for the actual response.
+- Re-narrate teammate work that is already visible above in chat. If the user asks "what did you do?" a single short sentence is enough.
+- Emit bare \`NO\`, \`NOPE\`, \`SKIP\`, \`PASS\`, \`ANNOUNCE_SKIP\`, or \`NO_REPLY\`. If you have nothing substantive to add, emit ONLY the canonical Clawboo token \`__skipped__\` and nothing else.
+- Spawn sub-agents, worker agents, or use any Task-tool / Claude Code sub-agent primitive. \`<delegate>\` is the ONLY routing mechanism on Clawboo.
+- Claim a teammate "timed out" or "is unresponsive". Say "still waiting on @<name>" and continue with whatever you can synthesize.
+- Do the work yourself instead of delegating, even if no teammate has replied yet. Shadow-doing produces duplicate / conflicting artifacts.
+- Greet teammates, introduce yourself, or comment on session continuity on resume. After any pause, pick up where you left off — you are already mid-conversation.
 - Write files for a deliverable a teammate is also producing. Either namespace your filename or let one owner emit the artifact (then synthesize their result).
 [End Your Rules]`
 }

--- a/apps/web/src/lib/teamProtocol.ts
+++ b/apps/web/src/lib/teamProtocol.ts
@@ -243,6 +243,64 @@ brief — is still loaded. The next message you receive (a \`[Team Update]\`
 from a teammate, or a fresh user message) is where you engage. Pick up the
 work as if there was no pause.
 
+### When you have nothing substantive to add
+
+If a \`[Team Update]\` or delegation arrives and you genuinely have nothing
+to contribute (the work is outside your specialty, you'd just be repeating
+a teammate's point, etc.), emit ONLY the literal token \`__skipped__\` and
+nothing else. The renderer filters it out — the chat stays clean and the
+orchestrator knows you've acknowledged.
+
+OpenClaw protocol tokens (\`ANNOUNCE_SKIP\`, \`NO_REPLY\`) are also filtered
+by the renderer as a safety net, but prefer \`__skipped__\` as the canonical
+Clawboo signal.
+
+DO NOT emit:
+- A bare \`NO\` or \`NOPE\` — these get filtered as broken-shape leaks, and
+  you should not emit them in the first place. If you disagree with
+  something, explain why in a full sentence (≥25 chars).
+- An acknowledgment ("OK", "Got it", "Will do") with no other content. If
+  you have nothing else to add, use \`__skipped__\` instead.
+- Variations like \`SKIP\`, \`PASS\`, \`NO_RESPONSE\`, or invented control
+  tokens. Stick to the canonical \`__skipped__\`.
+
+### Receiving [Team Update] messages
+
+A \`[Team Update]\` message looks like this:
+
+> [Team Update] — relayed summary from @<Name> (not a fresh user message)
+> The teammate finished a delegated task. Continue your own work using this update as context.
+> ---
+> ...summary body...
+> ---
+
+**This is a progress report, NOT a fresh user message.** Do NOT respond to
+it as if the user just spoke. Record it silently as context for your own
+work. Only emit a new response if you have substantive new work to do based
+on this update — and even then, the response should be that NEW work, not
+an acknowledgment.
+
+DO NOT emit:
+- "Got it — that's the X layer"
+- "Done! Created Y"
+- "Quiz created — N questions covering ..."
+- "Ready for the next deliverable"
+- Any text that just narrates what the teammate did
+
+If you have nothing substantive to add, emit ONLY \`__skipped__\` and
+nothing else.
+
+### After producing a deliverable
+
+When you produce a deliverable (a file write, a code block, a JSON object,
+a table, a structured response), the deliverable IS the response. Do NOT
+emit a separate acknowledgment turn ("Done!", "Quiz created — 5 questions
+covering X, Y, Z. Ready for next.") after the actual content.
+Acknowledgment-only turns are pure noise — the user can already see your
+deliverable above. If a follow-up is genuinely warranted (e.g., a question
+back to the orchestrator), make sure it has substantive content; do not
+narrate completion.
+
 ### Routing Rules
 ${rules}
 `
@@ -277,6 +335,95 @@ ${rules}
  * visible chat.
  */
 export const RESUME_ACK_TOKEN = '__resumed__'
+
+// ─── Render-time defensive filters ─────────────────────────────────────────
+//
+// Production showed three distinct families of broken-shape assistant turns
+// leaking into the visible chat:
+//
+//   1. OpenClaw protocol control tokens — `ANNOUNCE_SKIP`, `NO_REPLY`, and the
+//      stripped variant `NO`. These are emitted by the Gateway's agent-to-
+//      agent coordination layer (see OpenClaw issue tracker). The Gateway
+//      does NOT pre-filter them — Clawboo reads raw event streams, so the
+//      renderer is the right place.
+//   2. Clawboo control tokens — `__resumed__` (already filtered) and the new
+//      `__skipped__` canonical "no contribution" signal we instruct agents
+//      to use when they have nothing substantive to add.
+//   3. Short refusal-shape responses from team agents during normal turns —
+//      bare "Sorry", "Nope", "Cannot", "Unable". Onboarding has its own
+//      retry logic (`TeamOnboardingGate.tsx`); this catches everything else.
+//      Note: bare "NO" is covered by category 1 (the stripped NO_REPLY)
+//      rather than this refusal regex.
+//
+// `shouldDropAssistantTurn` is the single render-time entry point. It's wired
+// into both `chatComponents.groupEntriesToBlocks` (UI render) AND
+// `buildDelegationLinkages` (renderer-only delegation scan) so the same
+// turn-shape never seeds a misattributed delegation either.
+
+/**
+ * Canonical Clawboo "no substantive contribution" token. We instruct agents
+ * in `buildTeamAgentsMd` to emit ONLY this string when they have nothing to
+ * add to a delegation or relay. Filtered out of the visible chat so the
+ * transcript stays clean.
+ */
+export const SKIP_ACK_TOKEN = '__skipped__'
+
+const OPENCLAW_CONTROL_TOKENS = new Set<string>(['ANNOUNCE_SKIP', 'NO_REPLY', 'NO'])
+
+// OpenClaw Gateway has a known truncation bug that strips `NO_REPLY` to
+// variable lengths. Round 4 caught `NO_REPLY` and the fully-stripped `NO`;
+// Round 5 production showed `NO_RE` leaking through (Academic Psychologist
+// Boo emitted it twice). This regex matches any underscore-form prefix:
+//   NO_, NO_R, NO_RE, NO_REP, NO_REPL, NO_REPLY
+// Natural language doesn't write these underscore-form prefixes, so the
+// false-positive risk is zero. Bare `NO` is still matched by the canonical
+// set entry above to keep the existing semantics.
+const NO_REPLY_PREFIX_RE = /^NO_R?E?P?L?Y?$/i
+
+export function isOpenclawControlToken(text: string): boolean {
+  const trimmed = text.trim()
+  if (OPENCLAW_CONTROL_TOKENS.has(trimmed.toUpperCase())) return true
+  if (NO_REPLY_PREFIX_RE.test(trimmed)) return true
+  return false
+}
+
+export function isClawbooControlToken(text: string): boolean {
+  const t = text.trim()
+  return t === RESUME_ACK_TOKEN || t === SKIP_ACK_TOKEN
+}
+
+// Refusal regex used for short bare refusals in normal team turns. NOTE: the
+// onboarding-time regex in `TeamOnboardingGate.tsx` ALSO matches `no|nope`;
+// here we only match the longer refusal openers because bare `NO` is already
+// covered by `isOpenclawControlToken` (it's the stripped `NO_REPLY` variant
+// per OpenClaw issue tracker). Matching `no` here would over-trigger on
+// legitimate sentences starting with "No problem".
+const REFUSAL_RE = /^(nope|sorry|can'?t|cannot|unable)\b/i
+
+/** Threshold below which a refusal-shape text is treated as a leak. */
+export const MIN_SUBSTANTIVE_LENGTH = 25
+
+/**
+ * True when the text is a short refusal-shape response (likely a leak from a
+ * confused agent). The length floor (`MIN_SUBSTANTIVE_LENGTH`) prevents
+ * over-triggering on legitimate longer responses that begin with the same
+ * opener (e.g., "Sorry — I think we should re-frame this; ...").
+ */
+export function isLikelyRefusal(text: string): boolean {
+  const t = text.trim()
+  return t.length < MIN_SUBSTANTIVE_LENGTH && REFUSAL_RE.test(t)
+}
+
+/**
+ * Single render-time gate for dropping broken-shape assistant turns. Returns
+ * true if the renderer should skip the entry entirely (control tokens AND
+ * short refusal-shape leaks). The merged transcript renderer in
+ * `chatComponents.groupEntriesToBlocks` and the delegation source scanner in
+ * `buildDelegationLinkages` both call this to keep behavior consistent.
+ */
+export function shouldDropAssistantTurn(text: string): boolean {
+  return isOpenclawControlToken(text) || isClawbooControlToken(text) || isLikelyRefusal(text)
+}
 
 export function buildSilentResumeWakeMessage(params: {
   agentName: string
@@ -518,4 +665,61 @@ export function buildSelfDocumentingRelayHeader(params: {
   header +=
     '\nThe teammate finished a delegated task. Continue your own work using this update as context.'
   return header
+}
+
+/**
+ * Build a batched `[Team Update]` envelope that combines N teammate progress
+ * reports into ONE message. Used by `useTeamOrchestration`'s relay-batching
+ * path to coalesce parallel completions destined for the same hub (typically
+ * Boo Zero) inside a 3-second debounce window.
+ *
+ * Why batching matters: without it, 5 teammates finishing in parallel produce
+ * 5 separate `chat.send` calls to Boo Zero, each waking a fresh LLM turn,
+ * each generating an acknowledgment ("Got it — that's the X layer"). That
+ * was the ~576-token redundant-acknowledgment cascade observed in production.
+ * One batched envelope ⇒ one Boo Zero turn ⇒ one synthesis (or zero, per the
+ * rules block which now explicitly forbids acknowledgment-only responses).
+ *
+ * Note: each item's body is expected to be already condensed by
+ * `contextRelay.condenseSummary` before being passed in. This builder does
+ * NOT re-condense.
+ */
+export function buildBatchedRelayMessage(
+  items: Array<{
+    fromAgentName: string
+    body: string
+    taskContext?: string
+  }>,
+): string {
+  if (items.length === 0) return ''
+  if (items.length === 1) {
+    // Single-item case still goes through here when the batch window expires
+    // with only one teammate's update accumulated. Use the self-documenting
+    // single-item header for visual parity with the non-batched path.
+    const item = items[0]!
+    const header = buildSelfDocumentingRelayHeader({
+      fromAgentName: item.fromAgentName,
+      taskContext: item.taskContext,
+    })
+    return `${header}\n---\n${item.body}\n---`
+  }
+
+  const headerLines = [
+    `[Team Update] — ${items.length} teammates finished delegated tasks (not fresh user messages)`,
+    'The following are progress reports. Continue your own work using these updates as context.',
+    'Synthesize across them ONLY when the user has asked a follow-up that requires combining them, OR when you need a unified takeaway to drive the next round of delegations. Do NOT acknowledge them individually.',
+  ]
+  const sections = [headerLines.join('\n'), '---']
+  for (const item of items) {
+    let header = `@${item.fromAgentName}:`
+    if (item.taskContext) {
+      const ctx =
+        item.taskContext.length > 80 ? item.taskContext.slice(0, 80) + '...' : item.taskContext
+      header += ` (re: "${ctx}")`
+    }
+    sections.push(header)
+    sections.push(item.body)
+    sections.push('---')
+  }
+  return sections.join('\n')
 }

--- a/apps/web/src/lib/teamProtocol.ts
+++ b/apps/web/src/lib/teamProtocol.ts
@@ -216,19 +216,27 @@ a null \`kid\` header gracefully. Report back what you find.
 ### Resuming sessions
 
 OpenClaw sessions go cold when idle. Before sending you a real task, the
-orchestrator may send a brief warm-up message that looks like this:
+orchestrator sends a structured warm-up message that looks like this:
 
-> "You are resuming a team collaboration session as ${agentName} on team
-> ${teamName}. Stay quiet — the next message will be a [Team Update] or
-> a user message…"
+> "[RESUME_SIGNAL — this is NOT a user message]
+> Your session is being reactivated as ${agentName} on team "${teamName}".
+> This message is a warm-up ping, not work for you.
+>
+> REQUIRED RESPONSE: Reply with EXACTLY the single token \`__resumed__\` and
+> nothing else. No greeting. No introduction. No emoji. No acknowledgement
+> beyond that one word.
+>
+> The next message you receive will be the actual instruction. Pick up the
+> work then."
 
 **This is a session-warmup signal, not work for you to do.**
 
 When you see it:
-- Do NOT respond.
+- Reply with EXACTLY \`__resumed__\` (no other text, no whitespace, no
+  punctuation).
 - Do NOT introduce yourself.
 - Do NOT greet teammates ("Welcome aboard!", "Hey Frontend Boo!", etc.).
-- Do NOT acknowledge the re-init.
+- Do NOT acknowledge the re-init in any other way.
 
 Your prior context — this AGENTS.md, your SOUL.md, your TOOLS.md, the team
 brief — is still loaded. The next message you receive (a \`[Team Update]\`
@@ -263,12 +271,28 @@ ${rules}
  *
  * Both call sites converged on this helper to keep behavior consistent.
  */
+/**
+ * The literal token an agent should emit in response to a resume wake-up.
+ * Filtered out of the merged transcript renderer so it never pollutes the
+ * visible chat.
+ */
+export const RESUME_ACK_TOKEN = '__resumed__'
+
 export function buildSilentResumeWakeMessage(params: {
   agentName: string
   teamName: string
 }): string {
   const { agentName, teamName } = params
-  return `You are resuming a team collaboration session as ${agentName} on team "${teamName}". Stay quiet — the next message will be a [Team Update] or a user message with the real context. Continue from where you left off; do NOT introduce yourself, do NOT greet teammates, do NOT acknowledge this re-init.`
+  // Structural prompt — the LLM ignores prose "stay quiet" instructions
+  // more reliably than it ignores a literal-string contract. Pair with
+  // the AGENTS.md "Resuming sessions" rule (for team members) and the
+  // Boo Zero rules block (for the leader).
+  return `[RESUME_SIGNAL — this is NOT a user message]
+Your session is being reactivated as ${agentName} on team "${teamName}". This message is a warm-up ping, not work for you.
+
+REQUIRED RESPONSE: Reply with EXACTLY the single token \`${RESUME_ACK_TOKEN}\` and nothing else. No greeting. No introduction. No emoji. No acknowledgement beyond that one word.
+
+The next message you receive will be the actual instruction. Pick up the work then.`
 }
 
 export function buildTeamWakeMessage(params: BuildTeamWakeMessageParams): string {

--- a/apps/web/src/lib/teamRules.ts
+++ b/apps/web/src/lib/teamRules.ts
@@ -1,0 +1,107 @@
+// Team Rules — user-captured rules persisted per-team and injected into the
+// preamble of every team-chat message + every agent-to-agent delegation.
+//
+// Why this exists
+// ---------------
+// The user's corrections ("they are not sub agents", "don't do work
+// yourself") sit only in chat history. After a 7-hour gap they're outside
+// the last-8-messages window in `buildTeamContextPreamble` and effectively
+// gone. Without a durable persistence layer, the user has to repeat the
+// same correction every session — and the team makes the same mistake.
+//
+// Source of truth: SQLite settings row keyed `team-rules:<teamId>`.
+// Editable from two places:
+//   1. The Boo Zero brief panel ("Team Rules" textarea) — Maintenance view.
+//   2. The team chat composer slash command `/rule <text>` — appends a
+//      line to the team's rules in one click.
+
+const CACHE_TTL_MS = 5_000
+
+interface CacheEntry {
+  content: string
+  fetchedAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+/**
+ * Parse a draft message for the `/rule` slash command. Returns the rule
+ * text (sans the `/rule ` prefix) when matched; otherwise `null`. The
+ * prefix MUST be followed by whitespace + non-empty body to avoid
+ * misfiring on `/rule` alone or on `/ruleX`.
+ */
+export function parseRuleCommand(draft: string): string | null {
+  const trimmed = draft.trim()
+  // Require a space (not just any whitespace) after `/rule` so `/rules`
+  // or `/rule:` doesn't accidentally trigger.
+  if (!/^\/rule(\s|$)/i.test(trimmed)) return null
+  const rest = trimmed.replace(/^\/rule\s*/i, '').trim()
+  if (rest.length === 0) return null
+  return rest
+}
+
+/** Append a single rule line to existing content, deduping exact duplicates. */
+export function appendRule(existing: string, newRule: string): string {
+  const trimmedNew = newRule.trim()
+  if (!trimmedNew) return existing
+  const lines = existing
+    .split('\n')
+    .map((l) => l.replace(/^[-•*]\s*/, '').trim())
+    .filter((l) => l.length > 0)
+  if (lines.some((l) => l.toLowerCase() === trimmedNew.toLowerCase())) {
+    // Already there — no duplicate
+    return existing
+  }
+  const next = [...lines, trimmedNew].map((l) => `- ${l}`).join('\n')
+  return next
+}
+
+/**
+ * Fetch the current rules content for a team. Cached for 5 seconds so
+ * back-to-back sends don't hammer the API. Returns empty string on any
+ * failure — rules are an optional preamble, not a blocker.
+ */
+export async function fetchTeamRules(teamId: string): Promise<string> {
+  const cached = cache.get(teamId)
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.content
+  }
+  try {
+    const res = await fetch(`/api/team-rules/${encodeURIComponent(teamId)}`)
+    if (!res.ok) return ''
+    const body = (await res.json()) as { content?: string | null }
+    const content = typeof body.content === 'string' ? body.content : ''
+    cache.set(teamId, { content, fetchedAt: Date.now() })
+    return content
+  } catch {
+    return ''
+  }
+}
+
+/** PUT new rules content for a team. Invalidates the local cache. */
+export async function saveTeamRules(teamId: string, content: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/team-rules/${encodeURIComponent(teamId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    })
+    if (!res.ok) return false
+    cache.set(teamId, { content, fetchedAt: Date.now() })
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Wrap rules content in the envelope agents recognize. Returns null when empty. */
+export function buildTeamRulesBlock(content: string): string | null {
+  const trimmed = content.trim()
+  if (!trimmed) return null
+  return `[Team Rules — set by the user, authoritative]\n${trimmed}\n[End Team Rules]`
+}
+
+/** Test-only: clear the in-memory cache between test cases. */
+export function _resetTeamRulesCache(): void {
+  cache.clear()
+}

--- a/apps/web/src/stores/__tests__/chat.test.ts
+++ b/apps/web/src/stores/__tests__/chat.test.ts
@@ -32,6 +32,7 @@ describe('useChatStore', () => {
     useChatStore.setState({
       transcripts: new Map(),
       streamingText: new Map(),
+      streamStartedAt: new Map(),
       lastTokenUsage: new Map(),
     })
   })
@@ -40,6 +41,7 @@ describe('useChatStore', () => {
     const state = useChatStore.getState()
     expect(state.transcripts.size).toBe(0)
     expect(state.streamingText.size).toBe(0)
+    expect(state.streamStartedAt.size).toBe(0)
     expect(state.lastTokenUsage.size).toBe(0)
   })
 
@@ -161,6 +163,135 @@ describe('useChatStore', () => {
       expect(useChatStore.getState().lastTokenUsage.size).toBe(2)
       expect(useChatStore.getState().lastTokenUsage.get('r1')!.inputTokens).toBe(100)
       expect(useChatStore.getState().lastTokenUsage.get('r2')!.inputTokens).toBe(300)
+    })
+  })
+
+  // Round 5: stream-start timestamps moved from `lib/streamStartTracker.ts`
+  // into the chat store so renderers can subscribe reactively. The store
+  // anchors live `StreamingCard`s at their chronological position; on commit
+  // the entry's `timestampMs` reuses the same value so there's zero visible
+  // re-arrangement when the stream lands.
+  describe('setStreamStart / clearStreamStart', () => {
+    it('captures the first stream-start timestamp for a session', () => {
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      expect(useChatStore.getState().streamStartedAt.get('agent:a1:main')).toBe(1000)
+    })
+
+    it('first capture wins — subsequent setStreamStart calls do not reset', () => {
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      useChatStore.getState().setStreamStart('agent:a1:main', 1500)
+      useChatStore.getState().setStreamStart('agent:a1:main', 2000)
+      expect(useChatStore.getState().streamStartedAt.get('agent:a1:main')).toBe(1000)
+    })
+
+    it('clearStreamStart removes the anchor', () => {
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      useChatStore.getState().clearStreamStart('agent:a1:main')
+      expect(useChatStore.getState().streamStartedAt.has('agent:a1:main')).toBe(false)
+    })
+
+    it('the next stream after clear re-anchors from scratch', () => {
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      useChatStore.getState().clearStreamStart('agent:a1:main')
+      useChatStore.getState().setStreamStart('agent:a1:main', 5000)
+      expect(useChatStore.getState().streamStartedAt.get('agent:a1:main')).toBe(5000)
+    })
+
+    it('clearStreamStart is a no-op when the session has no anchor', () => {
+      const before = useChatStore.getState().streamStartedAt
+      useChatStore.getState().clearStreamStart('agent:nonexistent:main')
+      // Reference stays identical when nothing changed (Round 5 contract).
+      expect(useChatStore.getState().streamStartedAt).toBe(before)
+    })
+
+    it('isolates sessions — capturing one does not leak into another', () => {
+      useChatStore.getState().setStreamStart('agent:leader:team:t1', 1000)
+      useChatStore.getState().setStreamStart('agent:specialist:team:t1', 1500)
+      expect(useChatStore.getState().streamStartedAt.get('agent:leader:team:t1')).toBe(1000)
+      expect(useChatStore.getState().streamStartedAt.get('agent:specialist:team:t1')).toBe(1500)
+    })
+
+    it("clearTranscript also wipes the session's stream-start anchor", () => {
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      useChatStore.getState().clearTranscript('agent:a1:main')
+      expect(useChatStore.getState().streamStartedAt.has('agent:a1:main')).toBe(false)
+    })
+
+    it('emits a new state reference (renderers re-subscribe correctly)', () => {
+      const before = useChatStore.getState().streamStartedAt
+      useChatStore.getState().setStreamStart('agent:a1:main', 1000)
+      const after = useChatStore.getState().streamStartedAt
+      expect(after).not.toBe(before)
+    })
+  })
+
+  // Round 7: setClawbooDispatch + clearClawbooDispatches. The store records
+  // every `chat.send` Clawboo fires to a team specialist so the renderer
+  // can surface those events as DelegationCards (Path 3 in
+  // `buildDelegationLinkages`), independent of LLM emission format.
+  describe('setClawbooDispatch / clearClawbooDispatches', () => {
+    beforeEach(() => {
+      useChatStore.setState({
+        clawbooDispatches: new Map(),
+      })
+    })
+
+    function makeDispatch(overrides: Partial<import('../chat').ClawbooDispatch> = {}) {
+      return {
+        dispatchId: 'd-' + Math.random().toString(36).slice(2, 9),
+        sourceEntryId: 'src-1',
+        sourceAgentId: 'bz',
+        targetAgentId: 'eng',
+        targetAgentName: 'Engineer Boo',
+        taskBody: 'do the thing',
+        origin: 'dispatch-delegation' as const,
+        sequenceKey: 1,
+        timestampMs: 1_700_000_000_000,
+        teamId: 't1',
+        ...overrides,
+      }
+    }
+
+    it('stores a dispatch under the `${teamId}:${sourceEntryId}` key', () => {
+      const dispatch = makeDispatch()
+      useChatStore.getState().setClawbooDispatch(dispatch)
+      const stored = useChatStore.getState().clawbooDispatches.get('t1:src-1')
+      expect(stored).toHaveLength(1)
+      expect(stored![0]).toBe(dispatch)
+    })
+
+    it('accumulates multiple dispatches under the same source entry', () => {
+      useChatStore
+        .getState()
+        .setClawbooDispatch(makeDispatch({ dispatchId: 'd-a', targetAgentId: 'eng' }))
+      useChatStore
+        .getState()
+        .setClawbooDispatch(makeDispatch({ dispatchId: 'd-b', targetAgentId: 'des' }))
+      useChatStore
+        .getState()
+        .setClawbooDispatch(makeDispatch({ dispatchId: 'd-c', targetAgentId: 'his' }))
+      const stored = useChatStore.getState().clawbooDispatches.get('t1:src-1')
+      expect(stored).toHaveLength(3)
+      expect(stored!.map((d) => d.dispatchId)).toEqual(['d-a', 'd-b', 'd-c'])
+    })
+
+    it('dedups by dispatchId — a retry with the same id is a no-op', () => {
+      const dispatch = makeDispatch()
+      useChatStore.getState().setClawbooDispatch(dispatch)
+      useChatStore.getState().setClawbooDispatch(dispatch)
+      useChatStore.getState().setClawbooDispatch(dispatch)
+      expect(useChatStore.getState().clawbooDispatches.get('t1:src-1')).toHaveLength(1)
+    })
+
+    it('clearClawbooDispatches(teamId) wipes only that team — other teams untouched', () => {
+      useChatStore.getState().setClawbooDispatch(makeDispatch({ teamId: 't1', sourceEntryId: 'a' }))
+      useChatStore.getState().setClawbooDispatch(makeDispatch({ teamId: 't1', sourceEntryId: 'b' }))
+      useChatStore.getState().setClawbooDispatch(makeDispatch({ teamId: 't2', sourceEntryId: 'a' }))
+      useChatStore.getState().clearClawbooDispatches('t1')
+      expect(useChatStore.getState().clawbooDispatches.has('t1:a')).toBe(false)
+      expect(useChatStore.getState().clawbooDispatches.has('t1:b')).toBe(false)
+      // t2 still there.
+      expect(useChatStore.getState().clawbooDispatches.has('t2:a')).toBe(true)
     })
   })
 })

--- a/apps/web/src/stores/__tests__/chat.test.ts
+++ b/apps/web/src/stores/__tests__/chat.test.ts
@@ -408,4 +408,126 @@ describe('useChatStore', () => {
       expect(useChatStore.getState().pendingPlans.size).toBe(0)
     })
   })
+
+  // Round 10: parallel-workstreams state machine actions.
+  describe('setPendingWorkstreams / resolveWorkstreamTarget / clearPendingWorkstreams', () => {
+    beforeEach(() => {
+      useChatStore.setState({
+        pendingWorkstreams: new Map(),
+      })
+    })
+
+    function makeWorkstreams(
+      overrides: Partial<import('../chat').PendingWorkstreams> = {},
+    ): import('../chat').PendingWorkstreams {
+      return {
+        workstreamId: 't1:src-1:workstreams',
+        sourceEntryId: 'src-1',
+        sourceAgentId: 'bz',
+        teamId: 't1',
+        targets: [
+          {
+            targetAgentId: 'a',
+            targetAgentName: 'A',
+            task: 'workstream 1 task',
+            output: null,
+            resolvedEntryId: null,
+          },
+          {
+            targetAgentId: 'b',
+            targetAgentName: 'B',
+            task: 'workstream 2 task',
+            output: null,
+            resolvedEntryId: null,
+          },
+          {
+            targetAgentId: 'c',
+            targetAgentName: 'C',
+            task: 'workstream 3 task',
+            output: null,
+            resolvedEntryId: null,
+          },
+        ],
+        timestampMs: 1_700_000_000_000,
+        ...overrides,
+      }
+    }
+
+    it('stores a new workstreams record by workstreamId', () => {
+      const ws = makeWorkstreams()
+      useChatStore.getState().setPendingWorkstreams(ws)
+      expect(useChatStore.getState().pendingWorkstreams.get(ws.workstreamId)).toBe(ws)
+    })
+
+    it('setPendingWorkstreams is idempotent — re-registering preserves resolved targets', () => {
+      const ws = makeWorkstreams()
+      useChatStore.getState().setPendingWorkstreams(ws)
+      // Resolve target 'b' to capture in-flight progress.
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'b', 'B output', 'reply-b')
+      // Re-registering the SAME workstreamId must NOT clobber progress.
+      useChatStore.getState().setPendingWorkstreams(ws)
+      const after = useChatStore.getState().pendingWorkstreams.get(ws.workstreamId)!
+      expect(after.targets[1]!.resolvedEntryId).toBe('reply-b')
+      expect(after.targets[1]!.output).toBe('B output')
+    })
+
+    it('resolveWorkstreamTarget stores output for any target (parallel, no ordering)', () => {
+      const ws = makeWorkstreams()
+      useChatStore.getState().setPendingWorkstreams(ws)
+      // Resolve out-of-order: target C first, then A — parallel semantics
+      // don't care which lands first.
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'c', 'C result', 'reply-c')
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'a', 'A result', 'reply-a')
+      const after = useChatStore.getState().pendingWorkstreams.get(ws.workstreamId)!
+      expect(after.targets[0]!.output).toBe('A result')
+      expect(after.targets[0]!.resolvedEntryId).toBe('reply-a')
+      expect(after.targets[2]!.output).toBe('C result')
+      expect(after.targets[2]!.resolvedEntryId).toBe('reply-c')
+      // Target B is still unresolved.
+      expect(after.targets[1]!.resolvedEntryId).toBeNull()
+    })
+
+    it('resolveWorkstreamTarget is idempotent — same payload is a no-op', () => {
+      const ws = makeWorkstreams()
+      useChatStore.getState().setPendingWorkstreams(ws)
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'a', 'A result', 'reply-a')
+      const after1 = useChatStore.getState().pendingWorkstreams
+      // Re-fire with the same payload — store should return the previous state ref.
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'a', 'A result', 'reply-a')
+      const after2 = useChatStore.getState().pendingWorkstreams
+      expect(after2).toBe(after1)
+    })
+
+    it('resolveWorkstreamTarget is a no-op for unknown workstream or target', () => {
+      const ws = makeWorkstreams()
+      useChatStore.getState().setPendingWorkstreams(ws)
+      const before = useChatStore.getState().pendingWorkstreams
+      // Unknown workstream id.
+      useChatStore.getState().resolveWorkstreamTarget('nonexistent', 'a', 'x', 'y')
+      // Unknown target agent id on a known workstream.
+      useChatStore.getState().resolveWorkstreamTarget(ws.workstreamId, 'never-in-team', 'x', 'y')
+      const after = useChatStore.getState().pendingWorkstreams
+      expect(after).toBe(before)
+    })
+
+    it('clearPendingWorkstreams(teamId) wipes only that team — other teams untouched', () => {
+      useChatStore
+        .getState()
+        .setPendingWorkstreams(makeWorkstreams({ workstreamId: 't1:w1', teamId: 't1' }))
+      useChatStore
+        .getState()
+        .setPendingWorkstreams(makeWorkstreams({ workstreamId: 't1:w2', teamId: 't1' }))
+      useChatStore
+        .getState()
+        .setPendingWorkstreams(makeWorkstreams({ workstreamId: 't2:w1', teamId: 't2' }))
+      useChatStore.getState().clearPendingWorkstreams('t1')
+      expect(useChatStore.getState().pendingWorkstreams.has('t1:w1')).toBe(false)
+      expect(useChatStore.getState().pendingWorkstreams.has('t1:w2')).toBe(false)
+      expect(useChatStore.getState().pendingWorkstreams.has('t2:w1')).toBe(true)
+    })
+
+    it('initial state has empty pendingWorkstreams', () => {
+      expect(useChatStore.getState().pendingWorkstreams.size).toBe(0)
+    })
+  })
 })

--- a/apps/web/src/stores/__tests__/chat.test.ts
+++ b/apps/web/src/stores/__tests__/chat.test.ts
@@ -294,4 +294,118 @@ describe('useChatStore', () => {
       expect(useChatStore.getState().clawbooDispatches.has('t2:a')).toBe(true)
     })
   })
+
+  // Round 8B: pending-plan state machine actions.
+  describe('setPendingPlan / resolvePlanStep / clearPendingPlans', () => {
+    beforeEach(() => {
+      useChatStore.setState({
+        pendingPlans: new Map(),
+      })
+    })
+
+    function makePlan(overrides: Partial<import('../chat').PendingPlan> = {}) {
+      return {
+        planId: 't1:src-1:plan:0',
+        sourceEntryId: 'src-1',
+        sourceAgentId: 'bz',
+        teamId: 't1',
+        steps: [
+          {
+            targetName: 'A',
+            targetAgentId: 'a',
+            task: 'step 1',
+            output: null,
+            resolvedEntryId: null,
+          },
+          {
+            targetName: 'B',
+            targetAgentId: 'b',
+            task: 'step 2',
+            output: null,
+            resolvedEntryId: null,
+          },
+          {
+            targetName: 'C',
+            targetAgentId: 'c',
+            task: 'step 3',
+            output: null,
+            resolvedEntryId: null,
+          },
+        ],
+        currentStepIndex: 0,
+        timestampMs: 1_700_000_000_000,
+        ...overrides,
+      }
+    }
+
+    it('stores a new plan by planId', () => {
+      const plan = makePlan()
+      useChatStore.getState().setPendingPlan(plan)
+      expect(useChatStore.getState().pendingPlans.get(plan.planId)).toBe(plan)
+    })
+
+    it('setPendingPlan is idempotent — re-registering same planId is a no-op (preserves progress)', () => {
+      const plan = makePlan()
+      useChatStore.getState().setPendingPlan(plan)
+      // Manually advance progress
+      useChatStore.getState().resolvePlanStep(plan.planId, 0, 'output from A', 'reply-a')
+      // Attempt re-register with the SAME planId — should NOT clobber progress
+      useChatStore.getState().setPendingPlan(plan)
+      const after = useChatStore.getState().pendingPlans.get(plan.planId)!
+      expect(after.currentStepIndex).toBe(1)
+      expect(after.steps[0]!.output).toBe('output from A')
+    })
+
+    it('resolvePlanStep stores output + advances currentStepIndex when resolving the head step', () => {
+      const plan = makePlan()
+      useChatStore.getState().setPendingPlan(plan)
+      useChatStore.getState().resolvePlanStep(plan.planId, 0, 'A produced this', 'reply-a')
+      const after = useChatStore.getState().pendingPlans.get(plan.planId)!
+      expect(after.steps[0]!.output).toBe('A produced this')
+      expect(after.steps[0]!.resolvedEntryId).toBe('reply-a')
+      expect(after.currentStepIndex).toBe(1)
+    })
+
+    it('resolvePlanStep is idempotent — same resolution data does not double-advance', () => {
+      const plan = makePlan()
+      useChatStore.getState().setPendingPlan(plan)
+      useChatStore.getState().resolvePlanStep(plan.planId, 0, 'A produced this', 'reply-a')
+      useChatStore.getState().resolvePlanStep(plan.planId, 0, 'A produced this', 'reply-a')
+      const after = useChatStore.getState().pendingPlans.get(plan.planId)!
+      expect(after.currentStepIndex).toBe(1) // not 2
+    })
+
+    it('resolvePlanStep does NOT advance currentStepIndex for out-of-order resolutions', () => {
+      const plan = makePlan()
+      useChatStore.getState().setPendingPlan(plan)
+      // Resolve step 2 before step 0 — rare but possible if a later target
+      // replies first. We store the output but don't advance the head.
+      useChatStore.getState().resolvePlanStep(plan.planId, 2, 'C result', 'reply-c')
+      const after = useChatStore.getState().pendingPlans.get(plan.planId)!
+      expect(after.currentStepIndex).toBe(0)
+      expect(after.steps[2]!.output).toBe('C result')
+    })
+
+    it('resolvePlanStep is a no-op for unknown plan or step index', () => {
+      const before = useChatStore.getState().pendingPlans
+      useChatStore.getState().resolvePlanStep('nonexistent', 0, 'x', 'y')
+      const after = useChatStore.getState().pendingPlans
+      expect(after).toBe(before) // same ref
+    })
+
+    it('clearPendingPlans(teamId) wipes only that team — other teams untouched', () => {
+      useChatStore.getState().setPendingPlan(makePlan({ planId: 't1:p1', teamId: 't1' }))
+      useChatStore.getState().setPendingPlan(makePlan({ planId: 't1:p2', teamId: 't1' }))
+      useChatStore.getState().setPendingPlan(makePlan({ planId: 't2:p1', teamId: 't2' }))
+      useChatStore.getState().clearPendingPlans('t1')
+      expect(useChatStore.getState().pendingPlans.has('t1:p1')).toBe(false)
+      expect(useChatStore.getState().pendingPlans.has('t1:p2')).toBe(false)
+      expect(useChatStore.getState().pendingPlans.has('t2:p1')).toBe(true)
+    })
+
+    it('initial state has empty pendingPlans', () => {
+      // beforeEach reset → empty.
+      expect(useChatStore.getState().pendingPlans.size).toBe(0)
+    })
+  })
 })

--- a/apps/web/src/stores/chat.ts
+++ b/apps/web/src/stores/chat.ts
@@ -40,6 +40,57 @@ export interface ClawbooDispatch {
   teamId: string
 }
 
+// ─── Round 8B: pending plan state ─────────────────────────────────────────
+//
+// When the leader emits a `<plan>` block (one or more `<step to="@X">…`
+// children), Clawboo captures the steps and progresses through them
+// automatically — firing step N+1 each time step N's specialist responds.
+// State machine lives here so:
+//   • The state survives across the `useTeamOrchestration` debounce window
+//     (refs would reset on the hook re-mount that happens on team switch).
+//   • The renderer can subscribe and show a step-tracker card per plan.
+//   • Stop / team-switch clears everything (`clearPendingPlans(teamId)`).
+//
+// One pending plan per leader-source-entry: keyed by `${teamId}:${sourceEntryId}`.
+// `currentStepIndex` advances 0 → 1 → … → steps.length. When it equals
+// `steps.length`, the plan is "complete" and the leader gets a final
+// `[Plan Complete]` envelope (assembled from each step's output) so it can
+// do final synthesis.
+
+export interface PendingPlanStep {
+  /** The agent name as written in `to="…"`. */
+  targetName: string
+  /** Resolved roster id (or null if the name didn't match any participant). */
+  targetAgentId: string | null
+  /** Task body emitted by the leader. */
+  task: string
+  /** Output text from the specialist when the step completes. Null until then. */
+  output: string | null
+  /** entryId of the specialist's response that satisfied this step (claim anchor). */
+  resolvedEntryId: string | null
+}
+
+export interface PendingPlan {
+  /** Stable id for React keys + dispatch records. */
+  planId: string
+  /** entryId of the leader entry that emitted the `<plan>` block. */
+  sourceEntryId: string
+  /** Agent id of the leader (the source). */
+  sourceAgentId: string
+  /** Team id — used for cleanup + dispatch keys. */
+  teamId: string
+  /** Steps in source order. Mutated as the plan progresses. */
+  steps: PendingPlanStep[]
+  /**
+   * Index of the step currently in flight (0-based). When `>= steps.length`,
+   * the plan is complete and the `[Plan Complete]` envelope has been sent
+   * to the leader.
+   */
+  currentStepIndex: number
+  /** Timestamp when the plan was captured (used as the dispatch anchor). */
+  timestampMs: number
+}
+
 // ─── Store ────────────────────────────────────────────────────────────────────
 // Keyed by sessionKey so multiple agent conversations are held simultaneously.
 
@@ -72,6 +123,15 @@ interface ChatStore {
    * Path 3 source for `DelegationCard` rendering.
    */
   clawbooDispatches: Map<string, ClawbooDispatch[]>
+  /**
+   * Round 8B: in-progress `<plan>` state machines, keyed by `planId` (one
+   * plan per leader-source-entry). Each plan progresses one step at a time
+   * — when step N's specialist responds, Clawboo fires step N+1 with the
+   * prior output piped in. When all steps complete, the leader receives a
+   * `[Plan Complete]` envelope cueing final synthesis. See
+   * `useTeamOrchestration` for the state-machine wiring.
+   */
+  pendingPlans: Map<string, PendingPlan>
   /** Token usage from final chat events, keyed by runId. */
   lastTokenUsage: Map<string, { inputTokens: number; outputTokens: number }>
 
@@ -111,6 +171,32 @@ interface ChatStore {
    */
   clearClawbooDispatches: (teamId: string) => void
 
+  /**
+   * Round 8B: register a new pending plan when the leader emits a
+   * `<plan>` block. `useTeamOrchestration` calls this immediately after
+   * parsing, then fires step 1.
+   */
+  setPendingPlan: (plan: PendingPlan) => void
+
+  /**
+   * Round 8B: mark a step as resolved with the specialist's output. The
+   * orchestration hook calls this when it observes the specialist's reply
+   * for the in-flight step. The store also bumps `currentStepIndex` so the
+   * hook's next subscription tick fires step N+1.
+   */
+  resolvePlanStep: (
+    planId: string,
+    stepIndex: number,
+    output: string,
+    resolvedEntryId: string,
+  ) => void
+
+  /**
+   * Round 8B: clear all plans for a team. Fired on Stop and on team-switch
+   * (mirrors `clearClawbooDispatches`).
+   */
+  clearPendingPlans: (teamId: string) => void
+
   /** Store token usage for a completed run. */
   setLastTokenUsage: (runId: string, inputTokens: number, outputTokens: number) => void
 }
@@ -120,6 +206,7 @@ export const useChatStore = create<ChatStore>((set) => ({
   streamingText: new Map(),
   streamStartedAt: new Map(),
   clawbooDispatches: new Map(),
+  pendingPlans: new Map(),
   lastTokenUsage: new Map(),
 
   appendTranscript: (sessionKey, entries) =>
@@ -279,6 +366,60 @@ export const useChatStore = create<ChatStore>((set) => ({
       }
       if (!changed) return state
       return { clawbooDispatches: next }
+    }),
+
+  setPendingPlan: (plan) =>
+    set((state) => {
+      // Idempotent — if a plan with the same id is already registered (e.g.,
+      // the orchestration hook re-parsed the same leader entry after a
+      // page reload), keep the existing one to preserve `output` /
+      // `resolvedEntryId` / `currentStepIndex` progress.
+      if (state.pendingPlans.has(plan.planId)) return state
+      const next = new Map(state.pendingPlans)
+      next.set(plan.planId, plan)
+      return { pendingPlans: next }
+    }),
+
+  resolvePlanStep: (planId, stepIndex, output, resolvedEntryId) =>
+    set((state) => {
+      const existing = state.pendingPlans.get(planId)
+      if (!existing) return state
+      const step = existing.steps[stepIndex]
+      if (!step) return state
+      // Idempotent — already resolved (same output) → no state change.
+      if (step.resolvedEntryId === resolvedEntryId && step.output === output) return state
+      const nextSteps = existing.steps.map((s, i) =>
+        i === stepIndex ? { ...s, output, resolvedEntryId } : s,
+      )
+      const nextPlan: PendingPlan = {
+        ...existing,
+        steps: nextSteps,
+        // Advance to the next step only if THIS one is the in-flight head.
+        // Out-of-order resolves (a later step's response arrives first) are
+        // possible in theory but rare; we let the hook re-fire the head step
+        // until it lands.
+        currentStepIndex:
+          stepIndex === existing.currentStepIndex
+            ? existing.currentStepIndex + 1
+            : existing.currentStepIndex,
+      }
+      const next = new Map(state.pendingPlans)
+      next.set(planId, nextPlan)
+      return { pendingPlans: next }
+    }),
+
+  clearPendingPlans: (teamId) =>
+    set((state) => {
+      const next = new Map(state.pendingPlans)
+      let changed = false
+      for (const [planId, plan] of next) {
+        if (plan.teamId === teamId) {
+          next.delete(planId)
+          changed = true
+        }
+      }
+      if (!changed) return state
+      return { pendingPlans: next }
     }),
 
   setLastTokenUsage: (runId, inputTokens, outputTokens) =>

--- a/apps/web/src/stores/chat.ts
+++ b/apps/web/src/stores/chat.ts
@@ -38,6 +38,35 @@ export interface ClawbooDispatch {
   timestampMs: number
   /** Team id — used by `clearClawbooDispatches(teamId)` on Stop / team switch. */
   teamId: string
+  /**
+   * Round 9: when this dispatch is one step of a `<plan>` block, carries
+   * the parent plan's id so the renderer can group all step-dispatches
+   * for the same plan into a single PlanCard. Null/undefined for one-shot
+   * dispatches (regular `<delegate>` blocks, fallback regex matches,
+   * relay batches).
+   */
+  planId?: string | null
+  /**
+   * Round 9: the step's index within the parent plan (0-based). The
+   * renderer uses this to order step cards under the PlanCard header even
+   * if dispatches arrive out of source order. Paired with `planId`.
+   */
+  planStepIndex?: number | null
+  /**
+   * Round 10: when this dispatch is one target of a parallel workstream
+   * batch (≥2 sibling `<delegate>` tags emitted in one leader turn, no
+   * `<plan>` wrapper), carries the parent workstream's id so the renderer
+   * groups all sibling-dispatches for the same workstream into a single
+   * `WorkstreamCard`. Null/undefined for one-shot delegations.
+   */
+  workstreamId?: string | null
+  /**
+   * Round 10: the target's index within the parent workstream (0-based).
+   * Order is "source order" — first `<delegate>` tag in the leader turn is
+   * index 0, etc. Used by the renderer to render `Workstream N` labels
+   * stably even when dispatches arrive out of order.
+   */
+  workstreamTargetIndex?: number | null
 }
 
 // ─── Round 8B: pending plan state ─────────────────────────────────────────
@@ -91,6 +120,53 @@ export interface PendingPlan {
   timestampMs: number
 }
 
+// ─── Round 10: parallel workstreams state ────────────────────────────────────
+//
+// When the leader emits ≥2 sibling `<delegate>` tags in ONE turn — without a
+// `<plan>` wrapper — Clawboo captures them as a "workstream batch". Each
+// target works independently in parallel; there's no ordering, just an
+// in-flight set. When ALL targets respond, the leader receives a
+// `[Workstreams Complete]` envelope (mirror of `[Plan Complete]`) so it can
+// synthesize across them. Without this, Round 4/5's silence-on-relay rule
+// leaves the leader silent after parallel work resolves — the production
+// "talk is cheap, show me what you can do" failure mode.
+//
+// One pending workstreams record per leader-source-entry:
+// keyed by `${teamId}:${sourceEntryId}:workstreams` (the `:workstreams`
+// suffix keeps the id distinct from any plan id on the same source).
+
+export interface WorkstreamTarget {
+  /** Resolved roster id (or null if the `to=` name didn't match). */
+  targetAgentId: string | null
+  /** Resolved roster name of the target (for display + the complete envelope). */
+  targetAgentName: string
+  /** Task body emitted by the leader (verbatim from the `<delegate>` body). */
+  task: string
+  /** Output text from the specialist when the target completes. Null until then. */
+  output: string | null
+  /** entryId of the specialist's response that satisfied this target. */
+  resolvedEntryId: string | null
+}
+
+export interface PendingWorkstreams {
+  /** Stable id for React keys + dispatch records. */
+  workstreamId: string
+  /** entryId of the leader entry that emitted the parallel delegations. */
+  sourceEntryId: string
+  /** Agent id of the leader (the source). */
+  sourceAgentId: string
+  /** Team id — used for cleanup + dispatch keys. */
+  teamId: string
+  /** Targets in source order (first `<delegate>` is index 0, etc.). */
+  targets: WorkstreamTarget[]
+  /**
+   * Timestamp when the workstream was captured. Used as the "after" anchor
+   * for the progression pass's `findFreshResponse` — specialists' replies
+   * with timestamps >= this are eligible to resolve a target.
+   */
+  timestampMs: number
+}
+
 // ─── Store ────────────────────────────────────────────────────────────────────
 // Keyed by sessionKey so multiple agent conversations are held simultaneously.
 
@@ -132,6 +208,15 @@ interface ChatStore {
    * `useTeamOrchestration` for the state-machine wiring.
    */
   pendingPlans: Map<string, PendingPlan>
+  /**
+   * Round 10: in-progress parallel-workstream state machines, keyed by
+   * `workstreamId`. One record per leader turn that emitted ≥2 sibling
+   * `<delegate>` tags. Targets resolve independently; when all targets
+   * resolve, the leader receives a `[Workstreams Complete]` envelope.
+   * Mutually exclusive with `pendingPlans` on the same source entry
+   * (`planBlocks.length === 0` gate in `useTeamOrchestration`).
+   */
+  pendingWorkstreams: Map<string, PendingWorkstreams>
   /** Token usage from final chat events, keyed by runId. */
   lastTokenUsage: Map<string, { inputTokens: number; outputTokens: number }>
 
@@ -197,6 +282,32 @@ interface ChatStore {
    */
   clearPendingPlans: (teamId: string) => void
 
+  /**
+   * Round 10: register a new pending-workstreams record when the leader
+   * fires ≥2 parallel `<delegate>` tags in one turn (no `<plan>` wrapper).
+   * Idempotent — preserves progress on re-register (e.g., the orchestration
+   * subscription tick re-processes the same leader entry).
+   */
+  setPendingWorkstreams: (workstreams: PendingWorkstreams) => void
+
+  /**
+   * Round 10: mark one target as resolved with the specialist's output.
+   * Called by the orchestration progression pass when it observes a fresh
+   * substantive response from the target.
+   */
+  resolveWorkstreamTarget: (
+    workstreamId: string,
+    targetAgentId: string,
+    output: string,
+    resolvedEntryId: string,
+  ) => void
+
+  /**
+   * Round 10: clear all workstreams for a team. Fired on Stop and on
+   * team-switch (mirrors `clearPendingPlans` / `clearClawbooDispatches`).
+   */
+  clearPendingWorkstreams: (teamId: string) => void
+
   /** Store token usage for a completed run. */
   setLastTokenUsage: (runId: string, inputTokens: number, outputTokens: number) => void
 }
@@ -207,6 +318,7 @@ export const useChatStore = create<ChatStore>((set) => ({
   streamStartedAt: new Map(),
   clawbooDispatches: new Map(),
   pendingPlans: new Map(),
+  pendingWorkstreams: new Map(),
   lastTokenUsage: new Map(),
 
   appendTranscript: (sessionKey, entries) =>
@@ -420,6 +532,49 @@ export const useChatStore = create<ChatStore>((set) => ({
       }
       if (!changed) return state
       return { pendingPlans: next }
+    }),
+
+  setPendingWorkstreams: (workstreams) =>
+    set((state) => {
+      // Idempotent — preserve progress (resolved targets) on re-register so
+      // the orchestration subscription tick re-processing the same source
+      // entry doesn't wipe in-flight state.
+      if (state.pendingWorkstreams.has(workstreams.workstreamId)) return state
+      const next = new Map(state.pendingWorkstreams)
+      next.set(workstreams.workstreamId, workstreams)
+      return { pendingWorkstreams: next }
+    }),
+
+  resolveWorkstreamTarget: (workstreamId, targetAgentId, output, resolvedEntryId) =>
+    set((state) => {
+      const existing = state.pendingWorkstreams.get(workstreamId)
+      if (!existing) return state
+      const idx = existing.targets.findIndex((t) => t.targetAgentId === targetAgentId)
+      if (idx < 0) return state
+      const target = existing.targets[idx]
+      if (!target) return state
+      // Idempotent — already resolved with the same payload.
+      if (target.resolvedEntryId === resolvedEntryId && target.output === output) return state
+      const nextTargets = existing.targets.map((t, i) =>
+        i === idx ? { ...t, output, resolvedEntryId } : t,
+      )
+      const next = new Map(state.pendingWorkstreams)
+      next.set(workstreamId, { ...existing, targets: nextTargets })
+      return { pendingWorkstreams: next }
+    }),
+
+  clearPendingWorkstreams: (teamId) =>
+    set((state) => {
+      const next = new Map(state.pendingWorkstreams)
+      let changed = false
+      for (const [wsId, ws] of next) {
+        if (ws.teamId === teamId) {
+          next.delete(wsId)
+          changed = true
+        }
+      }
+      if (!changed) return state
+      return { pendingWorkstreams: next }
     }),
 
   setLastTokenUsage: (runId, inputTokens, outputTokens) =>

--- a/apps/web/src/stores/chat.ts
+++ b/apps/web/src/stores/chat.ts
@@ -1,6 +1,45 @@
 import { create } from 'zustand'
 import type { TranscriptEntry } from '@clawboo/protocol'
 
+// ─── Clawboo dispatch event ──────────────────────────────────────────────────
+//
+// Round 7: when Clawboo itself fires `chat.send` to a team specialist —
+// either via `dispatchDelegation` (a parsed `<delegate>` tag) or via
+// `flushRelayBatch` (forwarding the leader's response as a `[Team Update]`
+// envelope) — we record the routing event here. The renderer
+// (`buildDelegationLinkages`) consumes the map as a third synthesis source
+// alongside `<delegate>` tags and `sessions_send` tool entries, so
+// `DelegationCard`s reflect actual Clawboo routing regardless of what the
+// LLM emits in its prose.
+//
+// Wake events (`wakeTeamAgents` in `groupChatSendOperation.ts`) are
+// intentionally NOT recorded — those carry the `[RESUME_SIGNAL]` body and
+// the target's expected reply is `__resumed__` (filtered). Recording them
+// would render 5 empty cards per user message.
+
+export interface ClawbooDispatch {
+  /** Stable id for React keys + linkage dedup. */
+  dispatchId: string
+  /** entryId of the leader's transcript entry that triggered the dispatch. */
+  sourceEntryId: string
+  /** Agent id of the leader (the source). */
+  sourceAgentId: string
+  /** Agent id of the team specialist that received the chat.send. */
+  targetAgentId: string
+  /** Resolved roster name of the target. */
+  targetAgentName: string
+  /** The message body Clawboo sent (the task or relay summary). */
+  taskBody: string
+  /** Origin of the dispatch — affects visual badge in DelegationCard. */
+  origin: 'dispatch-delegation' | 'relay-batch'
+  /** Monotonic sequence key (lib/sequenceKey.ts) so target-response accrual works. */
+  sequenceKey: number
+  /** Timestamp when Clawboo fired the send. */
+  timestampMs: number
+  /** Team id — used by `clearClawbooDispatches(teamId)` on Stop / team switch. */
+  teamId: string
+}
+
 // ─── Store ────────────────────────────────────────────────────────────────────
 // Keyed by sessionKey so multiple agent conversations are held simultaneously.
 
@@ -9,6 +48,30 @@ interface ChatStore {
   transcripts: Map<string, TranscriptEntry[]>
   /** Live streaming text that hasn't been committed yet, keyed by sessionKey. */
   streamingText: Map<string, string>
+  /**
+   * Stream-start timestamp per session (ms since epoch). Captured on the
+   * FIRST streaming chunk for a session and used by:
+   *   1. `useGatewayEvents.appendOutputLines` to anchor the eventual
+   *      committed entry's `timestampMs` (so a long-streaming leader sorts
+   *      ABOVE fast specialists that wake mid-stream and commit first).
+   *   2. The renderer (`GroupChatPanel`, `chatComponents.MessageList`) to
+   *      position the live `StreamingCard` at its chronological slot in the
+   *      merged timeline — instead of always-at-the-end, which produced the
+   *      visible "leader's card jumps from bottom to top" re-arrangement
+   *      on commit (Round 5 production bug).
+   * Moved from `lib/streamStartTracker.ts` module-level Map (which wasn't
+   * reactive to React) so the renderer subscribes via Zustand.
+   */
+  streamStartedAt: Map<string, number>
+  /**
+   * Round 7: Clawboo's outgoing routing events, keyed by
+   * `${teamId}:${sourceEntryId}` so each leader entry can accumulate
+   * multiple dispatches (e.g., one Boo Zero turn triggering 5 relays).
+   * Populated by `useTeamOrchestration` whenever Clawboo fires `chat.send`
+   * to a team specialist. Consumed by `buildDelegationLinkages` as the
+   * Path 3 source for `DelegationCard` rendering.
+   */
+  clawbooDispatches: Map<string, ClawbooDispatch[]>
   /** Token usage from final chat events, keyed by runId. */
   lastTokenUsage: Map<string, { inputTokens: number; outputTokens: number }>
 
@@ -18,8 +81,35 @@ interface ChatStore {
   /** Set (or clear) the live streaming text for a session. */
   setStreamingText: (sessionKey: string, text: string | null) => void
 
+  /**
+   * Capture the first streaming chunk's timestamp. No-op if a stream-start
+   * is already recorded for this session (preserves the original anchor
+   * across mid-stream patches).
+   */
+  setStreamStart: (sessionKey: string, ts: number) => void
+
+  /**
+   * Clear the stream-start anchor — called at commit time AFTER
+   * `appendOutputLines` has read the value so the next streamed turn for
+   * the same session re-anchors from scratch.
+   */
+  clearStreamStart: (sessionKey: string) => void
+
   /** Wipe all transcript + streaming state for a session. */
   clearTranscript: (sessionKey: string) => void
+
+  /**
+   * Record one Clawboo outgoing routing event under the appropriate
+   * `${teamId}:${sourceEntryId}` key. Multiple dispatches accumulate per
+   * key (one source entry can route to many targets).
+   */
+  setClawbooDispatch: (dispatch: ClawbooDispatch) => void
+
+  /**
+   * Clear ALL dispatches for a given team. Fired on Stop and on team
+   * switch so zombie cards from cancelled work don't persist.
+   */
+  clearClawbooDispatches: (teamId: string) => void
 
   /** Store token usage for a completed run. */
   setLastTokenUsage: (runId: string, inputTokens: number, outputTokens: number) => void
@@ -28,6 +118,8 @@ interface ChatStore {
 export const useChatStore = create<ChatStore>((set) => ({
   transcripts: new Map(),
   streamingText: new Map(),
+  streamStartedAt: new Map(),
+  clawbooDispatches: new Map(),
   lastTokenUsage: new Map(),
 
   appendTranscript: (sessionKey, entries) =>
@@ -128,13 +220,65 @@ export const useChatStore = create<ChatStore>((set) => ({
       return { streamingText: next }
     }),
 
+  setStreamStart: (sessionKey, ts) =>
+    set((state) => {
+      // First-capture-wins: if a stream-start is already recorded, don't
+      // overwrite. Mid-stream patches keep arriving but the original anchor
+      // is what positions the card.
+      if (state.streamStartedAt.has(sessionKey)) return state
+      const next = new Map(state.streamStartedAt)
+      next.set(sessionKey, ts)
+      return { streamStartedAt: next }
+    }),
+
+  clearStreamStart: (sessionKey) =>
+    set((state) => {
+      if (!state.streamStartedAt.has(sessionKey)) return state
+      const next = new Map(state.streamStartedAt)
+      next.delete(sessionKey)
+      return { streamStartedAt: next }
+    }),
+
   clearTranscript: (sessionKey) =>
     set((state) => {
       const nextTranscripts = new Map(state.transcripts)
       const nextStreaming = new Map(state.streamingText)
+      const nextStreamStart = new Map(state.streamStartedAt)
       nextTranscripts.delete(sessionKey)
       nextStreaming.delete(sessionKey)
-      return { transcripts: nextTranscripts, streamingText: nextStreaming }
+      nextStreamStart.delete(sessionKey)
+      return {
+        transcripts: nextTranscripts,
+        streamingText: nextStreaming,
+        streamStartedAt: nextStreamStart,
+      }
+    }),
+
+  setClawbooDispatch: (dispatch) =>
+    set((state) => {
+      const next = new Map(state.clawbooDispatches)
+      const key = `${dispatch.teamId}:${dispatch.sourceEntryId}`
+      const existing = next.get(key) ?? []
+      // Dedup by dispatchId so a retry from the same call site doesn't
+      // accumulate duplicate cards (e.g., dispatchDelegation's 2-second
+      // retry-once-on-override-conflict path that reruns the same closure).
+      if (existing.some((d) => d.dispatchId === dispatch.dispatchId)) return state
+      next.set(key, [...existing, dispatch])
+      return { clawbooDispatches: next }
+    }),
+
+  clearClawbooDispatches: (teamId) =>
+    set((state) => {
+      const next = new Map(state.clawbooDispatches)
+      let changed = false
+      for (const key of next.keys()) {
+        if (key.startsWith(`${teamId}:`)) {
+          next.delete(key)
+          changed = true
+        }
+      }
+      if (!changed) return state
+      return { clawbooDispatches: next }
     }),
 
   setLastTokenUsage: (runId, inputTokens, outputTokens) =>

--- a/packages/boo-avatar/src/__tests__/avatar.test.ts
+++ b/packages/boo-avatar/src/__tests__/avatar.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateBooAvatar, booAvatarToDataUrl } from '../index'
+import { generateBooAvatar, booAvatarToDataUrl, resolveBooTint, TINTS } from '../index'
 import type { EyeShape, Accessory } from '../index'
 
 describe('generateBooAvatar', () => {
@@ -112,6 +112,38 @@ describe('isBooZero tint reservation', () => {
     // Explicit tint should win over isBooZero
     expect(svg).toContain('#34D399')
     expect(svg).not.toContain('stop-color="#ff4d4d"')
+  })
+})
+
+describe('resolveBooTint', () => {
+  it('returns one of the 10 TINTS for any seed', () => {
+    const tint = resolveBooTint('any-seed')
+    expect(TINTS).toContain(tint)
+  })
+
+  it('isBooZero=true returns the reserved OpenClaw red (TINTS[0])', () => {
+    expect(resolveBooTint('whatever', true)).toBe(TINTS[0])
+    expect(resolveBooTint('whatever', true)).toBe('#ff4d4d')
+  })
+
+  it('isBooZero=false never returns TINTS[0]', () => {
+    for (let i = 0; i < 50; i++) {
+      const tint = resolveBooTint(`agent-${i}`, false)
+      expect(tint).not.toBe(TINTS[0])
+    }
+  })
+
+  it('deterministic — same seed returns same tint', () => {
+    expect(resolveBooTint('determinism')).toBe(resolveBooTint('determinism'))
+  })
+
+  it('matches the tint that generateBooAvatar paints for the same seed', () => {
+    // Pick a few seeds and assert the resolved tint appears in the SVG
+    for (const seed of ['alpha', 'beta', 'gamma-007', 'long-seed-string-with-stuff']) {
+      const tint = resolveBooTint(seed)
+      const svg = generateBooAvatar({ seed })
+      expect(svg).toContain(tint)
+    }
   })
 })
 

--- a/packages/boo-avatar/src/index.ts
+++ b/packages/boo-avatar/src/index.ts
@@ -24,7 +24,7 @@ export interface BooAvatarParams {
 
 // ─── Constants ───────────────────────────────────────────────────
 
-const TINTS = [
+export const TINTS = [
   '#ff4d4d', // OpenClaw red (default)
   '#34D399', // mint
   '#FBBF24', // amber
@@ -46,6 +46,23 @@ function fnv1a(str: string): number {
     h = Math.imul(h, 0x01000193)
   }
   return h >>> 0
+}
+
+// ─── Tint resolution ─────────────────────────────────────────────
+
+/**
+ * Resolve an agent's tint from its seed (deterministic FNV-1a hash).
+ * Boo Zero gets the reserved OpenClaw Red (TINTS[0]); other agents
+ * skip index 0 and map into TINTS[1..9].
+ *
+ * This is the same logic `generateBooAvatar` uses internally —
+ * exported so consumers (e.g. DelegationCard) can accent UI with
+ * the exact same colour the avatar paints with.
+ */
+export function resolveBooTint(seed: string, isBooZero = false): string {
+  if (isBooZero) return TINTS[0]
+  const h = fnv1a(seed)
+  return TINTS[1 + (Math.abs(h) % (TINTS.length - 1))]
 }
 
 function createRng(seed: number): () => number {
@@ -166,8 +183,7 @@ export function generateBooAvatar(params: BooAvatarParams): string {
   const gidBody = `boo-body-${uid}`
 
   // Resolve tint — Boo Zero always gets OpenClaw Red; others skip index 0
-  const tint =
-    params.tint ?? (params.isBooZero ? TINTS[0] : TINTS[1 + (Math.abs(h) % (TINTS.length - 1))])
+  const tint = params.tint ?? resolveBooTint(seed, params.isBooZero)
   const tintDark = darkenHex(tint, 0.6)
 
   // Per-seed variations

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,9 @@
 
 export { BooAvatar } from './BooAvatar'
 export type { BooAvatarProps } from './BooAvatar'
+// Re-export so consumers can derive an agent's tint without adding a direct
+// `@clawboo/boo-avatar` dependency (the ui package already depends on it).
+export { resolveBooTint, TINTS } from '@clawboo/boo-avatar'
 export { cn } from './utils'
 export { cva } from 'class-variance-authority'
 export type { VariantProps } from 'class-variance-authority'

--- a/scripts/ingest-marketplace-content.ts
+++ b/scripts/ingest-marketplace-content.ts
@@ -13,6 +13,20 @@
 
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import prettier from 'prettier'
+
+// Write `content` to `outPath` after running it through Prettier with the
+// repo's resolved config. Without this, freshly-generated files would be
+// unformatted (the renderers emit double-quoted, single-line strings) and
+// drift against the existing committed files (which were formatted) — see
+// `scripts/verify-ingest.ts`, which mirrors the same Prettier-normalize step.
+async function writeFormatted(outPath: string, content: string): Promise<void> {
+  const formatted = await prettier.format(content, {
+    parser: 'typescript',
+    filepath: outPath,
+  })
+  await fs.writeFile(outPath, formatted, 'utf8')
+}
 import {
   AGENCY_AGENTS_SHA,
   AWESOME_OPENCLAW_SHA,
@@ -125,14 +139,14 @@ async function main(): Promise<void> {
     const agents = domainAgents.get(domain) ?? []
     const content = renderDomainFile(domain, agents)
     const outPath = domainFilePath(domain)
-    writePromises.push(fs.writeFile(outPath, content, 'utf8'))
+    writePromises.push(writeFormatted(outPath, content))
     console.log(`  Wrote ${path.relative(process.cwd(), outPath)} (${agents.length} entries)`)
   }
   await Promise.all(writePromises)
 
   // 6. Write agency/index.ts
   const agencyIndex = renderAgencyIndex()
-  await fs.writeFile(agencyIndexPath(), agencyIndex, 'utf8')
+  await writeFormatted(agencyIndexPath(), agencyIndex)
   console.log(`  Wrote ${path.relative(process.cwd(), agencyIndexPath())}`)
 
   // ─── Awesome OpenClaw pipeline ──────────────────────────────────────────────
@@ -164,19 +178,19 @@ async function main(): Promise<void> {
 
   // Write awesome-openclaw/usecases.ts
   const awesomeFileContent = renderAwesomeOpenclawFile(awesomeAgents)
-  await fs.writeFile(awesomeOpenclawFilePath(), awesomeFileContent, 'utf8')
+  await writeFormatted(awesomeOpenclawFilePath(), awesomeFileContent)
   console.log(
     `  Wrote ${path.relative(process.cwd(), awesomeOpenclawFilePath())} (${awesomeAgents.length} entries)`,
   )
 
   // Write awesome-openclaw/index.ts
   const awesomeIndex = renderAwesomeOpenclawIndex()
-  await fs.writeFile(awesomeOpenclawIndexPath(), awesomeIndex, 'utf8')
+  await writeFormatted(awesomeOpenclawIndexPath(), awesomeIndex)
   console.log(`  Wrote ${path.relative(process.cwd(), awesomeOpenclawIndexPath())}`)
 
   // 7. Write agents/index.ts (imports from all three sources)
   const agentsIndex = renderAgentsIndex()
-  await fs.writeFile(agentsIndexPath(), agentsIndex, 'utf8')
+  await writeFormatted(agentsIndexPath(), agentsIndex)
   console.log(`  Wrote ${path.relative(process.cwd(), agentsIndexPath())}`)
 
   // ─── Team file generation ──────────────────────────────────────────────────
@@ -212,7 +226,7 @@ async function main(): Promise<void> {
     workflowBodies,
     agentNameById,
   )
-  await fs.writeFile(agencyWorkflowsTeamPath(), agencyWorkflowsContent, 'utf8')
+  await writeFormatted(agencyWorkflowsTeamPath(), agencyWorkflowsContent)
   console.log(
     `  Wrote ${path.relative(process.cwd(), agencyWorkflowsTeamPath())} (${WORKFLOW_TEAM_CONFIGS.length} teams)`,
   )
@@ -220,7 +234,7 @@ async function main(): Promise<void> {
   // 9. Group awesome-openclaw agents by usecase + emit teams/awesome-openclaw.ts
   const awesomeGroups = groupAwesomeByUsecase(awesomeAgents)
   const awesomeTeamsContent = renderAwesomeOpenclawTeamsFile(awesomeGroups)
-  await fs.writeFile(awesomeOpenclawTeamsPath(), awesomeTeamsContent, 'utf8')
+  await writeFormatted(awesomeOpenclawTeamsPath(), awesomeTeamsContent)
   console.log(
     `  Wrote ${path.relative(process.cwd(), awesomeOpenclawTeamsPath())} (${awesomeGroups.size} teams)`,
   )
@@ -229,7 +243,7 @@ async function main(): Promise<void> {
   const excludeIds = workflowAgentIds()
   const syntheticTeams = generateSyntheticTeams(domainAgents, excludeIds)
   const syntheticContent = renderSyntheticTeamsFile(syntheticTeams)
-  await fs.writeFile(syntheticTeamsPath(), syntheticContent, 'utf8')
+  await writeFormatted(syntheticTeamsPath(), syntheticContent)
   console.log(
     `  Wrote ${path.relative(process.cwd(), syntheticTeamsPath())} (${syntheticTeams.length} teams)`,
   )

--- a/scripts/verify-ingest.ts
+++ b/scripts/verify-ingest.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from 'node:fs/promises'
+import prettier from 'prettier'
 import {
   AGENCY_AGENTS_SHA,
   AWESOME_OPENCLAW_SHA,
@@ -263,6 +264,16 @@ async function main(): Promise<void> {
     expected: renderSyntheticTeamsFile(syntheticTeams),
   })
 
+  // Normalize both sides through Prettier before comparing — the raw
+  // generator output is unformatted (double quotes, single-line strings)
+  // while committed files have been formatted by the repo's Prettier
+  // config (single quotes, line-wrapped). Without this normalization a
+  // freshly-regenerated file would never match a committed file even
+  // when the content is semantically identical.
+  async function format(text: string, filePath: string): Promise<string> {
+    return prettier.format(text, { parser: 'typescript', filepath: filePath })
+  }
+
   const failures: string[] = []
   for (const { label, path: filePath, expected } of filesToCheck) {
     let actual: string
@@ -272,8 +283,12 @@ async function main(): Promise<void> {
       failures.push(`  ❌ ${label}: FILE MISSING`)
       continue
     }
-    if (actual !== expected) {
-      failures.push(`  ❌ ${label}: content differs\n${shortDiff(expected, actual)}`)
+    const [expectedFmt, actualFmt] = await Promise.all([
+      format(expected, filePath),
+      format(actual, filePath),
+    ])
+    if (actualFmt !== expectedFmt) {
+      failures.push(`  ❌ ${label}: content differs\n${shortDiff(expectedFmt, actualFmt)}`)
     } else {
       console.log(`  ✓ ${label}`)
     }

--- a/tests/e2e/03-graph.spec.ts
+++ b/tests/e2e/03-graph.spec.ts
@@ -1,17 +1,20 @@
 import { test, expect, connectToMockGateway } from './helpers/fixtures'
 
 test.describe('Ghost Graph', () => {
-  test('Ghost Graph tab shows React Flow canvas', async ({ page, request, gateway }) => {
+  test('Atlas tab shows React Flow canvas', async ({ page, request, gateway }) => {
     await connectToMockGateway(page, request, gateway.url)
 
-    // The default view is Ghost Graph, so the toolbar title in the main content area should be visible
-    await expect(page.getByRole('main').getByText('Ghost Graph')).toBeVisible({ timeout: 5_000 })
+    // The default nav slot ('graph') now renders the Atlas all-teams view —
+    // its toolbar title is "Atlas — All Teams" (see GhostGraphPanel.tsx:103).
+    await expect(page.getByRole('main').getByText('Atlas — All Teams')).toBeVisible({
+      timeout: 5_000,
+    })
 
     // React Flow renders a container with class .react-flow
     const reactFlow = page.locator('.react-flow')
     await expect(reactFlow).toBeVisible({ timeout: 10_000 })
 
-    // Click an agent to switch to chat, then click Ghost Graph nav button to return.
+    // Click an agent to switch to chat, then click Atlas nav button to return.
     // Use Research Boo (a2) — always in the Default team, unlike Test Boo (a1, Boo Zero).
     const agentRow = page.locator('[data-testid="fleet-agent-row-a2"]')
     await agentRow.click()
@@ -20,9 +23,9 @@ test.describe('Ghost Graph', () => {
       timeout: 5_000,
     })
 
-    // Click Ghost Graph nav button in agent list column to switch back
+    // Click Atlas nav button in agent list column to switch back
     const sidebar = page.locator('[data-testid="agent-list-column"]')
-    await sidebar.locator('button:has-text("Ghost Graph")').click()
+    await sidebar.locator('button:has-text("Atlas")').click()
     await expect(reactFlow).toBeVisible({ timeout: 5_000 })
   })
 })

--- a/tests/e2e/04-teams.spec.ts
+++ b/tests/e2e/04-teams.spec.ts
@@ -27,8 +27,11 @@ test.describe('Teams', () => {
 
     const agentList = page.locator('[data-testid="agent-list-column"]')
 
-    // Default view is Ghost Graph — scope to main content area to avoid nav button ambiguity
-    await expect(page.getByRole('main').getByText('Ghost Graph')).toBeVisible({ timeout: 5_000 })
+    // Default view is Atlas (the 'graph' nav slot now renders the global
+    // all-teams view) — scope to main content area to avoid nav button ambiguity
+    await expect(page.getByRole('main').getByText('Atlas — All Teams')).toBeVisible({
+      timeout: 5_000,
+    })
 
     // Click Marketplace nav button
     await agentList.locator('button:has-text("Marketplace")').click()
@@ -38,8 +41,8 @@ test.describe('Teams', () => {
     await agentList.locator('button:has-text("Tokens Used")').click()
     await expect(page.getByText('Token usage by team and agent')).toBeVisible({ timeout: 5_000 })
 
-    // Click back to Ghost Graph
-    await agentList.locator('button:has-text("Ghost Graph")').click()
+    // Click back to Atlas
+    await agentList.locator('button:has-text("Atlas")').click()
     await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10_000 })
   })
 

--- a/tests/e2e/05-group-chat.spec.ts
+++ b/tests/e2e/05-group-chat.spec.ts
@@ -171,4 +171,98 @@ test.describe('Group Chat', () => {
     // Ghost Graph should still be visible alongside the gate (2-panel layout)
     await expect(page.locator('.react-flow')).toBeVisible({ timeout: 10_000 })
   })
+
+  test('nests delegated agent response inside the source DelegationCard', async ({
+    page,
+    request,
+    gateway,
+  }) => {
+    const { teamId } = await connectWithTeam(page, request, gateway.url)
+
+    // Seed two transcript entries on the team-scoped session keys:
+    //   1. Source assistant entry on a1 (Boo Zero / Test Boo) emitting a
+    //      `<delegate to="@Research Boo">…</delegate>` block.
+    //   2. Target reply assistant entry on a2 (Research Boo).
+    // After hydration, GroupChatPanel runs buildDelegationLinkages which
+    // pairs the two — the target reply should render INSIDE the source's
+    // DelegationCard (delegation-card-body), not as a sibling top-level
+    // assistant card.
+    const sourceSk = `agent:a1:team:${teamId}`
+    const targetSk = `agent:a2:team:${teamId}`
+    const baseTs = Date.now()
+    // Unique-per-run IDs so the chat-history POST isn't silently no-op'd by
+    // ON CONFLICT (entry_id) DO NOTHING when previous test runs left rows.
+    const runId = `e2e-${baseTs}`
+    const srcId = `src-${runId}`
+    const tgtId = `tgt-${runId}`
+    const replyText =
+      'Voice AI converts speech to structured intent — used in kiosks, in-car assistants, and call centers.'
+
+    await request.post(`${API_BASE}/api/chat-history`, {
+      data: {
+        sessionKey: sourceSk,
+        gatewayUrl: gateway.url,
+        entries: [
+          {
+            entryId: srcId,
+            runId: `run-bz-${runId}`,
+            sessionKey: sourceSk,
+            kind: 'assistant',
+            role: 'assistant',
+            text: 'On it. <delegate to="@Research Boo">Quick TL;DR of voice AI</delegate>',
+            source: 'runtime-chat',
+            timestampMs: baseTs,
+            sequenceKey: 1,
+            confirmed: true,
+            fingerprint: `fp-${srcId}`,
+          },
+        ],
+      },
+    })
+
+    await request.post(`${API_BASE}/api/chat-history`, {
+      data: {
+        sessionKey: targetSk,
+        gatewayUrl: gateway.url,
+        entries: [
+          {
+            entryId: tgtId,
+            runId: `run-eng-${runId}`,
+            sessionKey: targetSk,
+            kind: 'assistant',
+            role: 'assistant',
+            text: replyText,
+            source: 'runtime-chat',
+            timestampMs: baseTs + 5_000,
+            sequenceKey: 2,
+            confirmed: true,
+            fingerprint: `fp-${tgtId}`,
+          },
+        ],
+      },
+    })
+
+    // Open group chat
+    const agentList = page.locator('[data-testid="agent-list-column"]')
+    const groupChatRow = agentList.locator('[data-testid="group-chat-row"]')
+    await expect(groupChatRow).toBeVisible({ timeout: 5_000 })
+    await groupChatRow.click()
+    await expect(page.locator('[data-testid="group-chat-panel"]')).toBeVisible({ timeout: 5_000 })
+
+    // Exactly one DelegationCard renders for our seeded source block.
+    const card = page.locator('[data-testid="delegation-card"]')
+    await expect(card).toHaveCount(1, { timeout: 10_000 })
+
+    // The card body is visible (default-expanded for the newest delegation)
+    // and contains the target's reply text.
+    const cardBody = card.locator('[data-testid="delegation-card-body"]')
+    await expect(cardBody).toBeVisible({ timeout: 5_000 })
+    await expect(cardBody).toContainText('Voice AI converts speech to structured intent')
+
+    // The target reply must NOT also appear as a top-level sibling card
+    // outside the DelegationCard — count assert: the only paragraph
+    // containing the reply text lives inside delegation-card-body.
+    const allReplyMatches = page.locator(`text=${replyText}`)
+    await expect(allReplyMatches).toHaveCount(1)
+  })
 })


### PR DESCRIPTION
## Summary

- Enhances chat orchestration with improved delegation handling, delegation linkages, workstream support, tool entry parsing, follow-up handling, and multi-step plan state management.
- Adds team rules management and improves related team flows, including team deletion cleanup, Boo Zero agent/team settings integration, and updated group chat onboarding/detail experiences.
- Includes supporting UI and CI improvements, such as message component cleanup and marketplace ingest verification output.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed yet — app-level chat/team workflow changes unless this is the final release-ready package or CLI change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff