### PR TITLE
chore(release): prepare v0.1.1 release

### DIFF
--- a/.changeset/first-real-release.md
+++ b/.changeset/first-real-release.md
@@ -1,0 +1,28 @@
+---
+'clawboo': patch
+'@clawboo/protocol': minor
+'@clawboo/gateway-client': minor
+'@clawboo/db': minor
+'@clawboo/events': minor
+'@clawboo/logger': minor
+'@clawboo/config': minor
+'@clawboo/ui': minor
+'@clawboo/gateway-proxy': minor
+'@clawboo/boo-avatar': minor
+---
+
+First real release. Replaces the v0.0.0 / v0.1.0 placeholder builds.
+
+Ships the v0.1.0 marketplace-redesign milestone:
+
+- 304 first-class agent catalog entries across 3 sources (agency-agents, awesome-openclaw, clawboo builtin)
+- 82 workflow team templates (5 builtin, 5 agency-workflows, 42 awesome-openclaw, 30 synthetic excellence partitions)
+- 3-tab marketplace (Skills / Agents / Teams) with single-agent deploy flow
+- Atlas global org-graph + Group Chat team halos with Boo Zero as universal leader
+- Multi-agent orchestration: structured `<delegate>` protocol, multi-step `<plan>` state machine, parallel workstreams with auto-synthesis, relay-batching, override-fix retry
+- DelegationCards / PlanCards / WorkstreamCards with tint-aware borders, accordion topology, completion flash
+- Auto-install onboarding (Detect → Install → Configure → StartGateway → Team → Deploy)
+- Dynamic API port resolution (default 18790, auto-fallback through 18809) — never collides with other dev servers
+- Hybrid agent knowledge delivery (AGENTS.md essentials + CLAWBOO.md reference + self-documenting `[Team Update]` envelopes)
+- Local-DB ghost cleanup + per-agent KV cleanup on agent delete
+- 857 unit tests, 12 e2e tests, full CI gating via `pnpm verify:ingest` on marketplace codegen

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawboo",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "The open-source platform for deploying and orchestrating OpenClaw agent teams",
   "license": "MIT",
   "repository": {

--- a/packages/boo-avatar/package.json
+++ b/packages/boo-avatar/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/boo-avatar",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Deterministic ghost-lobster SVG avatar generator for Clawboo agents",
   "license": "MIT",
   "repository": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/config",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Settings loader and persistence for Clawboo (XDG dirs, env vars, OpenClaw fallback)",
   "license": "MIT",
   "repository": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/db",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "SQLite database layer for Clawboo using Drizzle ORM and better-sqlite3",
   "license": "MIT",
   "repository": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/events",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Bridge-Policy-Handler event pipeline for processing OpenClaw Gateway events",
   "license": "MIT",
   "repository": {

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/gateway-client",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "WebSocket client for the OpenClaw Gateway with typed RPC and event subscription",
   "license": "MIT",
   "repository": {

--- a/packages/gateway-proxy/package.json
+++ b/packages/gateway-proxy/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/gateway-proxy",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Same-origin WebSocket proxy for the OpenClaw Gateway with server-side auth injection",
   "license": "MIT",
   "repository": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/logger",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Pino-based structured logger for Clawboo packages",
   "license": "MIT",
   "repository": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/protocol",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Message parser, transcript types, and agent file definitions for Clawboo",
   "license": "MIT",
   "repository": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@clawboo/ui",
   "version": "0.0.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "description": "Shared React components, BooAvatar, design tokens, and utilities for Clawboo",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

- Prepares the first real release of the project.
- Bumps `clawboo` from `0.1.0` to `0.1.1` and releases `@clawboo/*` libraries at `0.1.0`.
- Adds the release milestone summary in `.changeset/first-real-release.md`.

## Type

- [ ] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [x] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff