### PR TITLE
fix(ci): always run publish job; let changesets/action handle no-op vs publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,6 @@ jobs:
     name: Publish packages
     runs-on: ubuntu-latest
     needs: [check]
-    if: needs.check.outputs.has_changesets == 'true'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- Removes the `has_changesets` gate from the publish job in `.github/workflows/publish.yml`.
- Fixes the post-merge publish path where consumed changeset files are deleted, causing the publish job to be skipped even when version bumps are ready to ship.
- Relies on `changesets/action@v1` to handle both flows correctly: open a Version PR when changesets exist, or publish when versions are already ahead of the registry.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed — CI workflow fix)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff