### PR TITLE
fix(server): Cannot GET / in clawboo@0.1.1 — robust SPA catch-all

### DIFF
--- a/.changeset/mighty-parks-shout.md
+++ b/.changeset/mighty-parks-shout.md
@@ -1,0 +1,9 @@
+---
+'clawboo': patch
+---
+
+fix(server): SPA root path now serves index.html in the bundled production server.
+
+Replaces an Express 5 wildcard catch-all (`/{*splat}`) that failed to match the bare `/` path under path-to-regexp v8 with a version-agnostic `app.use(handler)` SPA pattern. Also adds a `smoke-test-bundle` CI job that boots the bundled server and curls `/` so this class of bug can't ship again.
+
+Fixes the "Cannot GET /" that affected v0.1.1.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,62 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm verify:ingest
+
+  smoke-test-bundle:
+    name: Smoke test bundled CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm assemble
+
+      - name: Boot bundled server in background
+        working-directory: apps/cli
+        run: |
+          node dist/server.js > /tmp/clawboo-server.log 2>&1 &
+          echo $! > /tmp/clawboo-server.pid
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:18790/api/settings > /dev/null 2>&1; then
+              echo "Server is up after ${i} attempts"
+              break
+            fi
+            sleep 0.5
+          done
+          if ! curl -fsS http://localhost:18790/api/settings > /dev/null 2>&1; then
+            echo "FAIL: server did not become ready within 15s"
+            cat /tmp/clawboo-server.log
+            exit 1
+          fi
+
+      - name: Verify SPA at root path
+        run: |
+          body=$(curl -fsS http://localhost:18790/)
+          echo "$body" | grep -q '<div id="root"></div>' \
+            || (echo "FAIL: root did not return SPA HTML"; echo "$body" | head -20; cat /tmp/clawboo-server.log; exit 1)
+          echo "PASS: GET / returned SPA HTML"
+
+      - name: Verify deep SPA route falls through to index.html
+        run: |
+          body=$(curl -fsS http://localhost:18790/some/spa/route)
+          echo "$body" | grep -q '<div id="root"></div>' \
+            || (echo "FAIL: deep route did not fall through to SPA"; exit 1)
+          echo "PASS: GET /some/spa/route returned SPA HTML"
+
+      - name: Verify API route still works
+        run: |
+          curl -fsS http://localhost:18790/api/settings | grep -q hasToken \
+            || (echo "FAIL: API route broken"; exit 1)
+          echo "PASS: GET /api/settings returned JSON"
+
+      - name: Cleanup
+        if: always()
+        run: kill "$(cat /tmp/clawboo-server.pid)" 2>/dev/null || true

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -104,8 +104,14 @@ async function main() {
   if (!dev) {
     const uiDir = path.resolve(process.env['CLAWBOO_UI_DIR'] || path.join(__dirname, 'ui'))
     app.use(express.static(uiDir))
-    // SPA catch-all: non-API requests get index.html
-    app.get('/{*splat}', (_req, res) => {
+    // SPA catch-all: any unmatched GET serves index.html so client-side
+    // routing works. We use `app.use(handler)` rather than a wildcard pattern
+    // (`'/*splat'` / `'/{*splat}'`) — Express 5 + path-to-regexp v8 have
+    // subtle matching quirks around the bare `/` path that produced
+    // "Cannot GET /" in clawboo@0.1.1. `app.use` with no path matches every
+    // request by definition. Restricting to GET keeps non-GET 404s honest.
+    app.use((req, res, next) => {
+      if (req.method !== 'GET') return next()
       res.sendFile(path.join(uiDir, 'index.html'))
     })
   }


### PR DESCRIPTION
## Summary

- Fixes the `Cannot GET /` issue in `clawboo@0.1.1` by replacing the Express 5 catch-all route with a version-agnostic SPA fallback using `app.use(handler)`.
- Restores correct root and client-side route handling without relying on wildcard matching behavior in `path-to-regexp`.
- Adds a bundled server smoke-test job in CI to verify `/` serves the SPA.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff