### PR TITLE
fix(setup): OpenClaw protocol-4 + Windows compatibility

### DIFF
--- a/.changeset/thick-seas-invite.md
+++ b/.changeset/thick-seas-invite.md
@@ -1,0 +1,33 @@
+---
+'@clawboo/gateway-client': patch
+'clawboo': patch
+---
+
+fix: OpenClaw protocol-4 compatibility + Windows install support.
+
+Two independent blockers prevented users from completing onboarding:
+
+1. PROTOCOL MISMATCH. OpenClaw 2026.5.18 (latest) bumped the WS connect
+   protocol from 3 to 4. Clawboo's gateway-client advertised maxProtocol: 3
+   only, so every fresh install (which ran `npm install -g openclaw@latest`)
+   got an incompatible openclaw and hit "Something went wrong: protocol
+   mismatch" at connect time.
+
+   Fix: bump maxProtocol to 4 in packages/gateway-client/src/client.ts.
+   minProtocol stays at 3 so older openclaw (2026.3.x and earlier) still
+   negotiates correctly. Also pinned the install spec to `openclaw@^2026.5`
+   so a future minor bump landing protocol 5 doesn't silently break users.
+
+2. WINDOWS SPAWN ENOENT. Windows users saw `Error: spawn npm ENOENT` when
+   clicking Install in onboarding, AND the OpenClaw detection step always
+   reported "not installed" even after a successful manual `npm install -g`.
+   Both root-caused to Unix-only commands: `execFileSync('which', ...)` and
+   `spawn('npm', ...)` (Windows npm is npm.cmd).
+
+   Fix: new apps/web/server/lib/platform.ts helper with findExecutable
+   (cross-platform which/where) and resolveShimName (appends .cmd on
+   Windows). Applied at system.ts:57+343, modelCache.ts:59, and
+   processManager.ts:74 (which also gained a netstat-based fallback for
+   port-to-PID lookup on Windows). CI smoke-test-bundle now runs on a
+   matrix of [ubuntu-latest, windows-latest] so Windows regressions can't
+   ship undetected.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,12 @@ jobs:
 
   smoke-test-bundle:
     name: Smoke test bundled CLI (clean install simulation)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v4
 
@@ -124,4 +128,8 @@ jobs:
       # OpenClaw Gateway auxiliary port that broke v0.1.2). Asserts the
       # CLI's port-discovery correctly skips 18791, the SPA renders, the
       # deep-route catch-all works, and /api/settings returns JSON.
+      #
+      # Runs on both ubuntu-latest and windows-latest. The Windows run is
+      # the regression gate for v0.1.4's Windows-compat fixes (npm.cmd
+      # resolution, which→where shim, netstat-based findProcessByPort).
       - run: pnpm test:clean-install

--- a/apps/web/server/api/system.ts
+++ b/apps/web/server/api/system.ts
@@ -13,6 +13,7 @@ import {
   findProcessByPort,
 } from '../lib/processManager'
 import { getModelsFromCli } from '../lib/modelCache'
+import { findExecutable, resolveShimName } from '../lib/platform'
 import { MODEL_GROUPS as STATIC_MODEL_GROUPS } from '../../src/lib/modelCatalog'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -53,18 +54,20 @@ function sendEvent(res: Response, data: Record<string, unknown>): void {
 }
 
 function detectOpenClaw(): { installed: boolean; version: string | null; path: string | null } {
+  // findExecutable wraps the platform-specific `which` (Unix) / `where`
+  // (Windows) lookup. Returns null when not on PATH — no throw, so we
+  // can branch cleanly.
+  const binPath = findExecutable('openclaw')
+  if (!binPath) return { installed: false, version: null, path: null }
   try {
-    const binPath = execFileSync('which', ['openclaw'], { encoding: 'utf8' }).trim()
-    if (!binPath) return { installed: false, version: null, path: null }
-    try {
-      const raw = execFileSync(binPath, ['--version'], { encoding: 'utf8' }).trim()
-      const version = raw.replace(/^openclaw\s+v?/i, '').trim() || raw
-      return { installed: true, version, path: binPath }
-    } catch {
-      return { installed: true, version: null, path: binPath }
-    }
+    // Node 22 handles full-path .cmd invocation correctly (post
+    // CVE-2024-27980 fix in 20.12+), so passing a Windows .cmd path
+    // straight to execFileSync works.
+    const raw = execFileSync(binPath, ['--version'], { encoding: 'utf8' }).trim()
+    const version = raw.replace(/^openclaw\s+v?/i, '').trim() || raw
+    return { installed: true, version, path: binPath }
   } catch {
-    return { installed: false, version: null, path: null }
+    return { installed: true, version: null, path: binPath }
   }
 }
 
@@ -340,7 +343,17 @@ export async function installOpenclawPOST(_req: Request, res: Response): Promise
 
   sendEvent(res, { type: 'progress', step: 'installing', message: 'Installing OpenClaw...' })
 
-  const child = spawn('npm', ['install', '-g', 'openclaw@latest'], {
+  // Two Windows-compat fixes folded into this call site:
+  //   1. `resolveShimName('npm')` returns `npm.cmd` on Windows. Bare 'npm'
+  //      throws ENOENT on Windows because Node's spawn doesn't auto-resolve
+  //      .cmd extensions.
+  //   2. Pin to `openclaw@^2026.5` rather than `@latest`. OpenClaw bumped the
+  //      WS connect protocol from 3 to 4 in 2026.5.x, and Clawboo's
+  //      gateway-client now advertises maxProtocol: 4 to match. A future
+  //      OpenClaw 2026.6+ could bump to protocol 5; pinning to ^2026.5 means
+  //      new users get a Clawboo-compatible openclaw until we widen the
+  //      protocol range and ship a new clawboo.
+  const child = spawn(resolveShimName('npm'), ['install', '-g', 'openclaw@^2026.5'], {
     stdio: ['ignore', 'pipe', 'pipe'],
   })
 

--- a/apps/web/server/lib/__tests__/platform.test.ts
+++ b/apps/web/server/lib/__tests__/platform.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+
+import { findExecutable, isWindows, resolveShimName } from '../platform'
+
+describe('platform helper', () => {
+  describe('isWindows', () => {
+    it('reflects process.platform', () => {
+      expect(isWindows).toBe(process.platform === 'win32')
+    })
+  })
+
+  describe('resolveShimName', () => {
+    it('appends .cmd on Windows', () => {
+      if (isWindows) {
+        expect(resolveShimName('npm')).toBe('npm.cmd')
+        expect(resolveShimName('openclaw')).toBe('openclaw.cmd')
+        expect(resolveShimName('pnpm')).toBe('pnpm.cmd')
+      } else {
+        expect(resolveShimName('npm')).toBe('npm')
+        expect(resolveShimName('openclaw')).toBe('openclaw')
+        expect(resolveShimName('pnpm')).toBe('pnpm')
+      }
+    })
+  })
+
+  describe('findExecutable', () => {
+    it('finds a known binary that always exists (node)', () => {
+      // `node` is on PATH wherever this test runs — it's how vitest is
+      // invoked. So findExecutable('node') MUST return a non-null path
+      // on every platform.
+      const result = findExecutable('node')
+      expect(result).toBeTruthy()
+      expect(typeof result).toBe('string')
+      // The returned path must contain the binary name (case-insensitive
+      // on Windows, exact match elsewhere).
+      expect(result!.toLowerCase()).toContain('node')
+    })
+
+    it('returns null for nonsense names (does not throw)', () => {
+      const result = findExecutable('this-binary-definitely-does-not-exist-clawboo-test-42')
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/apps/web/server/lib/modelCache.ts
+++ b/apps/web/server/lib/modelCache.ts
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
+import { resolveShimName } from './platform'
+
 const execFileAsync = promisify(execFile)
 
 export interface ModelOption {
@@ -56,10 +58,16 @@ export async function getModelsFromCli(): Promise<ModelGroup[] | null> {
   if (cachedGroups && now - cacheTime < CACHE_TTL) return cachedGroups
 
   try {
-    const { stdout } = await execFileAsync('openclaw', ['models', 'list', '--all', '--json'], {
-      timeout: 15_000,
-      env: { ...process.env },
-    })
+    // On Windows, bare 'openclaw' is openclaw.cmd — Node spawn won't resolve
+    // the .cmd extension by itself, so use the platform-aware shim name.
+    const { stdout } = await execFileAsync(
+      resolveShimName('openclaw'),
+      ['models', 'list', '--all', '--json'],
+      {
+        timeout: 15_000,
+        env: { ...process.env },
+      },
+    )
     const parsed = JSON.parse(stdout) as CliOutput | CliModel[]
     const models = Array.isArray(parsed) ? parsed : parsed.models
     if (!Array.isArray(models) || models.length === 0) return cachedGroups

--- a/apps/web/server/lib/platform.ts
+++ b/apps/web/server/lib/platform.ts
@@ -1,0 +1,56 @@
+// Tiny cross-platform helpers for invoking shell-shim binaries (npm,
+// pnpm, openclaw) and discovering executables in PATH.
+//
+// Why this exists: Node's child_process spawn/execFile on Windows does
+// NOT auto-resolve `.cmd` extensions when given a bare name like 'npm'
+// (since npm on Windows is actually npm.cmd — a batch wrapper). Bypassing
+// this helper causes ENOENT on Windows even when the tool IS installed.
+// Symmetrically, `which` is a Unix command; Windows uses `where`.
+//
+// Use `findExecutable` when you need the full absolute path to a tool
+// (preferred — explicit, no PATH-resolution surprises at spawn time).
+// Use `resolveShimName` only when you must invoke a known shim by name
+// (e.g., for `spawn('npm', ...)` style calls).
+//
+// Bugs this prevents (regression history):
+// - v0.1.3 spawn('npm', ['install', '-g', 'openclaw@latest']) threw
+//   `Error: spawn npm ENOENT` on Windows. Reported by a user running
+//   `npx clawboo` on Windows; blocked the entire onboarding flow.
+// - v0.1.3 execFileSync('which', ['openclaw']) threw silently on
+//   Windows (catch returned `installed: false`). Onboarding always
+//   routed Windows users to InstallStep even after a successful
+//   manual `npm install -g openclaw@...`.
+
+import { execFileSync } from 'node:child_process'
+
+export const isWindows = process.platform === 'win32'
+
+/**
+ * Cross-platform `which`. Returns the absolute path to the first match,
+ * or `null` if not found. On Windows uses `where` (which can return
+ * multiple paths separated by CRLF — we take the first).
+ */
+export function findExecutable(name: string): string | null {
+  try {
+    const cmd = isWindows ? 'where' : 'which'
+    const out = execFileSync(cmd, [name], { encoding: 'utf8' }).trim()
+    if (!out) return null
+    // `where` on Windows may return multiple paths; first one wins.
+    const first = out.split(/\r?\n/)[0]
+    return first ? first.trim() : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve a shell-shim binary name (npm, pnpm, openclaw) to the actual
+ * executable name. On Windows, npm-CLI tools install as `<name>.cmd`
+ * batch wrappers; Node's spawn won't find them by bare name.
+ *
+ * Prefer `findExecutable` + spawn-the-full-path when possible. Use this
+ * only for callers that hardcode the binary name.
+ */
+export function resolveShimName(name: string): string {
+  return isWindows ? `${name}.cmd` : name
+}

--- a/apps/web/server/lib/processManager.ts
+++ b/apps/web/server/lib/processManager.ts
@@ -3,6 +3,8 @@ import path from 'node:path'
 import os from 'node:os'
 import { execFileSync } from 'node:child_process'
 
+import { isWindows } from './platform'
+
 export interface GatewayPidInfo {
   pid: number
   port: number
@@ -73,11 +75,38 @@ export async function probeGatewayPort(port: number, timeoutMs = 2000): Promise<
 
 export function findProcessByPort(port: number): number | null {
   try {
+    if (isWindows) {
+      // Windows has no lsof. `netstat -ano` lists every connection +
+      // listener with PID in the last column. Grab everything and filter
+      // in JS — execFileSync passes args as an argv array, so there's no
+      // shell interpolation and no injection risk on `port`.
+      const output = execFileSync('netstat', ['-ano'], {
+        encoding: 'utf8',
+        windowsHide: true,
+      })
+      const portSuffix = `:${port}`
+      for (const line of output.split(/\r?\n/)) {
+        const trimmed = line.trim()
+        if (!trimmed) continue
+        // Only LISTENING rows — ESTABLISHED / TIME_WAIT etc. aren't the
+        // process we care about.
+        if (!/\bLISTENING\b/i.test(trimmed)) continue
+        const cols = trimmed.split(/\s+/)
+        // netstat -ano columns: Proto Local Foreign State PID
+        const local = cols[1] ?? ''
+        if (!local.endsWith(portSuffix)) continue
+        const pid = parseInt(cols[cols.length - 1] ?? '', 10)
+        if (Number.isFinite(pid) && pid > 0) return pid
+      }
+      return null
+    }
     const output = execFileSync('lsof', ['-ti', `:${port}`], { encoding: 'utf8' })
-    const firstLine = output.trim().split('\n')[0]
+    const firstLine = output.trim().split('\n')[0] ?? ''
     const pid = parseInt(firstLine, 10)
     return Number.isFinite(pid) && pid > 0 ? pid : null
   } catch {
+    // Either the tool isn't installed or nothing's on the port. Caller
+    // handles null.
     return null
   }
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -3,7 +3,10 @@ import path from 'node:path'
 
 export default defineConfig({
   test: {
-    include: ['src/**/*.test.ts'],
+    // Cover both the React/SPA tests (src/) and the Express-server tests
+    // (server/) — we landed the first server-side unit test in v0.1.4 for
+    // lib/platform.ts; future server-lib tests should land alongside.
+    include: ['src/**/*.test.ts', 'server/**/*.test.ts'],
     environment: 'node',
     globals: true,
   },

--- a/packages/gateway-client/src/__tests__/client.test.ts
+++ b/packages/gateway-client/src/__tests__/client.test.ts
@@ -118,6 +118,28 @@ async function connectClient(
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('GatewayClient', () => {
+  describe('connect protocol range', () => {
+    it('advertises minProtocol: 3, maxProtocol: 4', async () => {
+      // OpenClaw 2026.5.x requires protocol 4. Older openclaw (2026.3.x and
+      // earlier) accepts protocol 3. Advertising the [3, 4] range lets both
+      // versions negotiate cleanly. Regression-locks this — if a future
+      // refactor accidentally narrows the range, this test fails.
+      const client = new GatewayClient()
+      const ws = await connectClient(client)
+
+      const connectReq = ws.sent
+        .map((s) => JSON.parse(s) as Record<string, unknown>)
+        .find((f) => f['method'] === 'connect')
+
+      expect(connectReq).toBeDefined()
+      const params = connectReq!['params'] as Record<string, unknown>
+      expect(params['minProtocol']).toBe(3)
+      expect(params['maxProtocol']).toBe(4)
+
+      client.disconnect()
+    })
+  })
+
   describe('call()', () => {
     it('sends a req frame with unique id and correct method', async () => {
       const client = new GatewayClient()

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -319,8 +319,14 @@ export class GatewayClient {
     }
 
     const params = {
+      // OpenClaw bumped the connect protocol from 3 → 4 in 2026.5.x.
+      // We advertise support for both so old (2026.3.x and earlier) and new
+      // (2026.5+) Gateways both negotiate cleanly. If openclaw ever bumps to
+      // 5, the install spec in apps/web/server/api/system.ts pins to ^2026.5
+      // — that prevents fresh installs from grabbing an incompatible version
+      // before this range is widened.
       minProtocol: 3,
-      maxProtocol: 3,
+      maxProtocol: 4,
       client: {
         id: opts.clientName ?? 'openclaw-control-ui',
         version: opts.clientVersion ?? '0.0.0',

--- a/scripts/test-clean-install.mjs
+++ b/scripts/test-clean-install.mjs
@@ -107,6 +107,11 @@ process.on('SIGTERM', () => {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 async function killByPort(port) {
+  // Cleanup is best-effort. On Windows there's no `lsof` — CI runners are
+  // ephemeral, so leftover processes get reaped when the job exits anyway.
+  // Implementing a `netstat -ano` parse here would be defensible but adds
+  // moving parts to a script whose main job is asserting onboarding works.
+  if (process.platform === 'win32') return
   try {
     const out = await runCmd('lsof', ['-ti', `:${port}`])
     const pids = out.trim().split('\n').filter(Boolean)
@@ -183,25 +188,39 @@ async function main() {
   // 5. Build a shadow PATH that includes node + npm + which (Clawboo needs
   //    them) but NOT `open` / `xdg-open` — that way the CLI's browser-open
   //    fails silently and we don't get a real browser launch during tests.
-  shadowBinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'clawboo-shadow-bin-'))
-  const allowedBins = ['node', 'npm', 'pnpm', 'which', 'ls']
-  for (const dir of ['/usr/bin', '/bin', '/usr/local/bin', path.dirname(process.execPath)]) {
-    for (const bin of allowedBins) {
-      const src = path.join(dir, bin)
-      try {
-        await fs.access(src)
-        await fs.symlink(src, path.join(shadowBinDir, bin)).catch(() => {})
-      } catch {
-        /* skip missing */
+  //
+  //    Windows: symlinking system binaries requires admin in some setups,
+  //    and `start` (the Windows browser-open shim) on a headless CI runner
+  //    won't open anything anyway. Skip the shadow PATH on Windows and let
+  //    the CLI inherit the system PATH.
+  const useShadowPath = process.platform !== 'win32'
+  let cliEnvPath = process.env.PATH ?? ''
+  if (useShadowPath) {
+    shadowBinDir = await fs.mkdtemp(path.join(os.tmpdir(), 'clawboo-shadow-bin-'))
+    const allowedBins = ['node', 'npm', 'pnpm', 'which', 'ls']
+    for (const dir of ['/usr/bin', '/bin', '/usr/local/bin', path.dirname(process.execPath)]) {
+      for (const bin of allowedBins) {
+        const src = path.join(dir, bin)
+        try {
+          await fs.access(src)
+          await fs.symlink(src, path.join(shadowBinDir, bin)).catch(() => {})
+        } catch {
+          /* skip missing */
+        }
       }
     }
+    cliEnvPath = shadowBinDir
   }
 
   // 6. Spawn the CLI binary
   cliProc = spawn('node', [CLI_PATH], {
     env: {
-      PATH: shadowBinDir,
+      PATH: cliEnvPath,
       HOME: tmpDir,
+      // Windows uses USERPROFILE — Node's os.homedir() reads it. Keep it
+      // pointed at the isolated state dir so any HOME-derived state goes
+      // there too.
+      USERPROFILE: tmpDir,
       OPENCLAW_STATE_DIR: path.join(tmpDir, '.openclaw'),
       STUDIO_ACCESS_TOKEN: '',
       CLAWBOO_API_PORT: '',


### PR DESCRIPTION
## Summary

- Fixes onboarding failures caused by the OpenClaw protocol 4 upgrade by updating the gateway client handshake and pinning installs to `openclaw@^2026.5`.
- Fixes Windows install failures caused by `spawn npm ENOENT` by adding cross-platform executable detection and shim resolution for spawn/exec paths.
- Adds test and CI coverage for protocol compatibility, Windows platform handling, and bundled install smoke testing to prevent these regressions from shipping again.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff