### PR TITLE
fix(ci): bump smoke-test HTTP timeout to 20s for Windows runner

### DIFF
--- a/scripts/test-clean-install.mjs
+++ b/scripts/test-clean-install.mjs
@@ -45,7 +45,12 @@ const REPO_ROOT = path.resolve(__dirname, '..')
 const CLI_PATH = path.join(REPO_ROOT, 'apps/cli/dist/index.js')
 const FAKE_PORT = 18791
 const READY_TIMEOUT_MS = 30_000
-const HTTP_TIMEOUT_MS = 5_000
+// /api/system/status does multiple I/O ops: filesystem checks for
+// openclaw.json + .env, a 2-s probeGatewayPort fetch to :18789, plus
+// the openclaw binary probe via which/where. On Windows CI runners the
+// cumulative latency exceeded 5 s in practice. 20 s is a generous cap
+// that still fails fast on real hangs.
+const HTTP_TIMEOUT_MS = 20_000
 
 // ─── Tiny logger ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Increases the smoke-test HTTP timeout from 5s to 20s for the Windows CI runner.
- Prevents `/api/system/status` from failing with `AbortError` on `windows-latest` due to cumulative I/O and probe latency.
- Unblocks the smoke-test-bundle matrix entry so Version Packages PRs can pass CI cleanly before publish is retried.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed — CI timeout fix)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff