### PR TITLE
feat(connection): in-dashboard device pairing approval for OpenClaw 2026.5+

### DIFF
--- a/.changeset/open-candies-camp.md
+++ b/.changeset/open-candies-camp.md
@@ -1,0 +1,26 @@
+---
+'clawboo': patch
+---
+
+feat(connection): in-dashboard device pairing approval for OpenClaw 2026.5+.
+
+OpenClaw 2026.5.x dropped auto-pair-on-first-connect. Every fresh
+Clawboo install hits a NOT_PAIRED rejection on first connect, requiring
+the user to drop into a terminal and run two openclaw CLI commands.
+
+This release adds an inline "Approve this device" UI in the Gateway
+connect screen. When the connect throws NOT_PAIRED, the form swaps to
+a single button that hits a new POST /api/system/approve-device
+endpoint. The server shells out to `openclaw devices approve --latest`
+to extract the pending requestId, then `openclaw devices approve <UUID>`
+for the actual approval (--latest alone is a preview-only flag; the
+explicit ID is required for approval).
+
+After approval, the SPA auto-retries the original connect attempt with
+the same URL + token state. Users complete onboarding with a single
+button click instead of context-switching to a terminal.
+
+The approval UI also shows the manual CLI fallback (openclaw devices
+approve --latest → openclaw devices approve <requestId>) as a footer
+hint for power users who prefer terminal workflows or whose openclaw
+CLI is on a non-standard PATH.

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -18,6 +18,7 @@ import {
   openclawConfigGET,
   openclawConfigPATCH,
   systemModelsGET,
+  approveDevicePOST,
 } from './system'
 import {
   teamsGET,
@@ -89,6 +90,7 @@ router.post('/api/system/gateway', gatewayControlPOST)
 router.get('/api/system/openclaw-config', openclawConfigGET)
 router.patch('/api/system/openclaw-config', openclawConfigPATCH)
 router.get('/api/system/models', systemModelsGET)
+router.post('/api/system/approve-device', approveDevicePOST)
 
 // Teams
 router.get('/api/teams', teamsGET)

--- a/apps/web/server/api/system.ts
+++ b/apps/web/server/api/system.ts
@@ -334,6 +334,59 @@ export async function systemStatusGET(_req: Request, res: Response): Promise<voi
   }
 }
 
+// POST /api/system/approve-device
+//
+// Approves the most-recently pending OpenClaw device pairing request.
+// Required because OpenClaw 2026.5.x dropped the auto-pair-on-first-connect
+// behavior — now every fresh install must approve its device once. Without
+// this endpoint, users hit a raw "Gateway error (NOT_PAIRED): pairing
+// required: device is not approved yet" with no in-product remediation.
+//
+// Two-step implementation:
+//   1. `openclaw devices approve --latest` is a PREVIEW (per the CLI's own
+//      help text: "Show the most recent pending request to approve
+//      explicitly"). It prints the pending requestId in the line:
+//        "Approve this exact request with: openclaw devices approve <UUID>"
+//   2. We parse that UUID, then run `openclaw devices approve <UUID>` to
+//      actually perform the approval. (There's no --yes / one-shot flag.)
+export async function approveDevicePOST(_req: Request, res: Response): Promise<void> {
+  const oc = detectOpenClaw()
+  if (!oc.installed || !oc.path) {
+    res.status(400).json({ error: 'OpenClaw not installed' })
+    return
+  }
+  try {
+    // Step 1: preview to get the pending requestId.
+    const previewOut = execFileSync(oc.path, ['devices', 'approve', '--latest'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    })
+    // Regex matches the documented "openclaw devices approve <UUID>" line.
+    // Loose enough to survive minor wording changes (catches any line that
+    // ends with the canonical approve command + UUID).
+    const match = previewOut.match(/openclaw devices approve\s+([a-f0-9-]{36})/i)
+    if (!match) {
+      res.status(404).json({
+        error: 'No pending device pairing requests found',
+        details: previewOut.trim().slice(0, 500),
+      })
+      return
+    }
+    const requestId = match[1]
+
+    // Step 2: actually approve with the explicit ID.
+    const approveOut = execFileSync(oc.path, ['devices', 'approve', requestId], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    })
+    res.json({ ok: true, requestId, output: approveOut.trim().slice(0, 1000) })
+  } catch (err) {
+    res.status(500).json({
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
 // POST /api/system/install-openclaw
 export async function installOpenclawPOST(_req: Request, res: Response): Promise<void> {
   res.setHeader('Content-Type', 'text/event-stream')

--- a/apps/web/src/features/connection/DevicePairingApproval.tsx
+++ b/apps/web/src/features/connection/DevicePairingApproval.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useState } from 'react'
+import { motion } from 'framer-motion'
+import { CheckCircle2, Loader2, ShieldCheck } from 'lucide-react'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type DevicePairingApprovalProps = {
+  /**
+   * Called after a successful approval — caller is responsible for retrying
+   * the failed Gateway connect attempt.
+   */
+  onApproved: () => void
+  /** Optional cancel handler (e.g. to return to the connect form). */
+  onCancel?: () => void
+}
+
+type Phase = 'idle' | 'approving' | 'approved' | 'error'
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Renders an inline "Approve this device" UI when the WebSocket connect
+ * fails with `code === 'NOT_PAIRED'`. Triggered by `GatewayConnectScreen`
+ * and `GatewayBootstrap` when OpenClaw 2026.5.x rejects the proxy's device
+ * because it hasn't been approved yet.
+ *
+ * Single button → `POST /api/system/approve-device` → on 200, calls
+ * `onApproved` so the caller can retry the connect.
+ */
+export function DevicePairingApproval({ onApproved, onCancel }: DevicePairingApprovalProps) {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleApprove = useCallback(async () => {
+    setPhase('approving')
+    setErrorMessage(null)
+    try {
+      const res = await fetch('/api/system/approve-device', { method: 'POST' })
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean
+        error?: string
+        details?: string
+      }
+      if (!res.ok || !data.ok) {
+        setErrorMessage(
+          data.error ||
+            data.details ||
+            `Approval failed (HTTP ${res.status}). Check that OpenClaw is installed and the Gateway is running.`,
+        )
+        setPhase('error')
+        return
+      }
+      setPhase('approved')
+      // Brief success flash, then hand off to caller to retry the connect.
+      setTimeout(() => {
+        onApproved()
+      }, 700)
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : String(err))
+      setPhase('error')
+    }
+  }, [onApproved])
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18 }}
+      className="flex flex-col gap-4"
+      data-testid="device-pairing-approval"
+    >
+      {/* Header */}
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent/10 ring-1 ring-accent/20">
+          <ShieldCheck className="h-4 w-4 text-accent" strokeWidth={2.25} />
+        </div>
+        <div className="flex flex-col gap-1">
+          <h2
+            className="text-[15px] font-semibold tracking-tight text-text"
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            Approve this device
+          </h2>
+          <p className="text-[12px] leading-snug text-secondary">
+            OpenClaw 2026.5+ requires you to approve new devices before they can connect. This is a
+            one-time step on this machine.
+          </p>
+        </div>
+      </div>
+
+      {/* Status / error */}
+      {phase === 'error' && errorMessage && (
+        <div
+          role="alert"
+          data-testid="device-pairing-error"
+          className="rounded-lg border border-destructive/20 bg-destructive/8 px-3 py-2 text-[12px] leading-snug text-destructive"
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      {phase === 'approved' && (
+        <div
+          role="status"
+          className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/8 px-3 py-2 text-[12px] leading-snug text-emerald-400"
+        >
+          <CheckCircle2 className="h-3.5 w-3.5" strokeWidth={2.5} />
+          Approved. Reconnecting…
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => void handleApprove()}
+          disabled={phase === 'approving' || phase === 'approved'}
+          data-testid="device-pairing-approve-button"
+          className="flex h-10 flex-1 items-center justify-center gap-2 rounded-lg bg-accent font-mono text-[12px] font-semibold tracking-wide text-white shadow-sm transition hover:brightness-110 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {phase === 'approving' && (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={2.5} />
+              Approving…
+            </>
+          )}
+          {phase === 'approved' && (
+            <>
+              <CheckCircle2 className="h-3.5 w-3.5" strokeWidth={2.5} />
+              Approved
+            </>
+          )}
+          {(phase === 'idle' || phase === 'error') && 'Approve this device'}
+        </button>
+        {onCancel && phase !== 'approving' && phase !== 'approved' && (
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="device-pairing-cancel-button"
+            className="h-10 rounded-lg border border-white/8 bg-transparent px-3 font-mono text-[12px] text-secondary transition hover:bg-white/4"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {/* Footer hint — how to do it manually */}
+      <p className="font-mono text-[10px] leading-relaxed text-secondary/40">
+        Or from your terminal:{' '}
+        <code className="rounded bg-white/4 px-1 py-0.5 text-secondary/60">
+          openclaw devices approve --latest
+        </code>{' '}
+        then{' '}
+        <code className="rounded bg-white/4 px-1 py-0.5 text-secondary/60">
+          openclaw devices approve &lt;requestId&gt;
+        </code>
+        .
+      </p>
+    </motion.div>
+  )
+}

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -19,7 +19,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Loader2, RotateCcw } from 'lucide-react'
-import { GatewayClient, resolveProxyGatewayUrl } from '@clawboo/gateway-client'
+import {
+  GatewayClient,
+  GatewayResponseError,
+  resolveProxyGatewayUrl,
+} from '@clawboo/gateway-client'
 import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
 import type { DbApprovalHistory } from '@clawboo/db'
 import { GatewayConnectScreen } from './GatewayConnectScreen'
@@ -476,6 +480,15 @@ export function GatewayBootstrap() {
             preloadApprovalHistory()
           } catch (err) {
             setStartingGateway(false)
+            // OpenClaw 2026.5+ rejects unapproved devices with NOT_PAIRED.
+            // The GatewayConnectScreen has an in-product pairing flow — close
+            // this overlay so the user lands there. Otherwise they see a raw
+            // gateway error and have no obvious next action.
+            if (err instanceof GatewayResponseError && err.code === 'NOT_PAIRED') {
+              setGatewayOffline(false)
+              setStartGatewayError(null)
+              return
+            }
             setStartGatewayError(
               err instanceof Error ? err.message : 'Failed to connect after starting Gateway',
             )

--- a/apps/web/src/features/connection/GatewayConnectScreen.tsx
+++ b/apps/web/src/features/connection/GatewayConnectScreen.tsx
@@ -3,11 +3,13 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Eye, EyeOff, Loader2 } from 'lucide-react'
 import {
   GatewayClient,
+  GatewayResponseError,
   formatGatewayError,
   isLocalGatewayUrl,
   resolveProxyGatewayUrl,
 } from '@clawboo/gateway-client'
 import { useConnectionStore } from '@/stores/connection'
+import { DevicePairingApproval } from './DevicePairingApproval'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -39,6 +41,10 @@ export function GatewayConnectScreen({
   const [showToken, setShowToken] = useState(false)
   const [connecting, setConnecting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Set when the gateway rejects the connect with NOT_PAIRED. Renders the
+  // DevicePairingApproval component in place of the connect form until the
+  // user approves the device (one-time, OpenClaw 2026.5+ requirement).
+  const [needsPairing, setNeedsPairing] = useState(false)
 
   // Stable GatewayClient instance — created once, reused across retries
   const clientRef = useRef<GatewayClient | null>(null)
@@ -117,6 +123,17 @@ export function GatewayConnectScreen({
       setGatewayUrl(trimmedUrl)
       onConnected(client)
     } catch (err) {
+      // OpenClaw 2026.5+ requires explicit device-pairing approval before a
+      // new client can connect. Detect that specific rejection and surface
+      // the in-dashboard approval UI instead of the raw error toast.
+      if (err instanceof GatewayResponseError && err.code === 'NOT_PAIRED') {
+        setNeedsPairing(true)
+        setError(null)
+        setStatus('error')
+        setConnecting(false)
+        clientRef.current = null
+        return
+      }
       const message = formatGatewayError(err)
       setError(message)
       setStatus('error')
@@ -125,6 +142,13 @@ export function GatewayConnectScreen({
       clientRef.current = null
     }
   }, [url, token, connecting, setStatus, setGatewayUrl, onConnected])
+
+  // Called by DevicePairingApproval once the user approves. We auto-retry
+  // the original connect with the existing form values.
+  const handlePairingApproved = useCallback(() => {
+    setNeedsPairing(false)
+    void handleConnect()
+  }, [handleConnect])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -171,120 +195,128 @@ export function GatewayConnectScreen({
           </div>
         </div>
 
-        {/* ── Form ── */}
-        <div className="flex flex-col gap-4" onKeyDown={handleKeyDown} role="group">
-          {/* Gateway URL */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="gateway-url"
-              className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary"
-            >
-              Gateway URL
-            </label>
-            <input
-              id="gateway-url"
-              type="text"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="ws://localhost:18789"
-              spellCheck={false}
-              autoComplete="off"
-              disabled={connecting}
-              data-testid="gateway-url-input"
-              className="h-10 rounded-lg border border-white/10 bg-background px-3 font-mono text-[13px] text-text outline-none transition placeholder:text-secondary/30 focus:border-white/20 focus:ring-1 focus:ring-ring/30 disabled:opacity-50"
-            />
-            {isLocal && (
-              <p className="font-mono text-[10px] text-mint/60">Local gateway detected</p>
-            )}
-          </div>
-
-          {/* Gateway token */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="gateway-token"
-              className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary"
-            >
-              Token{' '}
-              <span className="normal-case font-normal text-secondary/50">
-                {initialHasToken ? '(saved)' : '(optional)'}
-              </span>
-            </label>
-            <div className="relative">
+        {/* ── Pairing-approval branch (OpenClaw 2026.5+ NOT_PAIRED) ── */}
+        {needsPairing ? (
+          <DevicePairingApproval
+            onApproved={handlePairingApproved}
+            onCancel={() => setNeedsPairing(false)}
+          />
+        ) : (
+          /* ── Form ── */
+          <div className="flex flex-col gap-4" onKeyDown={handleKeyDown} role="group">
+            {/* Gateway URL */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="gateway-url"
+                className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary"
+              >
+                Gateway URL
+              </label>
               <input
-                id="gateway-token"
-                type={showToken ? 'text' : 'password'}
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                onFocus={() => {
-                  // Clear placeholder dots so user can type real value
-                  if (token === '••••••••') setToken('')
-                }}
-                placeholder="gateway-token"
+                id="gateway-url"
+                type="text"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="ws://localhost:18789"
                 spellCheck={false}
-                autoComplete="current-password"
+                autoComplete="off"
                 disabled={connecting}
-                data-testid="gateway-token-input"
-                className="h-10 w-full rounded-lg border border-white/10 bg-background px-3 pr-10 font-mono text-[13px] text-text outline-none transition placeholder:text-secondary/30 focus:border-white/20 focus:ring-1 focus:ring-ring/30 disabled:opacity-50"
+                data-testid="gateway-url-input"
+                className="h-10 rounded-lg border border-white/10 bg-background px-3 font-mono text-[13px] text-text outline-none transition placeholder:text-secondary/30 focus:border-white/20 focus:ring-1 focus:ring-ring/30 disabled:opacity-50"
               />
-              <button
-                type="button"
-                tabIndex={-1}
-                onClick={() => setShowToken((v) => !v)}
-                aria-label={showToken ? 'Hide token' : 'Show token'}
-                className="absolute inset-y-0 right-2 flex items-center text-secondary/40 transition hover:text-secondary"
-              >
-                {showToken ? (
-                  <EyeOff className="h-4 w-4" strokeWidth={1.75} />
-                ) : (
-                  <Eye className="h-4 w-4" strokeWidth={1.75} />
-                )}
-              </button>
+              {isLocal && (
+                <p className="font-mono text-[10px] text-mint/60">Local gateway detected</p>
+              )}
             </div>
-            <p className="font-mono text-[10px] text-secondary/40">
-              Leave empty for unauthenticated local gateways.
-            </p>
-          </div>
 
-          {/* Error message */}
-          <AnimatePresence initial={false}>
-            {error && (
-              <motion.div
-                key="error"
-                initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                animate={{ opacity: 1, height: 'auto', marginTop: 0 }}
-                exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                transition={{ duration: 0.15 }}
-                className="overflow-hidden"
+            {/* Gateway token */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="gateway-token"
+                className="font-mono text-[10px] font-semibold uppercase tracking-widest text-secondary"
               >
-                <div
-                  role="alert"
-                  data-testid="gateway-connect-error"
-                  className="rounded-lg border border-destructive/20 bg-destructive/8 px-3 py-2 text-[12px] leading-snug text-destructive"
+                Token{' '}
+                <span className="normal-case font-normal text-secondary/50">
+                  {initialHasToken ? '(saved)' : '(optional)'}
+                </span>
+              </label>
+              <div className="relative">
+                <input
+                  id="gateway-token"
+                  type={showToken ? 'text' : 'password'}
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  onFocus={() => {
+                    // Clear placeholder dots so user can type real value
+                    if (token === '••••••••') setToken('')
+                  }}
+                  placeholder="gateway-token"
+                  spellCheck={false}
+                  autoComplete="current-password"
+                  disabled={connecting}
+                  data-testid="gateway-token-input"
+                  className="h-10 w-full rounded-lg border border-white/10 bg-background px-3 pr-10 font-mono text-[13px] text-text outline-none transition placeholder:text-secondary/30 focus:border-white/20 focus:ring-1 focus:ring-ring/30 disabled:opacity-50"
+                />
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={() => setShowToken((v) => !v)}
+                  aria-label={showToken ? 'Hide token' : 'Show token'}
+                  className="absolute inset-y-0 right-2 flex items-center text-secondary/40 transition hover:text-secondary"
                 >
-                  {error}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+                  {showToken ? (
+                    <EyeOff className="h-4 w-4" strokeWidth={1.75} />
+                  ) : (
+                    <Eye className="h-4 w-4" strokeWidth={1.75} />
+                  )}
+                </button>
+              </div>
+              <p className="font-mono text-[10px] text-secondary/40">
+                Leave empty for unauthenticated local gateways.
+              </p>
+            </div>
 
-          {/* Connect button */}
-          <button
-            type="button"
-            onClick={() => void handleConnect()}
-            disabled={connectDisabled}
-            data-testid="gateway-connect-button"
-            className="mt-1 flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-accent font-mono text-[13px] font-semibold tracking-wide text-white shadow-sm transition hover:brightness-110 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {connecting ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.5} />
-                Connecting…
-              </>
-            ) : (
-              'Connect'
-            )}
-          </button>
-        </div>
+            {/* Error message */}
+            <AnimatePresence initial={false}>
+              {error && (
+                <motion.div
+                  key="error"
+                  initial={{ opacity: 0, height: 0, marginTop: 0 }}
+                  animate={{ opacity: 1, height: 'auto', marginTop: 0 }}
+                  exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                  transition={{ duration: 0.15 }}
+                  className="overflow-hidden"
+                >
+                  <div
+                    role="alert"
+                    data-testid="gateway-connect-error"
+                    className="rounded-lg border border-destructive/20 bg-destructive/8 px-3 py-2 text-[12px] leading-snug text-destructive"
+                  >
+                    {error}
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            {/* Connect button */}
+            <button
+              type="button"
+              onClick={() => void handleConnect()}
+              disabled={connectDisabled}
+              data-testid="gateway-connect-button"
+              className="mt-1 flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-accent font-mono text-[13px] font-semibold tracking-wide text-white shadow-sm transition hover:brightness-110 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {connecting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" strokeWidth={2.5} />
+                  Connecting…
+                </>
+              ) : (
+                'Connect'
+              )}
+            </button>
+          </div>
+        )}
 
         {/* ── Footer hint ── */}
         <p className="mt-6 text-center font-mono text-[10px] text-secondary/30">


### PR DESCRIPTION
## Summary

- Adds an in-dashboard device pairing approval flow for OpenClaw `2026.5+`, so users can approve pending devices directly from the Gateway connect screen.
- Introduces a new `/api/system/approve-device` endpoint that shells out to `openclaw devices approve` and automatically retries the original connection after approval.
- Improves onboarding by detecting `NOT_PAIRED` errors, surfacing an inline “Approve this device” action, and returning users to the connect flow instead of leaving them with a raw error state.

## Type

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff