### PR TITLE
fix(connection): device pairing on fresh macOS install

### DIFF
--- a/.changeset/device-pairing-macos-fixes.md
+++ b/.changeset/device-pairing-macos-fixes.md
@@ -1,0 +1,8 @@
+---
+'clawboo': patch
+---
+
+Fix device pairing on fresh macOS installs (v0.1.7):
+
+- `POST /api/system/approve-device` now uses `spawnSync` for the `openclaw devices approve --latest` preview step so the CLI's preview-mode non-zero exit code no longer swallows the request-id stdout we need to parse. Step 2 (the real approval) keeps `execFileSync` but surfaces `stderr` / `stdout` from any thrown error instead of Node's `Command failed: <argv>` wrapper.
+- The onboarding wizard's `StartGatewayStep` now catches `GatewayResponseError { code: 'NOT_PAIRED' }` and renders the in-product `DevicePairingApproval` card inline. Users no longer have to do a manual page refresh to escape the wizard's "Something went wrong" panel on a fresh-install machine with OpenClaw 2026.5.x. After approval, the wizard auto-retries the connect and advances normally.

--- a/apps/web/server/api/system.ts
+++ b/apps/web/server/api/system.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
-import { execFileSync, spawn } from 'node:child_process'
+import { execFileSync, spawn, spawnSync } from 'node:child_process'
 import { resolveStateDir, loadSettings, saveSettings } from '@clawboo/config'
 import {
   readGatewayPid,
@@ -343,46 +343,71 @@ export async function systemStatusGET(_req: Request, res: Response): Promise<voi
 // required: device is not approved yet" with no in-product remediation.
 //
 // Two-step implementation:
-//   1. `openclaw devices approve --latest` is a PREVIEW (per the CLI's own
-//      help text: "Show the most recent pending request to approve
-//      explicitly"). It prints the pending requestId in the line:
-//        "Approve this exact request with: openclaw devices approve <UUID>"
-//   2. We parse that UUID, then run `openclaw devices approve <UUID>` to
-//      actually perform the approval. (There's no --yes / one-shot flag.)
+//   1. `openclaw devices approve --latest` is a PREVIEW on 2026.5.x — the
+//      CLI prints "Approve this exact request with: openclaw devices approve
+//      <UUID>" AND exits non-zero (the non-zero is the CLI's own "preview
+//      only — run the real command next" signal). We parse the UUID out of
+//      the captured stdout/stderr.
+//   2. We then run `openclaw devices approve <UUID>` to actually perform
+//      the approval. There's no --yes / one-shot flag in OpenClaw 2026.5.x.
+//
+// v0.1.7 fix: step 1 MUST use spawnSync (returns a result object) rather
+// than execFileSync (throws on non-zero exit). v0.1.5 used execFileSync
+// here and the throw discarded the stdout containing the requestId before
+// the regex could run, so the user saw "Command failed: …" in the SPA's
+// approval dialog instead of a successful approval.
 export async function approveDevicePOST(_req: Request, res: Response): Promise<void> {
   const oc = detectOpenClaw()
   if (!oc.installed || !oc.path) {
     res.status(400).json({ error: 'OpenClaw not installed' })
     return
   }
-  try {
-    // Step 1: preview to get the pending requestId.
-    const previewOut = execFileSync(oc.path, ['devices', 'approve', '--latest'], {
-      encoding: 'utf8',
-      timeout: 5_000,
-    })
-    // Regex matches the documented "openclaw devices approve <UUID>" line.
-    // Loose enough to survive minor wording changes (catches any line that
-    // ends with the canonical approve command + UUID).
-    const match = previewOut.match(/openclaw devices approve\s+([a-f0-9-]{36})/i)
-    if (!match) {
-      res.status(404).json({
-        error: 'No pending device pairing requests found',
-        details: previewOut.trim().slice(0, 500),
-      })
-      return
-    }
-    const requestId = match[1]
 
-    // Step 2: actually approve with the explicit ID.
+  // Step 1: preview to discover the pending requestId.
+  const preview = spawnSync(oc.path, ['devices', 'approve', '--latest'], {
+    encoding: 'utf8',
+    timeout: 5_000,
+  })
+
+  if (preview.error) {
+    // Spawn-level failure (ENOENT, timeout, etc.) — distinct from the child
+    // exiting non-zero in preview mode.
+    res.status(500).json({ error: `Failed to run openclaw: ${preview.error.message}` })
+    return
+  }
+
+  // Scan both channels defensively — different openclaw versions may emit
+  // the requestId line to either stdout or stderr.
+  const combined = `${preview.stdout ?? ''}\n${preview.stderr ?? ''}`
+  const match = combined.match(/openclaw devices approve\s+([a-f0-9-]{36})/i)
+  if (!match) {
+    res.status(404).json({
+      error: 'No pending device pairing requests found',
+      details: combined.trim().slice(0, 500),
+    })
+    return
+  }
+  const requestId = match[1]
+
+  // Step 2: actually approve with the explicit UUID. Non-zero exit here IS
+  // a real failure — surface stderr cleanly instead of Node's "Command
+  // failed: <argv>" wrapper.
+  try {
     const approveOut = execFileSync(oc.path, ['devices', 'approve', requestId], {
       encoding: 'utf8',
       timeout: 10_000,
     })
     res.json({ ok: true, requestId, output: approveOut.trim().slice(0, 1000) })
   } catch (err) {
+    const stderr = (err as { stderr?: Buffer | string }).stderr
+    const stdout = (err as { stdout?: Buffer | string }).stdout
+    const message =
+      String(stderr ?? '').trim() ||
+      String(stdout ?? '').trim() ||
+      (err instanceof Error ? err.message : String(err))
     res.status(500).json({
-      error: err instanceof Error ? err.message : String(err),
+      error: `Failed to approve device: ${message.slice(0, 500)}`,
+      requestId,
     })
   }
 }

--- a/apps/web/src/features/onboarding/steps/StartGatewayStep.tsx
+++ b/apps/web/src/features/onboarding/steps/StartGatewayStep.tsx
@@ -9,9 +9,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowLeft, Check, ChevronDown, Loader2, RotateCcw } from 'lucide-react'
-import { GatewayClient, resolveProxyGatewayUrl } from '@clawboo/gateway-client'
+import {
+  GatewayClient,
+  GatewayResponseError,
+  resolveProxyGatewayUrl,
+} from '@clawboo/gateway-client'
 import { consumeSSE } from '@/lib/sseClient'
 import { useSystemStore } from '@/stores/system'
+import { DevicePairingApproval } from '@/features/connection/DevicePairingApproval'
 import { StepIndicator } from '../StepIndicator'
 
 // ─── Props ───────────────────────────────────────────────────────────────────
@@ -23,13 +28,16 @@ export type StartGatewayStepProps = {
 
 // ─── Status phases ───────────────────────────────────────────────────────────
 
-type Phase = 'starting' | 'connecting' | 'connected' | 'error'
+type Phase = 'starting' | 'connecting' | 'connected' | 'error' | 'pairing-required'
 
 const PHASE_LABELS: Record<Phase, string> = {
   starting: 'Starting Gateway…',
   connecting: 'Connecting…',
   connected: 'Connected!',
   error: 'Something went wrong',
+  // 'pairing-required' hides the status label entirely — the
+  // DevicePairingApproval card below has its own "Approve this device" header.
+  'pairing-required': '',
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
@@ -65,6 +73,17 @@ export function StartGatewayStep({ onStarted, onBack }: StartGatewayStepProps) {
       setGatewayControlStatus('running')
       onStarted(client)
     } catch (err) {
+      // OpenClaw 2026.5+ rejects unapproved devices with NOT_PAIRED on first
+      // connect. Render the in-product approval card inline instead of
+      // showing the generic "Something went wrong" error — saves the user
+      // from having to refresh the page to escape the wizard. After they
+      // click Approve, `onApproved` calls autoConnect() again and the
+      // wizard advances to the next step normally.
+      if (err instanceof GatewayResponseError && err.code === 'NOT_PAIRED') {
+        setPhase('pairing-required')
+        clientRef.current = null
+        return
+      }
       setPhase('error')
       setGatewayControlStatus('error')
       setErrorMessage(err instanceof Error ? err.message : 'Failed to connect to Gateway')
@@ -159,7 +178,7 @@ export function StartGatewayStep({ onStarted, onBack }: StartGatewayStepProps) {
                     scale: [1, 1.06, 1],
                     opacity: [0.4, 0.7, 0.4],
                   }
-                : phase === 'connected'
+                : phase === 'connected' || phase === 'pairing-required'
                   ? { scale: 1, opacity: 1 }
                   : { scale: 1, opacity: 0.3 }
             }
@@ -175,34 +194,52 @@ export function StartGatewayStep({ onStarted, onBack }: StartGatewayStepProps) {
           />
         </div>
 
-        {/* ── Status text ───────────────────────────────────── */}
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={phase}
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -6 }}
-            transition={{ duration: 0.2 }}
-            className="mb-1 flex items-center gap-2"
-          >
-            {phase === 'connected' && <Check className="h-4 w-4 text-mint" strokeWidth={2.5} />}
-            {isRunning && (
-              <Loader2 className="h-4 w-4 animate-spin text-accent" strokeWidth={2.5} />
-            )}
-            <span
-              className={[
-                'text-[15px] font-semibold',
-                phase === 'connected'
-                  ? 'text-mint'
-                  : phase === 'error'
-                    ? 'text-destructive'
-                    : 'text-text',
-              ].join(' ')}
-              style={{ fontFamily: 'var(--font-display)' }}
+        {/* ── Status text (hidden during pairing — approval card owns its own header) ── */}
+        {phase !== 'pairing-required' && (
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={phase}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={{ duration: 0.2 }}
+              className="mb-1 flex items-center gap-2"
             >
-              {PHASE_LABELS[phase]}
-            </span>
-          </motion.div>
+              {phase === 'connected' && <Check className="h-4 w-4 text-mint" strokeWidth={2.5} />}
+              {isRunning && (
+                <Loader2 className="h-4 w-4 animate-spin text-accent" strokeWidth={2.5} />
+              )}
+              <span
+                className={[
+                  'text-[15px] font-semibold',
+                  phase === 'connected'
+                    ? 'text-mint'
+                    : phase === 'error'
+                      ? 'text-destructive'
+                      : 'text-text',
+                ].join(' ')}
+                style={{ fontFamily: 'var(--font-display)' }}
+              >
+                {PHASE_LABELS[phase]}
+              </span>
+            </motion.div>
+          </AnimatePresence>
+        )}
+
+        {/* ── Device pairing approval (OpenClaw 2026.5+ NOT_PAIRED) ── */}
+        <AnimatePresence initial={false}>
+          {phase === 'pairing-required' && (
+            <motion.div
+              key="pairing"
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={{ opacity: 0, height: 0 }}
+              transition={{ duration: 0.18 }}
+              className="mt-2 mb-4 w-full overflow-hidden"
+            >
+              <DevicePairingApproval onApproved={() => void autoConnect()} />
+            </motion.div>
+          )}
         </AnimatePresence>
 
         {/* ── Log toggle ─────────────────────────────────────── */}


### PR DESCRIPTION
## Summary

- Fixes device approval for fresh OpenClaw `2026.5.x` installs by handling the preview-step non-zero exit correctly when extracting the pending pairing request ID.
- Improves approval error handling by surfacing useful `stdout`/`stderr` output instead of Node’s generic command-failed wrapper when the real approval step fails.
- Fixes onboarding dead-ends by handling `NOT_PAIRED` directly in `StartGatewayStep` and showing inline device approval without requiring a full-page refresh.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff