### PR TITLE
fix(system): Windows .cmd spawn compat (bundles into v0.1.7)

### DIFF
--- a/.changeset/windows-cmd-compat.md
+++ b/.changeset/windows-cmd-compat.md
@@ -1,0 +1,18 @@
+---
+'clawboo': patch
+---
+
+Fix Windows `.cmd` spawn compat (bundled into v0.1.7):
+
+Windows users hit a "Network error" message at the install-OpenClaw step in the onboarding wizard (and would have hit the same failure mode at gateway start, device-pair approval, and the model-list cache if they got past install). Root cause: Node 18.20.2+ / 20.12.2+ / 22+ refuse to spawn `.cmd` / `.bat` files without `shell: true` (CVE-2024-27980 hardening). The throw happened SYNCHRONOUSLY at the spawn call site, escaped the request handler after SSE headers were already flushed, and the browser surfaced the dropped connection as "Network error" with no actionable detail.
+
+Added `shell: isWindows` to all six `child_process` call sites that target `.cmd` shims on Windows:
+
+- `detectOpenClaw` (system.ts) — `execFileSync(openclaw.cmd, ['--version'])`
+- `approveDevicePOST` step 1 (system.ts) — `spawnSync(openclaw.cmd, ['devices', 'approve', '--latest'])`
+- `approveDevicePOST` step 2 (system.ts) — `execFileSync(openclaw.cmd, ['devices', 'approve', <UUID>])`
+- `installOpenclawPOST` (system.ts) — `spawn(npm.cmd, ['install', '-g', 'openclaw@^2026.5'])`
+- `gatewayControlPOST` start (system.ts) — `spawn(openclaw.cmd, ['gateway', ...])`
+- `getModelsFromCli` (modelCache.ts) — `execFileAsync(openclaw.cmd, ['models', 'list', '--all', '--json'])`
+
+The two SSE-emitting spawn sites (install + gateway start) additionally got wrapped in try/catch so synchronous spawn throws now produce a clean `SPAWN_THROW` SSE error event with the actual error message instead of crashing the request handler. The misleading comment in `detectOpenClaw` claiming Node 22 handles full-path `.cmd` invocation correctly was corrected. `shell: isWindows` is a no-op on Unix, so the change is Windows-only at runtime.

--- a/apps/web/server/api/system.ts
+++ b/apps/web/server/api/system.ts
@@ -13,7 +13,7 @@ import {
   findProcessByPort,
 } from '../lib/processManager'
 import { getModelsFromCli } from '../lib/modelCache'
-import { findExecutable, resolveShimName } from '../lib/platform'
+import { findExecutable, isWindows, resolveShimName } from '../lib/platform'
 import { MODEL_GROUPS as STATIC_MODEL_GROUPS } from '../../src/lib/modelCatalog'
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -60,10 +60,15 @@ function detectOpenClaw(): { installed: boolean; version: string | null; path: s
   const binPath = findExecutable('openclaw')
   if (!binPath) return { installed: false, version: null, path: null }
   try {
-    // Node 22 handles full-path .cmd invocation correctly (post
-    // CVE-2024-27980 fix in 20.12+), so passing a Windows .cmd path
-    // straight to execFileSync works.
-    const raw = execFileSync(binPath, ['--version'], { encoding: 'utf8' }).trim()
+    // `shell: isWindows` is required because Node 18.20.2+ / 20.12.2+ / 22+
+    // refuse to spawn .cmd / .bat files without it (CVE-2024-27980 fix).
+    // On Windows, binPath is the absolute path to openclaw.cmd, so this
+    // applies even though we're passing an absolute path. On Unix, the
+    // option is a no-op.
+    const raw = execFileSync(binPath, ['--version'], {
+      encoding: 'utf8',
+      shell: isWindows,
+    }).trim()
     const version = raw.replace(/^openclaw\s+v?/i, '').trim() || raw
     return { installed: true, version, path: binPath }
   } catch {
@@ -364,9 +369,13 @@ export async function approveDevicePOST(_req: Request, res: Response): Promise<v
   }
 
   // Step 1: preview to discover the pending requestId.
+  // `shell: isWindows` — required by Node 18.20.2+ / 20.12.2+ / 22+ when
+  // oc.path resolves to a .cmd shim on Windows (CVE-2024-27980 fix). No-op
+  // on Unix.
   const preview = spawnSync(oc.path, ['devices', 'approve', '--latest'], {
     encoding: 'utf8',
     timeout: 5_000,
+    shell: isWindows,
   })
 
   if (preview.error) {
@@ -393,9 +402,11 @@ export async function approveDevicePOST(_req: Request, res: Response): Promise<v
   // a real failure — surface stderr cleanly instead of Node's "Command
   // failed: <argv>" wrapper.
   try {
+    // `shell: isWindows` — see detectOpenClaw for rationale (CVE-2024-27980).
     const approveOut = execFileSync(oc.path, ['devices', 'approve', requestId], {
       encoding: 'utf8',
       timeout: 10_000,
+      shell: isWindows,
     })
     res.json({ ok: true, requestId, output: approveOut.trim().slice(0, 1000) })
   } catch (err) {
@@ -421,19 +432,41 @@ export async function installOpenclawPOST(_req: Request, res: Response): Promise
 
   sendEvent(res, { type: 'progress', step: 'installing', message: 'Installing OpenClaw...' })
 
-  // Two Windows-compat fixes folded into this call site:
+  // Three Windows-compat fixes folded into this call site:
   //   1. `resolveShimName('npm')` returns `npm.cmd` on Windows. Bare 'npm'
   //      throws ENOENT on Windows because Node's spawn doesn't auto-resolve
   //      .cmd extensions.
-  //   2. Pin to `openclaw@^2026.5` rather than `@latest`. OpenClaw bumped the
+  //   2. `shell: isWindows` — Node 18.20.2+ / 20.12.2+ / 22+ refuse to spawn
+  //      .cmd / .bat files without shell:true (CVE-2024-27980 fix). Without
+  //      it, spawn THROWS EINVAL synchronously, the throw escapes the
+  //      request handler after the SSE headers are already flushed, and the
+  //      browser surfaces the dropped connection as "Network error". On
+  //      Unix the option is a no-op.
+  //   3. Pin to `openclaw@^2026.5` rather than `@latest`. OpenClaw bumped the
   //      WS connect protocol from 3 to 4 in 2026.5.x, and Clawboo's
   //      gateway-client now advertises maxProtocol: 4 to match. A future
   //      OpenClaw 2026.6+ could bump to protocol 5; pinning to ^2026.5 means
   //      new users get a Clawboo-compatible openclaw until we widen the
   //      protocol range and ship a new clawboo.
-  const child = spawn(resolveShimName('npm'), ['install', '-g', 'openclaw@^2026.5'], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
+  let child
+  try {
+    child = spawn(resolveShimName('npm'), ['install', '-g', 'openclaw@^2026.5'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: isWindows,
+    })
+  } catch (err) {
+    // Defensive: if spawn throws synchronously (CVE-2024-27980 EINVAL, or
+    // any future similar guard), surface the actual error as an SSE event
+    // instead of crashing the request handler and letting the SPA show a
+    // generic "Network error" from the dropped fetch stream.
+    sendEvent(res, {
+      type: 'error',
+      code: 'SPAWN_THROW',
+      message: err instanceof Error ? err.message : String(err),
+    })
+    res.end()
+    return
+  }
 
   child.stdout?.on('data', (chunk: Buffer) => {
     const lines = chunk.toString().split('\n').filter(Boolean)
@@ -664,10 +697,26 @@ export async function gatewayControlPOST(req: Request, res: Response): Promise<v
       message: `Starting gateway on port ${port}...`,
     })
 
-    const child = spawn(oc.path, ['gateway', '--port', String(port), '--allow-unconfigured'], {
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    })
+    // `shell: isWindows` — required by Node 18.20.2+ / 20.12.2+ / 22+ when
+    // oc.path resolves to openclaw.cmd on Windows (CVE-2024-27980 fix).
+    // Without it, spawn throws EINVAL synchronously after SSE headers are
+    // flushed, and the SPA sees a dropped stream as "Network error".
+    let child
+    try {
+      child = spawn(oc.path, ['gateway', '--port', String(port), '--allow-unconfigured'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: isWindows,
+      })
+    } catch (err) {
+      sendEvent(res, {
+        type: 'error',
+        code: 'SPAWN_THROW',
+        message: err instanceof Error ? err.message : String(err),
+      })
+      res.end()
+      return
+    }
 
     child.unref()
 

--- a/apps/web/server/lib/modelCache.ts
+++ b/apps/web/server/lib/modelCache.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 
-import { resolveShimName } from './platform'
+import { isWindows, resolveShimName } from './platform'
 
 const execFileAsync = promisify(execFile)
 
@@ -60,12 +60,15 @@ export async function getModelsFromCli(): Promise<ModelGroup[] | null> {
   try {
     // On Windows, bare 'openclaw' is openclaw.cmd — Node spawn won't resolve
     // the .cmd extension by itself, so use the platform-aware shim name.
+    // `shell: isWindows` — Node 18.20.2+ / 20.12.2+ / 22+ refuse to spawn
+    // .cmd files without it (CVE-2024-27980 fix). On Unix it's a no-op.
     const { stdout } = await execFileAsync(
       resolveShimName('openclaw'),
       ['models', 'list', '--all', '--json'],
       {
         timeout: 15_000,
         env: { ...process.env },
+        shell: isWindows,
       },
     )
     const parsed = JSON.parse(stdout) as CliOutput | CliModel[]


### PR DESCRIPTION
## Summary

- Fixes Windows `.cmd` spawn compatibility by adding `shell: isWindows` to all affected `child_process` call sites that target `.cmd` shims.
- Prevents wizard failures during OpenClaw install and other setup steps on Windows, where Node’s newer hardening rejects spawning `.cmd` files without `shell: true`.
- Improves error handling for SSE-emitting spawn flows so synchronous spawn failures surface as clean SSE events instead of a generic network error.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff