### PR TITLE
fix(windows): harden v0.1.7 startup, deploy, and retry flows

### DIFF
--- a/.changeset/windows-cmd-compat.md
+++ b/.changeset/windows-cmd-compat.md
@@ -2,17 +2,15 @@
 'clawboo': patch
 ---
 
-Fix Windows `.cmd` spawn compat (bundled into v0.1.7):
+Windows compatibility hardening (bundled into v0.1.7):
 
-Windows users hit a "Network error" message at the install-OpenClaw step in the onboarding wizard (and would have hit the same failure mode at gateway start, device-pair approval, and the model-list cache if they got past install). Root cause: Node 18.20.2+ / 20.12.2+ / 22+ refuse to spawn `.cmd` / `.bat` files without `shell: true` (CVE-2024-27980 hardening). The throw happened SYNCHRONOUSLY at the spawn call site, escaped the request handler after SSE headers were already flushed, and the browser surfaced the dropped connection as "Network error" with no actionable detail.
+**Round 1 — `.cmd` spawn failures**: Windows users hit "Network error" at the install-OpenClaw step because Node 18.20.2+ refuses to launch `.cmd` / `.bat` files without `shell: true` (CVE-2024-27980 hardening). The throw escaped the request handler after SSE headers were flushed and the browser surfaced the dropped connection as a generic network failure. Added `shell: isWindows` to six `child_process` call sites that target `.cmd` shims (detectOpenClaw, approveDevicePOST steps 1+2, installOpenclawPOST, gatewayControlPOST start, getModelsFromCli) and wrapped the two SSE-emitting sites in try/catch so synchronous spawn errors surface as clean SSE events instead of crashing the request handler.
 
-Added `shell: isWindows` to all six `child_process` call sites that target `.cmd` shims on Windows:
+**Round 2 — Windows polish after live testing**: real-laptop testing of round-1 surfaced four more issues:
 
-- `detectOpenClaw` (system.ts) — `execFileSync(openclaw.cmd, ['--version'])`
-- `approveDevicePOST` step 1 (system.ts) — `spawnSync(openclaw.cmd, ['devices', 'approve', '--latest'])`
-- `approveDevicePOST` step 2 (system.ts) — `execFileSync(openclaw.cmd, ['devices', 'approve', <UUID>])`
-- `installOpenclawPOST` (system.ts) — `spawn(npm.cmd, ['install', '-g', 'openclaw@^2026.5'])`
-- `gatewayControlPOST` start (system.ts) — `spawn(openclaw.cmd, ['gateway', ...])`
-- `getModelsFromCli` (modelCache.ts) — `execFileAsync(openclaw.cmd, ['models', 'list', '--all', '--json'])`
+- `cmd.exe` console window popped up in front of the dashboard on every shellout — `shell: true` opens a visible console on Windows by default. Added `windowsHide: isWindows` alongside every `shell: isWindows` (six sites).
+- CLI dashboard poll timed out after 15s — bumped to 45s (90 × 500ms) in `apps/cli/src/index.ts` because the bundled CJS cold-boot on Windows is slow (Windows Defender real-time scanning + Node's first-load module compile).
+- `agents.create` timed out at 30s on team deploy — bumped the gateway-client's default RPC timeout from 30s to 60s and added per-call 120s overrides to `agents.create` and `agents.files.set` to cover the worst-case OpenRouter model-capabilities fetch on Windows (observed up to 74s in user logs).
+- "Retry" button at the Gateway-start step didn't recover (only page refresh did) because the 15s server-side polling fired before the Gateway finished binding (~51s on Windows), and a Retry click would spawn a duplicate openclaw process racing the first for port 18789. Bumped server polling to 60s (120 × 500ms), extracted the polling loop into a `pollUntilReachable` helper, and added a mid-launch detection check via `readGatewayPid` + `isProcessAlive` — if a previous request already spawned the Gateway and its pid is alive, the new request joins the existing polling instead of spawning a duplicate.
 
-The two SSE-emitting spawn sites (install + gateway start) additionally got wrapped in try/catch so synchronous spawn throws now produce a clean `SPAWN_THROW` SSE error event with the actual error message instead of crashing the request handler. The misleading comment in `detectOpenClaw` claiming Node 22 handles full-path `.cmd` invocation correctly was corrected. `shell: isWindows` is a no-op on Unix, so the change is Windows-only at runtime.
+All Round-2 options are no-ops on Unix; macOS compatibility is preserved.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -297,8 +297,13 @@ async function run(): Promise<void> {
     }
 
     // Poll for the dashboard via port discovery (env / runtime file / scan).
-    // Up to 15 seconds; the server typically binds in ~500ms.
-    const maxAttempts = 30
+    // Up to 45 seconds. The server typically binds in ~500ms on a warm
+    // install, but on Windows the FIRST cold boot of the bundled CJS (1.4 MB
+    // + better-sqlite3 native bindings + Express + WS proxy) can take 20-30s
+    // due to Windows Defender real-time scanning of the freshly-extracted
+    // npm package + Node's first-load module compile. 15s timed out on
+    // fresh Windows installs — see v0.1.7 round-2 Windows compat fix.
+    const maxAttempts = 90
     for (let i = 0; i < maxAttempts; i++) {
       await new Promise((r) => setTimeout(r, 500))
       const found = await findRunningDashboard()

--- a/apps/web/server/api/system.ts
+++ b/apps/web/server/api/system.ts
@@ -65,9 +65,13 @@ function detectOpenClaw(): { installed: boolean; version: string | null; path: s
     // On Windows, binPath is the absolute path to openclaw.cmd, so this
     // applies even though we're passing an absolute path. On Unix, the
     // option is a no-op.
+    // `windowsHide: isWindows` — with shell:true on Windows we go through
+    // cmd.exe which would otherwise pop a visible console window in front
+    // of the dashboard. Hide it. No-op on Unix.
     const raw = execFileSync(binPath, ['--version'], {
       encoding: 'utf8',
       shell: isWindows,
+      windowsHide: isWindows,
     }).trim()
     const version = raw.replace(/^openclaw\s+v?/i, '').trim() || raw
     return { installed: true, version, path: binPath }
@@ -371,11 +375,12 @@ export async function approveDevicePOST(_req: Request, res: Response): Promise<v
   // Step 1: preview to discover the pending requestId.
   // `shell: isWindows` — required by Node 18.20.2+ / 20.12.2+ / 22+ when
   // oc.path resolves to a .cmd shim on Windows (CVE-2024-27980 fix). No-op
-  // on Unix.
+  // on Unix. `windowsHide: isWindows` — hide the cmd.exe console window.
   const preview = spawnSync(oc.path, ['devices', 'approve', '--latest'], {
     encoding: 'utf8',
     timeout: 5_000,
     shell: isWindows,
+    windowsHide: isWindows,
   })
 
   if (preview.error) {
@@ -403,10 +408,12 @@ export async function approveDevicePOST(_req: Request, res: Response): Promise<v
   // failed: <argv>" wrapper.
   try {
     // `shell: isWindows` — see detectOpenClaw for rationale (CVE-2024-27980).
+    // `windowsHide: isWindows` — hide the cmd.exe console window.
     const approveOut = execFileSync(oc.path, ['devices', 'approve', requestId], {
       encoding: 'utf8',
       timeout: 10_000,
       shell: isWindows,
+      windowsHide: isWindows,
     })
     res.json({ ok: true, requestId, output: approveOut.trim().slice(0, 1000) })
   } catch (err) {
@@ -432,7 +439,7 @@ export async function installOpenclawPOST(_req: Request, res: Response): Promise
 
   sendEvent(res, { type: 'progress', step: 'installing', message: 'Installing OpenClaw...' })
 
-  // Three Windows-compat fixes folded into this call site:
+  // Four Windows-compat fixes folded into this call site:
   //   1. `resolveShimName('npm')` returns `npm.cmd` on Windows. Bare 'npm'
   //      throws ENOENT on Windows because Node's spawn doesn't auto-resolve
   //      .cmd extensions.
@@ -442,7 +449,10 @@ export async function installOpenclawPOST(_req: Request, res: Response): Promise
   //      request handler after the SSE headers are already flushed, and the
   //      browser surfaces the dropped connection as "Network error". On
   //      Unix the option is a no-op.
-  //   3. Pin to `openclaw@^2026.5` rather than `@latest`. OpenClaw bumped the
+  //   3. `windowsHide: isWindows` — with shell:true on Windows, Node spawns
+  //      through cmd.exe, which by default pops a console window in front
+  //      of the dashboard. Hide it. No-op on Unix.
+  //   4. Pin to `openclaw@^2026.5` rather than `@latest`. OpenClaw bumped the
   //      WS connect protocol from 3 to 4 in 2026.5.x, and Clawboo's
   //      gateway-client now advertises maxProtocol: 4 to match. A future
   //      OpenClaw 2026.6+ could bump to protocol 5; pinning to ^2026.5 means
@@ -453,6 +463,7 @@ export async function installOpenclawPOST(_req: Request, res: Response): Promise
     child = spawn(resolveShimName('npm'), ['install', '-g', 'openclaw@^2026.5'], {
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: isWindows,
+      windowsHide: isWindows,
     })
   } catch (err) {
     // Defensive: if spawn throws synchronously (CVE-2024-27980 EINVAL, or
@@ -668,6 +679,45 @@ export async function gatewayControlPOST(req: Request, res: Response): Promise<v
       await new Promise((r) => setTimeout(r, 500))
     }
 
+    // Reusable polling helper — called from BOTH the "spawn fresh" path and
+    // the "join existing launch" path (when a previous request already
+    // spawned the Gateway and we just need to wait for it to bind). Polls
+    // for 60s total (120 × 500ms). 15s was too short for Windows where the
+    // Gateway can take 30-50s to bind on cold start — see v0.1.7 round-2.
+    const maxAttempts = 120
+    const pollUntilReachable = (reportPid: number | undefined): void => {
+      let attempts = 0
+      const poll = async () => {
+        attempts++
+        const reachable = await probeGatewayPort(port)
+        if (reachable) {
+          // Sync .env token → Clawboo settings so the proxy uses the correct token.
+          // The .env file is the Gateway's source of truth for auth tokens.
+          syncTokenFromEnv()
+          sendEvent(res, { type: 'complete', success: true, pid: reportPid ?? null, port })
+          res.end()
+          return
+        }
+        if (attempts >= maxAttempts) {
+          sendEvent(res, {
+            type: 'error',
+            code: 'TIMEOUT',
+            message: `Gateway did not become reachable within ${maxAttempts / 2}s`,
+          })
+          res.end()
+          return
+        }
+        sendEvent(res, {
+          type: 'progress',
+          step: 'waiting',
+          message: `Waiting for gateway... (${attempts}/${maxAttempts})`,
+        })
+        setTimeout(() => void poll(), 500)
+      }
+      // Start polling after a brief delay
+      setTimeout(() => void poll(), 500)
+    }
+
     // Check if already running (for start only)
     if (action === 'start') {
       const reachable = await probeGatewayPort(port)
@@ -681,6 +731,31 @@ export async function gatewayControlPOST(req: Request, res: Response): Promise<v
         res.end()
         return
       }
+      // Mid-launch detection — if a previous request spawned the Gateway
+      // and its process is still alive but the port hasn't bound yet, do
+      // NOT spawn a duplicate (which would race for port 18789 and one
+      // would fail with EADDRINUSE). Join the polling with the existing
+      // pid instead. This is the load-bearing fix for the Windows "Retry
+      // button doesn't help, only refresh does" symptom — on Windows the
+      // first start takes longer than the previous 15s polling window, so
+      // users would click Retry while the Gateway was still mid-boot and
+      // the duplicate spawn would corrupt things. With this guard, Retry
+      // just joins the in-flight launch and waits patiently.
+      const pidInfo = readGatewayPid()
+      const alive = pidInfo ? isProcessAlive(pidInfo.pid) : false
+      if (pidInfo && alive) {
+        sendEvent(res, {
+          type: 'progress',
+          step: 'starting',
+          message: 'Gateway is starting (joined in-flight launch)...',
+        })
+        pollUntilReachable(pidInfo.pid)
+        // Detached child outlives the request; keep res.on('close') no-op
+        res.on('close', () => {})
+        return
+      }
+      // Otherwise: stale pid (process exited) — clean up and fall through to spawn.
+      if (pidInfo && !alive) removeGatewayPid()
     }
 
     // Find openclaw binary
@@ -701,12 +776,15 @@ export async function gatewayControlPOST(req: Request, res: Response): Promise<v
     // oc.path resolves to openclaw.cmd on Windows (CVE-2024-27980 fix).
     // Without it, spawn throws EINVAL synchronously after SSE headers are
     // flushed, and the SPA sees a dropped stream as "Network error".
+    // `windowsHide: isWindows` — hide the cmd.exe console window so the
+    // Gateway start doesn't flash a black terminal in front of the dashboard.
     let child
     try {
       child = spawn(oc.path, ['gateway', '--port', String(port), '--allow-unconfigured'], {
         detached: true,
         stdio: ['ignore', 'pipe', 'pipe'],
         shell: isWindows,
+        windowsHide: isWindows,
       })
     } catch (err) {
       sendEvent(res, {
@@ -744,38 +822,8 @@ export async function gatewayControlPOST(req: Request, res: Response): Promise<v
       res.end()
     })
 
-    // Poll until gateway is reachable
-    let attempts = 0
-    const maxAttempts = 30
-    const poll = async () => {
-      attempts++
-      const reachable = await probeGatewayPort(port)
-      if (reachable) {
-        // Sync .env token → Clawboo settings so the proxy uses the correct token.
-        // The .env file is the Gateway's source of truth for auth tokens.
-        syncTokenFromEnv()
-        sendEvent(res, { type: 'complete', success: true, pid: child.pid, port })
-        res.end()
-        return
-      }
-      if (attempts >= maxAttempts) {
-        sendEvent(res, {
-          type: 'error',
-          code: 'TIMEOUT',
-          message: `Gateway did not become reachable within ${maxAttempts / 2}s`,
-        })
-        res.end()
-        return
-      }
-      sendEvent(res, {
-        type: 'progress',
-        step: 'waiting',
-        message: `Waiting for gateway... (${attempts}/${maxAttempts})`,
-      })
-      setTimeout(() => void poll(), 500)
-    }
-    // Start polling after a brief delay
-    setTimeout(() => void poll(), 500)
+    // Begin polling for the freshly-spawned child
+    pollUntilReachable(child.pid)
 
     // Do NOT kill detached child on client disconnect
     res.on('close', () => {

--- a/apps/web/server/lib/modelCache.ts
+++ b/apps/web/server/lib/modelCache.ts
@@ -62,6 +62,8 @@ export async function getModelsFromCli(): Promise<ModelGroup[] | null> {
     // the .cmd extension by itself, so use the platform-aware shim name.
     // `shell: isWindows` — Node 18.20.2+ / 20.12.2+ / 22+ refuse to spawn
     // .cmd files without it (CVE-2024-27980 fix). On Unix it's a no-op.
+    // `windowsHide: isWindows` — hide the cmd.exe console window that would
+    // otherwise flash in front of the dashboard on each model-list refresh.
     const { stdout } = await execFileAsync(
       resolveShimName('openclaw'),
       ['models', 'list', '--all', '--json'],
@@ -69,6 +71,7 @@ export async function getModelsFromCli(): Promise<ModelGroup[] | null> {
         timeout: 15_000,
         env: { ...process.env },
         shell: isWindows,
+        windowsHide: isWindows,
       },
     )
     const parsed = JSON.parse(stdout) as CliOutput | CliModel[]

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -170,7 +170,7 @@ export class GatewayClient {
 
   // ── Request/response ────────────────────────────────────────────────────────
 
-  async call<T = unknown>(method: string, params?: unknown, timeoutMs = 30_000): Promise<T> {
+  async call<T = unknown>(method: string, params?: unknown, timeoutMs = 60_000): Promise<T> {
     if (!method.trim()) throw new Error('Gateway method is required.')
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new Error('Gateway is not connected.')
@@ -479,8 +479,16 @@ export class GatewayClient {
   readonly agents = {
     list: (): Promise<AgentsListResult> => this.call<AgentsListResult>('agents.list', {}),
 
+    // `agents.create` is the slowest known RPC because the Gateway has to
+    // resolve and validate the agent's default model, which on Windows can
+    // include an OpenRouter capabilities fetch that runs 30-75 seconds
+    // (Windows Defender / DNS / firewall variability). Observed real
+    // latencies on a fresh Windows install: 16s / 18s / 33s / 33s. We pass
+    // a 2-minute timeout so the team deploy doesn't fail half-way through.
+    // No-op on a fast Mac — the call returns in 2-3s and the timer never
+    // fires. See v0.1.7 round-2 Windows compat fix.
     create: (config: AgentCreateConfig): Promise<AgentCreateResult> =>
-      this.call<AgentCreateResult>('agents.create', config),
+      this.call<AgentCreateResult>('agents.create', config, 120_000),
 
     delete: (id: string): Promise<void> => this.call<void>('agents.delete', { agentId: id }),
 
@@ -497,8 +505,13 @@ export class GatewayClient {
         return ''
       },
 
+      // `agents.files.set` is fast individually but a team deploy fires it
+      // 4-5 times per agent (SOUL / IDENTITY / TOOLS / AGENTS / CLAWBOO).
+      // The first batch right after agents.create can pile up against the
+      // Gateway's still-warming-up state machine on Windows. 2-minute
+      // timeout matches agents.create — same v0.1.7 round-2 rationale.
       set: (agentId: string, name: string, content: string): Promise<void> =>
-        this.call<void>('agents.files.set', { agentId, name, content }),
+        this.call<void>('agents.files.set', { agentId, name, content }, 120_000),
     },
   }
 


### PR DESCRIPTION
## Summary

- Fixes Windows follow-up issues from live testing by hiding `cmd.exe` windows for `.cmd`-based spawn flows and increasing dashboard startup polling timeouts for cold boot scenarios.
- Improves reliability for team deploys on Windows by increasing gateway RPC timeouts and adding longer per-call overrides for `agents.create` and `agents.files.set`.
- Fixes Gateway start retry behavior by detecting in-flight launches and joining the existing startup flow instead of spawning a duplicate process that can race for the gateway port.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff