### PR TITLE
fix(windows): timeout-bound findExecutable so /api/system/status can't hang

### DIFF
--- a/.changeset/windows-status-probe-timeout.md
+++ b/.changeset/windows-status-probe-timeout.md
@@ -1,0 +1,5 @@
+---
+'clawboo': patch
+---
+
+Fixed a Windows hang in `/api/system/status` (hit by the onboarding DetectStep): the synchronous `where` / `which` binary probe (`findExecutable`) is now timeout-bounded, so a slow spawn under Windows Defender can no longer block the server's event loop and stall the request.

--- a/apps/web/server/lib/platform.ts
+++ b/apps/web/server/lib/platform.ts
@@ -33,7 +33,20 @@ export const isWindows = process.platform === 'win32'
 export function findExecutable(name: string): string | null {
   try {
     const cmd = isWindows ? 'where' : 'which'
-    const out = execFileSync(cmd, [name], { encoding: 'utf8' }).trim()
+    // `timeout` is load-bearing: this runs SYNCHRONOUSLY (it blocks the single-
+    // threaded server), and on Windows `where` can be slow under Defender
+    // real-time scanning. An unbounded spawn here froze `/api/system/status`
+    // past the client timeout on Windows CI runners (and would stall the
+    // onboarding DetectStep for real users). `where`/`which` is normally
+    // <200 ms, so a 5 s cap never trips in practice but bounds the worst case;
+    // on timeout it throws → caught below → treated as "not found".
+    // `windowsHide` suppresses the cmd.exe console flash (matches our other
+    // Windows spawns).
+    const out = execFileSync(cmd, [name], {
+      encoding: 'utf8',
+      timeout: 5_000,
+      windowsHide: true,
+    }).trim()
     if (!out) return null
     // `where` on Windows may return multiple paths; first one wins.
     const first = out.split(/\r?\n/)[0]


### PR DESCRIPTION
## Summary

- Fixes a Windows-specific hang where the synchronous `where`/`which` probe could block `/api/system/status` long enough to exceed the client timeout.
- Adds a 5-second timeout to executable detection so onboarding status checks fail fast instead of stalling indefinitely.
- Applies `windowsHide` to the probe path to keep the Windows flow quieter and more reliable during clean-install and onboarding checks.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [x] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff