### PR TITLE
docs: quote YAML-sensitive descriptions across markdown docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,12 @@ truth, exactly what ships to [docs.claw.boo](https://docs.claw.boo).
 - `*.md` / `*.mdx` — the pages (129 total). Mintlify-flavored Markdown: YAML frontmatter
   (`title` / `description`), callout components (`<Note>` / `<Tip>` / `<Info>` / `<Warning>` /
   `<Danger>`), and root-relative links such as `/concepts/the-board`. Almost every page is `.md`;
-  a couple are `.mdx` where Mintlify's plain-`.md` resolver doesn't pick the page up. **If a page's
-  inbound links start failing `mint broken-links`, rename it `.md` → `.mdx`** (no other change needed —
-  the nav uses extensionless paths).
+  a couple are `.mdx` where a page genuinely needs MDX/JSX. **Frontmatter must be valid YAML: wrap any
+  `title` / `description` value containing a colon (or a leading `@`, backtick, or other YAML-special
+  character) in double quotes.** An unquoted `: ` is parsed as a nested mapping, so the page fails to
+  build and Mintlify serves it as a 404. `mint broken-links` does NOT catch this (it only checks links);
+  only a full build does, so verify with `mint dev` before opening a PR. The extension is irrelevant:
+  the same frontmatter breaks `.md` and `.mdx` identically, so never "fix" a broken page by renaming it.
 - `docs.json` — theme + the four-tab navigation (Documentation / Reference / Internals / Resources).
   Hand-maintained: when you add a page, add its path to the right group's `pages` array.
 - `images/` — screenshots, referenced by pages as `/images/<name>`.

--- a/docs/appendices/faq.md
+++ b/docs/appendices/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Frequently asked questions
-description: Common questions about Clawboo: runtimes, data location, local-first behavior, cost, safe network exposure, and resetting.
+description: 'Common questions about Clawboo: runtimes, data location, local-first behavior, cost, safe network exposure, and resetting.'
 ---
 
 Short, grounded answers to the questions that come up most. Each answer links to the page that covers the topic in full.

--- a/docs/concepts/architecture-invariants.md
+++ b/docs/concepts/architecture-invariants.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture invariants
-description: The load-bearing rules every Clawboo change preserves: registry of record, same-origin Gateway access, the pure event pipeline, and idempotent schema.
+description: 'The load-bearing rules every Clawboo change preserves: registry of record, same-origin Gateway access, the pure event pipeline, and idempotent schema.'
 ---
 
 An invariant is a rule the codebase is built to hold no matter what changes around it. Clawboo has a small set of them. They are not style preferences; break one and a whole class of bug becomes possible: a stale agent list that survives a Gateway outage stops being stale; a graph edge stops mapping to anything real; the browser starts talking to credentials it should never see.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -1,6 +1,6 @@
 ---
 title: Memory
-description: Clawboo's two memory tiers: one shared Memory-MCP store every runtime reads and writes, plus each runtime's preserved private native memory.
+description: "Clawboo's two memory tiers: one shared Memory-MCP store every runtime reads and writes, plus each runtime's preserved private native memory."
 ---
 
 Clawboo gives a team two kinds of memory. There is **one shared store**: declarative facts and versioned procedures in SQLite, served over a Memory [MCP](/appendices/glossary) server, that every [runtime](/appendices/glossary) reads and writes. And there is **each runtime's own private native memory**: Hermes's `MEMORY.md`, Claude Code's project memory, clawboo-native's session store, which Clawboo preserves but never touches and never syncs.

--- a/docs/concepts/scheduling.md
+++ b/docs/concepts/scheduling.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduling
-description: Routines: Clawboo's durable team-task scheduler, its rebuildable ticker, the two cron domains, the one-firing-owner invariant, and the error-halts policy.
+description: "Routines: Clawboo's durable team-task scheduler, its rebuildable ticker, the two cron domains, the one-firing-owner invariant, and the error-halts policy."
 ---
 
 A **Routine** is a scheduled team task: a cron-shaped trigger that, on each fire, materializes a [board](/concepts/the-board) task and dispatches it through the same executor pipeline a delegated task would use. Routines are how a team gets recurring or future-dated work, a morning briefing, a nightly report, a one-shot reminder, without anyone sitting at the dashboard to kick it off.

--- a/docs/concepts/the-board.md
+++ b/docs/concepts/the-board.md
@@ -1,6 +1,6 @@
 ---
 title: The board
-description: Clawboo's durable, transactional task-coordination substrate: state machine, atomic claim, dependencies, and crash recovery.
+description: "Clawboo's durable, transactional task-coordination substrate: state machine, atomic claim, dependencies, and crash recovery."
 ---
 
 The board is Clawboo's durable, transactional source of truth for task coordination. It is a set of SQLite tables, `tasks`, `task_deps`, `task_comments`, `workspaces`, and `execution_processes`, fronted by a single data-access layer that every other subsystem goes through. When a team delegates work, the work becomes a board task; when an agent picks up work, it atomically claims a board task; when a run completes, the outcome lands on the board. Refresh the page, restart the server, run twelve agents at once against one database file; the board survives all of it.

--- a/docs/concepts/verification.md
+++ b/docs/concepts/verification.md
@@ -1,6 +1,6 @@
 ---
 title: Verification
-description: Builder≠judge: a deterministic gate plus an independent read-only critic that make "done" mean verified, with completed_with_debt as a graceful exit.
+description: 'Builder≠judge: a deterministic gate plus an independent read-only critic that make "done" mean verified, with completed_with_debt as a graceful exit.'
 ---
 
 Verification is the rule that makes `done` mean _verified_. A code task that mutated files can reach `done` only when two independent checks agree: a **deterministic gate** (the task's own build/test/lint command, judged by its exit code) passes, and, on a green gate, for a risky or large change, a read-only **critic** (an independent reviewer that cannot push) raises no blocking finding. The principle underneath is **builder≠judge**: the agent that did the work never certifies its own work. A generator self-grading is a known failure mode; Clawboo's only signals into `done` are a machine truth (an exit code) and a structurally-independent reviewer.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: The two install paths: native-first (paste a key, no Gateway) or the OpenClaw Gateway, plus prerequisites.
+description: 'The two install paths: native-first (paste a key, no Gateway) or the OpenClaw Gateway, plus prerequisites.'
 ---
 
 Clawboo runs the same way for everyone: one command, `npx clawboo`, which launches a local dashboard and walks you through a first-run wizard. The only real choice the wizard asks is **how you want your agents to run**. This page explains the two paths so you can pick before you start.

--- a/docs/getting-started/quickstart-native.md
+++ b/docs/getting-started/quickstart-native.md
@@ -1,5 +1,5 @@
 ---
-title: Quickstart: the native runtime (no Gateway)
+title: 'Quickstart: the native runtime (no Gateway)'
 description: Run npx clawboo, choose the native runtime, paste a provider key, and land in a working two-agent team with no OpenClaw Gateway.
 ---
 

--- a/docs/getting-started/quickstart-openclaw.md
+++ b/docs/getting-started/quickstart-openclaw.md
@@ -1,5 +1,5 @@
 ---
-title: Quickstart: the OpenClaw Gateway
+title: 'Quickstart: the OpenClaw Gateway'
 description: Run npx clawboo, let onboarding detect, install, and configure OpenClaw, start the Gateway, approve the device, then deploy a team.
 ---
 

--- a/docs/guides/attach-mcp-external-agent.md
+++ b/docs/guides/attach-mcp-external-agent.md
@@ -1,6 +1,6 @@
 ---
 title: Attach Clawboo's MCP to an external agent
-description: A worked walkthrough: pick a server and transport, fetch the attach snippet, wire it into Claude Code, Codex, or a custom MCP client, and bind scope safely.
+description: 'A worked walkthrough: pick a server and transport, fetch the attach snippet, wire it into Claude Code, Codex, or a custom MCP client, and bind scope safely.'
 ---
 
 Use this guide when you want an agent that Clawboo does **not** run, a standalone Claude Code session, a Codex CLI, or your own [MCP](/appendices/glossary) client, to join a Clawboo team by attaching one of the four hosted MCP servers (`tasks`, `memory`, `tools`, `teamchat`). Once attached, the external agent reads and claims [board](/concepts/the-board) tasks, searches [shared memory](/concepts/memory), calls brokered tools, and posts in a [team room](/concepts/peer-chat), over the same SQLite store every Clawboo runtime shares.

--- a/docs/guides/governance-and-budgets.md
+++ b/docs/guides/governance-and-budgets.md
@@ -1,5 +1,5 @@
 ---
-title: Set up governance: budgets, caps, and approvals
+title: 'Set up governance: budgets, caps, and approvals'
 description: A walkthrough for putting a USD budget on a team, watching the kill-switch pause at the cap, and resolving risky-delegation approvals.
 ---
 

--- a/docs/guides/recurring-team-work.md
+++ b/docs/guides/recurring-team-work.md
@@ -1,6 +1,6 @@
 ---
 title: Schedule recurring team work
-description: A walkthrough for putting a team task on a clock with Routines: cron, one-shot, presets, the one-firing-owner invariant, error-halts, and pause/resume/run-now.
+description: 'A walkthrough for putting a team task on a clock with Routines: cron, one-shot, presets, the one-firing-owner invariant, error-halts, and pause/resume/run-now.'
 ---
 
 This guide composes Clawboo's scheduler into a real workflow: you'll create a **Routine** that fires a team task on a clock, understand why a failing Routine parks itself instead of retrying, and pause, resume, run, or delete it from one surface. Use it when you want a nightly report, a morning briefing, or a one-off future run to happen without anyone sitting at the dashboard to kick it off.

--- a/docs/internals/board-internals.md
+++ b/docs/internals/board-internals.md
@@ -1,6 +1,6 @@
 ---
 title: Board internals
-description: The board data-access layer: the atomic claim, the transactional state machine, the SQLite contention recipe, recursive CTEs, and crash recovery.
+description: 'The board data-access layer: the atomic claim, the transactional state machine, the SQLite contention recipe, recursive CTEs, and crash recovery.'
 ---
 
 [The board](/concepts/the-board) is Clawboo's durable task-coordination substrate. This page is the implementation deep-dive for people working _on_ it: the single data-access layer that owns every board write, the conditional-UPDATE claim that makes single-assignee work race-free, the state machine that enforces legal transitions inside a write transaction, the SQLite contention recipe that keeps many concurrent writers honest, the recursive CTEs that walk the dependency and parent graphs, and the two reconciliation passes that recover stuck work.

--- a/docs/internals/codegen-and-ingestion.md
+++ b/docs/internals/codegen-and-ingestion.md
@@ -1,6 +1,6 @@
 ---
 title: Codegen and ingestion
-description: How the marketplace catalog is generated from pinned upstream repos, the zero-loss identityTemplate invariant, and the verify:ingest drift gate that keeps committed codegen honest.
+description: 'How the marketplace catalog is generated from pinned upstream repos, the zero-loss identityTemplate invariant, and the verify:ingest drift gate that keeps committed codegen honest.'
 ---
 
 The marketplace catalog, 304 deployable agents and 82 teams, is **committed codegen**. None of it is fetched at runtime, and none of it is hand-maintained entry by entry. Instead, `scripts/ingest-marketplace-content.ts` reads two upstream GitHub repos at pinned commits, parses each `.md` file into a typed catalog entry, renders the entries as TypeScript source, runs that source through Prettier, and writes it to disk. The generated files (~20 of them under `apps/web/src/features/marketplace/`) are committed to git and imported directly by the app. A second script, `scripts/verify-ingest.ts`, re-runs the same render pipeline in memory and diffs the result against the committed files; that diff is a CI gate on every PR and every release.

--- a/docs/internals/executor-runner.md
+++ b/docs/internals/executor-runner.md
@@ -1,6 +1,6 @@
 ---
 title: The executor runner
-description: How the server drives one board task through a runtime end-to-end: claim, worktree, prompt assembly, governance, rotation, verify, and handoff.
+description: 'How the server drives one board task through a runtime end-to-end: claim, worktree, prompt assembly, governance, rotation, verify, and handoff.'
 ---
 
 The executor runner is the server-side integration glue that drives a single board task through a runtime, from claim to terminal. It lives in `apps/web/server/lib/executorRunner.ts`, and it is the un-flagged graduation of the idea that **a teammate is a [`RuntimeAdapter`](/internals/runtime-adapter)**: given a task id, an assignee, and an adapter factory, it atomically claims the task, opens an execution row, acquires an isolated [worktree](/concepts/worktrees-and-handoff) when the runtime can use one, assembles a tiered prompt, drives the adapter's normalized event stream, enforces [governance](/concepts/governance) on every cost event, rotates the session when it runs out of room, runs the [verification](/concepts/verification) gate, and writes a cross-runtime handoff.

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -1,6 +1,6 @@
 ---
 title: Internals overview
-description: A contributor's map of Clawboo's monorepo: the packages, the seams, and the internals deep-dives that explain how it all fits together.
+description: "A contributor's map of Clawboo's monorepo: the packages, the seams, and the internals deep-dives that explain how it all fits together."
 ---
 
 This section is for people working **on** Clawboo, not just with it. Each page is a deep-dive into one part of the machine: the design, the seam or trait it hangs on, the rationale, and the invariants you have to preserve when you change it. They are grounded in the real package and module source, not the README.

--- a/docs/internals/release-process.md
+++ b/docs/internals/release-process.md
@@ -1,6 +1,6 @@
 ---
 title: Release process
-description: How Clawboo ships: Changesets, the CI gate, the Version-PR publish flow, and why a release is the CLI's npm publish with the libs inlined.
+description: "How Clawboo ships: Changesets, the CI gate, the Version-PR publish flow, and why a release is the CLI's npm publish with the libs inlined."
 ---
 
 A Clawboo release is the publish of **one npm package**: the `clawboo` CLI in `apps/cli`. Every `@clawboo/*` library in the workspace is `private: true` and never reaches npm on its own; the libraries it needs are _inlined_ into the CLI's shipped bundle. The release machinery is Changesets for versioning + changelog, a CI gate that mirrors the publish steps, and a two-phase `publish.yml` (open a Version PR, then publish on its merge).

--- a/docs/internals/runtime-adapter.md
+++ b/docs/internals/runtime-adapter.md
@@ -1,6 +1,6 @@
 ---
 title: The RuntimeAdapter trait
-description: The executor seam every runtime implements: the RuntimeAdapter trait, the normalized RuntimeEvent union, the registry, the contract suite, and the KV-cache tiers.
+description: 'The executor seam every runtime implements: the RuntimeAdapter trait, the normalized RuntimeEvent union, the registry, the contract suite, and the KV-cache tiers.'
 ---
 
 `@clawboo/executor` is the substrate that lets Clawboo drive five heterogeneous agent runtimes through one interface. It defines the `RuntimeAdapter` trait (the seam an adapter implements), the normalized `RuntimeEvent` union (the lifecycle stream every adapter emits), the `RuntimeRegistry` (the open set of available adapters), a single-consumer `AsyncQueue` primitive, the `runAdapterContract` test suite every adapter must pass, and the `./tiers` KV-cache prompt-assembly discipline. The package is pure: no workspace dependencies, no `node:*` imports, so it builds browser-safe and ships inlined into the CLI bundle.

--- a/docs/internals/testing.md
+++ b/docs/internals/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing strategy
-description: How Clawboo verifies itself: the two Vitest projects, sandboxed Playwright e2e, the clean-install smoke gate, the eval harness, and the standing repo guards.
+description: 'How Clawboo verifies itself: the two Vitest projects, sandboxed Playwright e2e, the clean-install smoke gate, the eval harness, and the standing repo guards.'
 ---
 
 Clawboo is a team-first orchestrator: many agents write one SQLite file, five [runtimes](/appendices/glossary) execute heterogeneous work, and the whole thing ships as a single bundled CLI that has to boot on a stranger's machine. Each of those facts has a matching test layer. This page explains the layers, why each exists, and the invariants the standing guard tests freeze in place; so you can extend the suite without re-learning the same lessons the suite was written to encode.

--- a/docs/intro/how-it-works.md
+++ b/docs/intro/how-it-works.md
@@ -1,6 +1,6 @@
 ---
 title: How Clawboo works
-description: An end-to-end architecture overview: the CLI, the bundled server and SPA, the durable board, the runtime seam, and the MCP spine.
+description: 'An end-to-end architecture overview: the CLI, the bundled server and SPA, the durable board, the runtime seam, and the MCP spine.'
 ---
 
 Clawboo is a single `npx clawboo` command that becomes a local mission-control dashboard for a fleet of AI agents. Under that one command sits a small, deliberate stack: a bundled Express server serving a Vite single-page app, a SQLite database that is the durable source of truth for task coordination, a uniform interface (`RuntimeAdapter`) that lets one orchestrator drive five different agent runtimes, four Model Context Protocol servers that those runtimes share, and an append-only event log that every visualization is a projection of.

--- a/docs/intro/why-clawboo.md
+++ b/docs/intro/why-clawboo.md
@@ -1,6 +1,6 @@
 ---
 title: Why Clawboo
-description: What Clawboo adds over running runtimes standalone or stitching them yourself: one team room, race-free coordination, deep integration, independent verification, governance, and observability.
+description: 'What Clawboo adds over running runtimes standalone or stitching them yourself: one team room, race-free coordination, deep integration, independent verification, governance, and observability.'
 ---
 
 You can already run a coding agent on its own. You can run several of them. What you cannot easily do is make _different_ agent runtimes, one on the native harness, one on OpenClaw, one on Hermes, work as one team without writing the coordination layer yourself: a shared room they can all speak in, a way to hand work between them without double-firing, and guardrails that hold when twelve of them write the same database at once.

--- a/docs/operating/index.md
+++ b/docs/operating/index.md
@@ -1,6 +1,6 @@
 ---
 title: Operating Clawboo
-description: Operator overview: where Clawboo runs, how to expose it safely, where data lives, and what the defaults are.
+description: 'Operator overview: where Clawboo runs, how to expose it safely, where data lives, and what the defaults are.'
 ---
 
 This section is for the person who runs the Clawboo server, on a laptop, a shared box, or behind a reverse proxy, rather than the person clicking around the dashboard. Clawboo is a single Node process: a bundled Express server that serves the SPA, exposes the REST API, hosts the four [MCP servers](/reference/mcp-tools) in-process, and owns one SQLite file plus an encrypted secrets vault under `~/.clawboo`. By default it binds **loopback (`127.0.0.1`)** with no authentication, which is the right posture for a single-user machine; exposing it on a network is an explicit opt-in that requires the access gate. The pages below cover the four operator concerns in order: where it runs, how to expose it safely, what attaches to it, and where the state lives, and the reference pages give the exact knobs.

--- a/docs/operating/production-defaults.md
+++ b/docs/operating/production-defaults.md
@@ -1,6 +1,6 @@
 ---
 title: Production defaults & posture
-description: The values a fresh Clawboo install runs with: log level, budget posture, breaker thresholds, reaper TTLs, each justified, with override env vars.
+description: 'The values a fresh Clawboo install runs with: log level, budget posture, breaker thresholds, reaper TTLs, each justified, with override env vars.'
 ---
 
 This page is the operator's reference for the values a fresh Clawboo install runs with out of the box, and why each was chosen. Clawboo is designed to be a first-impression product, not a lab harness: nothing throttles or pauses an agent until you opt in, observability is local-only unless you point it at a collector, and the safety backstops are tuned so a healthy run never trips one.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,6 +1,6 @@
 ---
 title: Environment variables
-description: Every environment variable Clawboo reads: state paths, ports, secrets, runtime keys, OpenClaw interop, logging, and operational tuning.
+description: 'Every environment variable Clawboo reads: state paths, ports, secrets, runtime keys, OpenClaw interop, logging, and operational tuning.'
 ---
 
 A complete, code-grounded list of every environment variable Clawboo actually reads. Each entry names the variable, what reads it, its purpose, and its default. Variables not listed here are not consulted by Clawboo.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,6 @@
 ---
 title: Reference
-description: Index of Clawboo's factual reference: REST API, CLI, configuration, env vars, database schema, MCP tools, marketplace catalog, events, and packages.
+description: "Index of Clawboo's factual reference: REST API, CLI, configuration, env vars, database schema, MCP tools, marketplace catalog, events, and packages."
 ---
 
 Factual, code-grounded reference for every public surface of Clawboo: the **124-route** REST API, the `npx clawboo` CLI, configuration and environment variables, the **27-table** SQLite schema, the **4** MCP servers and their tools, the marketplace catalog of **304 agents** and **82 teams**, the orchestration event and error vocabulary, and one page per workspace package (**25** in total). These pages describe what the code does, verified against source; they do not teach a workflow. For learning-oriented walkthroughs see [Getting Started](/getting-started/index); for the _why_ see [Concepts](/concepts/index).

--- a/docs/reference/marketplace-catalog.md
+++ b/docs/reference/marketplace-catalog.md
@@ -1,6 +1,6 @@
 ---
 title: Marketplace catalog reference
-description: The agent and team catalog: schemas, ID convention, zero-loss invariant, three sources with pinned SHAs, and the codegen/ingestion pipeline.
+description: 'The agent and team catalog: schemas, ID convention, zero-loss invariant, three sources with pinned SHAs, and the codegen/ingestion pipeline.'
 ---
 
 The marketplace ships a static, in-bundle catalog of **304 agents** and **82 teams**. Every entry is a committed TypeScript literal; the catalog is browsed and deployed entirely client-side, with no network fetch at runtime. Two of the agent sources (agency-agents, awesome-openclaw) and three of the team files are **codegen'd** from pinned upstream commits by `scripts/ingest-marketplace-content.ts`; the rest are hand-written. A CI gate (`pnpm verify:ingest`) re-derives the codegen'd files in memory and fails on drift.

--- a/docs/reference/packages/compaction.md
+++ b/docs/reference/packages/compaction.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/compaction"
-description: Pass-through-safe, failure-preserving tool-output compaction: cuts verbose tool output before it re-enters context, never compressing away an error.
+title: '@clawboo/compaction'
+description: 'Pass-through-safe, failure-preserving tool-output compaction: cuts verbose tool output before it re-enters context, never compressing away an error.'
 ---
 
 - **Version** `0.1.0`

--- a/docs/reference/packages/config.md
+++ b/docs/reference/packages/config.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/config"
-description: Settings loader and persistence for Clawboo: resolves state dirs, env overrides, and OpenClaw config fallback.
+title: '@clawboo/config'
+description: 'Settings loader and persistence for Clawboo: resolves state dirs, env overrides, and OpenClaw config fallback.'
 ---
 
 - **Version** 0.1.0 · **Purity** server-only (uses `node:fs` / `node:os` / `node:path`)

--- a/docs/reference/packages/db.md
+++ b/docs/reference/packages/db.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/db"
-description: SQLite + Drizzle ORM data layer: schema, board, memory, tools, governance, events, sessions, routines, team-chat.
+title: '@clawboo/db'
+description: 'SQLite + Drizzle ORM data layer: schema, board, memory, tools, governance, events, sessions, routines, team-chat.'
 ---
 
 **Version** 0.1.0 · **Purity** server-only (`better-sqlite3` native binding) · **Purpose** the single SQLite + Drizzle data layer: schema, connection, and every domain repository (board, memory, tools broker, governance, event log, sessions, routines, team-chat). It is the cross-process bus: the Express server and the MCP stdio bins open the same file.

--- a/docs/reference/packages/evals.md
+++ b/docs/reference/packages/evals.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/evals"
-description: Server-only eval harness for clawboo's own orchestration: capability/regression suites, code/model graders, pass@1 / pass^k, and the ±verifier × ±structured-state ablation scorecard.
+title: '@clawboo/evals'
+description: "Server-only eval harness for clawboo's own orchestration: capability/regression suites, code/model graders, pass@1 / pass^k, and the ±verifier × ±structured-state ablation scorecard."
 ---
 
 - **Version** `0.1.0`

--- a/docs/reference/packages/gateway-client.md
+++ b/docs/reference/packages/gateway-client.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/gateway-client"
-description: WebSocket client for the OpenClaw Gateway: typed RPC, event subscription, reconnect, and Ed25519 device auth.
+title: '@clawboo/gateway-client'
+description: 'WebSocket client for the OpenClaw Gateway: typed RPC, event subscription, reconnect, and Ed25519 device auth.'
 ---
 
 |                    |                                                                                                                                                                                               |

--- a/docs/reference/packages/governance.md
+++ b/docs/reference/packages/governance.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/governance"
-description: Pure verification (builder≠judge) and governance primitives: verdict schemas, severity policy, budget cent-math, caps, and circuit-breaker reducer.
+title: '@clawboo/governance'
+description: 'Pure verification (builder≠judge) and governance primitives: verdict schemas, severity policy, budget cent-math, caps, and circuit-breaker reducer.'
 ---
 
 - **Version** `0.1.0`

--- a/docs/reference/packages/index.md
+++ b/docs/reference/packages/index.md
@@ -1,6 +1,6 @@
 ---
 title: Package overview
-description: The 25 @clawboo/* workspace packages: version, purity, purpose, dependency graph, and build order.
+description: 'The 25 @clawboo/* workspace packages: version, purity, purpose, dependency graph, and build order.'
 ---
 
 Clawboo is a TurboRepo + pnpm-workspaces monorepo. Every shared library lives under the `@clawboo/*` scope in `packages/`; all of them are **internal** (`private: true`); the only published npm artifact is the `clawboo` CLI (`apps/cli`), which inlines every `@clawboo/*` package it needs into its bundle (`dist/`). The two consumers are `apps/web` (the dashboard + Express API) and `apps/cli` (`npx clawboo`). Packages divide cleanly into **pure / browser-safe** ones (no `node:*` imports, safe to bundle into the Vite SPA or run in a worker) and **server-only** ones (touch `node:fs`/`node:http`/`better-sqlite3` and may only run in the Express server, the bundled CLI server, or the MCP stdio bins). Dependencies flow one way: apps depend on packages, packages depend on packages, and packages never import apps. `@clawboo/tsconfig` is the shared TypeScript-config root (a devDependency everywhere, no runtime edge).

--- a/docs/reference/packages/obs.md
+++ b/docs/reference/packages/obs.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/obs"
-description: Pure observability primitives: typed orchestration-event schema, runtime-error taxonomy, graph + fleet-health projection reducers, metric folds, and the structured-output judge drive.
+title: '@clawboo/obs'
+description: 'Pure observability primitives: typed orchestration-event schema, runtime-error taxonomy, graph + fleet-health projection reducers, metric folds, and the structured-output judge drive.'
 ---
 
 - **Version** `0.1.0`

--- a/docs/reference/packages/scheduler.md
+++ b/docs/reference/packages/scheduler.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/scheduler"
-description: Pure scheduling primitives: cron-spec parsing, next-occurrence math, the TaskTemplate schema, and the ScheduleSource trait + ScheduleRecord + multiplexer.
+title: '@clawboo/scheduler'
+description: 'Pure scheduling primitives: cron-spec parsing, next-occurrence math, the TaskTemplate schema, and the ScheduleSource trait + ScheduleRecord + multiplexer.'
 ---
 
 |                    |                                                                                                                                                                              |

--- a/docs/reference/packages/ui.md
+++ b/docs/reference/packages/ui.md
@@ -1,6 +1,6 @@
 ---
-title: "@clawboo/ui"
-description: Shared React UI primitives: the BooAvatar component, the cn class merger, the cva re-export, and the design-token constant.
+title: '@clawboo/ui'
+description: 'Shared React UI primitives: the BooAvatar component, the cn class merger, the cva re-export, and the design-token constant.'
 ---
 
 - **Version** 0.1.0 · **Purity** browser-safe (React component package; ships JSX)

--- a/docs/reference/rest-api/agents.md
+++ b/docs/reference/rest-api/agents.md
@@ -1,6 +1,6 @@
 ---
 title: Agents API
-description: REST reference for the agent registry-of-record: list, create, sync, per-agent reads, files, sessions, delete, and ghost cleanup.
+description: 'REST reference for the agent registry-of-record: list, create, sync, per-agent reads, files, sessions, delete, and ghost cleanup.'
 ---
 
 REST surface for the [agent registry-of-record](/appendices/glossary). SQLite is the source of truth for who exists; an `AgentSource` syncs each upstream (the OpenClaw Gateway, the in-process native runtime) INTO SQLite. Reads serve SQLite, so the agent list, an agent record, and an agent's files keep answering even when the Gateway connection is down; a `stale` flag marks that case. Writes (create), file PUTs, and live session lists delegate to the owning source and return **503** when the source needs a live upstream that is disconnected.

--- a/docs/reference/rest-api/board.md
+++ b/docs/reference/rest-api/board.md
@@ -1,6 +1,6 @@
 ---
 title: Board API
-description: REST reference for the durable board: tasks, atomic claim, status gate, comments, executions, deps, and per-task worktrees.
+description: 'REST reference for the durable board: tasks, atomic claim, status gate, comments, executions, deps, and per-task worktrees.'
 ---
 
 REST surface over the durable [board](/concepts/the-board), the transactional source of truth for team/task coordination. These routes create and list tasks, atomically claim a task for a single assignee, transition status through the state machine (with the intrinsic verification gate), record the execution ledger, link dependency chains, cancel a dead downstream chain, and provision / inspect / pause / complete a task's per-task git worktree (its system-of-record).

--- a/docs/reference/rest-api/capabilities.md
+++ b/docs/reference/rest-api/capabilities.md
@@ -1,6 +1,6 @@
 ---
 title: Capabilities API
-description: REST reference for the unified capability inventory: list every runtime's skills, tools, and connectors, and act on the manageable ones.
+description: "REST reference for the unified capability inventory: list every runtime's skills, tools, and connectors, and act on the manageable ones."
 ---
 
 REST surface for the unified [capability inventory](/concepts/capabilities): one merged stream of every skill, tool, and connector across all five runtimes, plus a single manageability-gated action endpoint. `GET /api/capabilities` is the one read both the Ghost Graph and the Capabilities dashboard consume; `POST /api/capabilities/:action` installs a curated skill or connector, toggles a manageable capability, or resolves a pending tool-call approval.

--- a/docs/reference/rest-api/governance.md
+++ b/docs/reference/rest-api/governance.md
@@ -1,6 +1,6 @@
 ---
 title: Governance API
-description: REST reference for governance: list/set USD budgets, resume a paused scope, read the forensic audit log, and route a delegation approval.
+description: 'REST reference for governance: list/set USD budgets, resume a paused scope, read the forensic audit log, and route a delegation approval.'
 ---
 
 REST surface for Clawboo's spend [governance](/concepts/governance): the hard USD budget kill-switch (list / set / resume budgets), the append-only forensic audit log, the delegation-approval handshake, and the persisted approval-decision history. The budget kill-switch and audit are always on; budgets are uncapped by default (a budget row exists only when you create one), so no USD is enforced until you set a cap.

--- a/docs/reference/rest-api/memory.md
+++ b/docs/reference/rest-api/memory.md
@@ -1,6 +1,6 @@
 ---
 title: Memory API
-description: REST reference for the memory resource group: search, save facts and procedures, browse, and inspect the active embedding provider.
+description: 'REST reference for the memory resource group: search, save facts and procedures, browse, and inspect the active embedding provider.'
 ---
 
 REST surface for the shared [memory](/concepts/memory) tier: search the 2-tier store (declarative **facts** + versioned **procedures**), save a fact or a procedure, browse what is stored, and inspect which embedding provider backs vector/hybrid search. This is the UI-facing half of the memory dual surface; the model-facing half is the [Memory MCP server](/reference/rest-api/tools-and-mcp). Both halves share one `SqliteMemoryStore` over the same SQLite file, so a fact saved here is searchable from a runtime's Memory tool and vice versa.

--- a/docs/reference/rest-api/observability.md
+++ b/docs/reference/rest-api/observability.md
@@ -1,6 +1,6 @@
 ---
 title: Observability API
-description: REST reference for the orchestration event log: feed, traces, errors, fleet health, graph projection, SSE live-tail, client mirror, and eval smoke run.
+description: 'REST reference for the orchestration event log: feed, traces, errors, fleet health, graph projection, SSE live-tail, client mirror, and eval smoke run.'
 ---
 
 REST surface over the durable orchestration event log: query the raw event feed, reconstruct a single trace with metrics, pull the harness-bug error feed, read the fleet-health triage, fold the event-sourced delegation graph, live-tail the log over Server-Sent Events, and mirror client-observed runtime events back into the log. This group also covers `POST /api/eval/smoke`, the on-demand deterministic eval run.

--- a/docs/reference/rest-api/runtimes.md
+++ b/docs/reference/rest-api/runtimes.md
@@ -1,6 +1,6 @@
 ---
 title: Runtimes API
-description: REST reference for the runtimes resource group: list, install, connect, healthcheck, run, and seed a native team.
+description: 'REST reference for the runtimes resource group: list, install, connect, healthcheck, run, and seed a native team.'
 ---
 
 REST surface for the four non-OpenClaw [runtimes](/appendices/glossary) (`claude-code`, `codex`, `hermes`, `clawboo-native`): list their capabilities and connection state, install a runtime CLI, connect or disconnect a provider key, verify a key before use, and drive a board task on a chosen runtime. This group also covers `POST /api/onboarding/seed-native-team`, which mints a default native leader + specialist team for the first-run flow.

--- a/docs/reference/rest-api/schedules.md
+++ b/docs/reference/rest-api/schedules.md
@@ -1,6 +1,6 @@
 ---
 title: Schedules API
-description: REST reference for the unified scheduler: list, create, update, pause/resume, delete, and force-run schedules across two sources.
+description: 'REST reference for the unified scheduler: list, create, update, pause/resume, delete, and force-run schedules across two sources.'
 ---
 
 REST surface for the unified scheduler: one merged read/write view over two [schedule sources](/concepts/scheduling): clawboo **Routines** (the `team-task` domain, fully managed) and the **OpenClaw Gateway cron** (the `runtime-own-life` domain, written through the Gateway's own operator RPC). A read always succeeds and reports per-source degradation as data; a write routes to the owning source by id and surfaces the typed scheduling errors as precise status codes.

--- a/docs/reference/rest-api/system.md
+++ b/docs/reference/rest-api/system.md
@@ -1,6 +1,6 @@
 ---
 title: System API
-description: REST reference for /api/system/*: OpenClaw status, install, configure, gateway lifecycle, config, device pairing, and models.
+description: 'REST reference for /api/system/*: OpenClaw status, install, configure, gateway lifecycle, config, device pairing, and models.'
 ---
 
 REST surface for the OpenClaw side of the host: detect what is installed, install the OpenClaw CLI, write its config, control the Gateway process, read or patch `openclaw.json`, approve a device-pairing request, and list the model catalog. These routes are how the onboarding wizard and the System maintenance panel drive OpenClaw from the dashboard.

--- a/docs/reference/rest-api/teams.md
+++ b/docs/reference/rest-api/teams.md
@@ -1,6 +1,6 @@
 ---
 title: Teams API
-description: REST reference for teams and their sub-resources: CRUD, agent membership, the Know-Your-Team onboarding gate, team rules, and the peer-chat room.
+description: 'REST reference for teams and their sub-resources: CRUD, agent membership, the Know-Your-Team onboarding gate, team rules, and the peer-chat room.'
 ---
 
 REST surface for [teams](/appendices/glossary) and everything scoped to a team: team CRUD, agent→team membership, the per-team "Know Your Team" onboarding flags, the durable team-rules text, and the mixed-runtime peer-chat room (read + the explicit exchange kickoff).

--- a/docs/runtimes/claude-code.md
+++ b/docs/runtimes/claude-code.md
@@ -1,6 +1,6 @@
 ---
 title: Claude Code runtime
-description: Connect and run the Claude Code runtime: capabilities, the ANTHROPIC_API_KEY vault flow, install, and the SDK-backed driver.
+description: 'Connect and run the Claude Code runtime: capabilities, the ANTHROPIC_API_KEY vault flow, install, and the SDK-backed driver.'
 ---
 
 Use this page when you want a [Boo](/appendices/glossary) backed by **Claude Code**, Anthropic's coding agent. Clawboo wraps the [Claude Agent SDK](https://docs.claude.com/en/docs/claude-code/overview) so a Claude Code run executes a durable board task in its own [worktree](/appendices/glossary), reports up, and resumes across runs.

--- a/docs/runtimes/codex.md
+++ b/docs/runtimes/codex.md
@@ -1,6 +1,6 @@
 ---
 title: Codex runtime
-description: The codex runtime: spawns codex exec, authenticates via ChatGPT OAuth, synthesizes text-deltas, reports no USD cost, and carries a thread id.
+description: 'The codex runtime: spawns codex exec, authenticates via ChatGPT OAuth, synthesizes text-deltas, reports no USD cost, and carries a thread id.'
 ---
 
 `codex` is the [runtime](/appendices/glossary) that drives OpenAI's `codex exec` CLI: Clawboo installs the `codex` binary, spawns it per board task in an isolated home, and reshapes its `--json` event stream into the normalized [RuntimeEvent](/appendices/glossary) stream every other runtime emits. It is one of the five runtimes, a co-equal peer beside `openclaw`, `clawboo-native`, `claude-code`, and `hermes`.

--- a/docs/runtimes/native.md
+++ b/docs/runtimes/native.md
@@ -1,6 +1,6 @@
 ---
 title: Clawboo Native runtime
-description: The clawboo-native in-process conversational harness: provider SDKs direct, no Gateway, jailed file tools, in-process MCP, and how to connect a key.
+description: 'The clawboo-native in-process conversational harness: provider SDKs direct, no Gateway, jailed file tools, in-process MCP, and how to connect a key.'
 ---
 
 `clawboo-native` is Clawboo's own [runtime](/appendices/glossary): an in-process conversational harness that talks to provider SDKs directly (Anthropic, OpenAI, OpenRouter, Ollama) with **no OpenClaw Gateway** in the loop. It is one of the five runtimes, a co-equal peer beside `openclaw`, `claude-code`, `codex`, and `hermes`; there is no conversion or export between a native agent and any other runtime's agent.

--- a/docs/using/board.md
+++ b/docs/using/board.md
@@ -1,6 +1,6 @@
 ---
 title: Using the board
-description: Read and work the durable kanban board: columns, task cards, the team filter, the task-detail drawer, and the chat-fused board.
+description: 'Read and work the durable kanban board: columns, task cards, the team filter, the task-detail drawer, and the chat-fused board.'
 ---
 
 Use this page when you want to see what your team is actually doing; the durable kanban [board](/concepts/the-board) is Clawboo's transactional record of every task, who owns it, whether it verified, and what it cost. The board is canonical; the group chat is narration of it. This page covers the **Board** panel (its columns and cards), the per-task **detail drawer**, and the **chat-fused board** that interleaves task cards directly into group chat.

--- a/docs/using/ghost-graph.md
+++ b/docs/using/ghost-graph.md
@@ -1,6 +1,6 @@
 ---
 title: Using the Ghost Graph and Atlas
-description: Read and edit your fleet's org graph: dual-shape Boo nodes, peacock skill expand, team halos, connect mode, and the Atlas global view.
+description: "Read and edit your fleet's org graph: dual-shape Boo nodes, peacock skill expand, team halos, connect mode, and the Atlas global view."
 ---
 
 Use this page when you want to _see_ how your agents relate: who reports to whom, which skills each Boo carries, and what each one is doing right now. Clawboo renders this as a React Flow canvas in two scopes: **Atlas** (the global all-teams org graph) and the per-team **Ghost Graph** (embedded inside a team's group chat). Both are the same `GhostGraph` component driven by a `scope` prop; what differs is which agents they show and a couple of Atlas-only controls.

--- a/docs/using/index.md
+++ b/docs/using/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using Clawboo: the feature map
+title: 'Using Clawboo: the feature map'
 description: A navigation index to every Clawboo dashboard feature, grouped by where it lives in the UI.
 ---
 

--- a/docs/using/system-maintenance.md
+++ b/docs/using/system-maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: System maintenance
-description: Manage OpenClaw from the System panel: gateway control, default model, API keys, agent coordination, and updates.
+description: 'Manage OpenClaw from the System panel: gateway control, default model, API keys, agent coordination, and updates.'
 ---
 
 Use the **System** panel when you want to operate the OpenClaw [Gateway](/appendices/glossary) and its config from inside the dashboard instead of the terminal: start/stop/restart the Gateway, pick the default model, store provider API keys, toggle agent-to-agent coordination, and check for OpenClaw updates. The panel manages **OpenClaw only**; the other runtimes (`clawboo-native`, `claude-code`, `codex`, `hermes`) are managed from the [Runtimes](/runtimes/connecting-runtimes) panel.


### PR DESCRIPTION
## Summary

- Updates markdown documentation to wrap YAML-sensitive description values in double quotes.
- Prevents YAML parsing issues caused by special characters in frontmatter and structured doc metadata.
- Applies the formatting cleanup across README, concepts, guides, and reference documentation for better consistency and reliability.

## Type

- [ ] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [x] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed — documentation-only change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff