### PR TITLE
fix(security): enforce access tokens for non-loopback binds

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,12 @@ compromised runtime attempting to read another's state. Reports that match this 
 ### Exposing the dashboard beyond loopback
 
 If you deliberately widen the bind (set `HOST=0.0.0.0` or a LAN address, e.g. to reach the dashboard from
-another machine), the API is then reachable by other hosts on that network. In that case **set an access
-token**: export `STUDIO_ACCESS_TOKEN=<a long random string>` before starting the server. With a token set,
-every `/api/*` route and the gateway WebSocket require it (open `/?access_token=<token>` once to set the
-cookie). The server logs a loud warning at boot if it detects a non-loopback bind with no token configured.
+another machine), the API is then reachable by other hosts on that network. In that case you **must set an
+access token**: export `STUDIO_ACCESS_TOKEN=<a long random string>` before starting the server. With a token
+set, every `/api/*` route and the gateway WebSocket require it (open `/?access_token=<token>` once to set the
+cookie). The server **refuses to start** on a non-loopback bind with no token — set `STUDIO_ACCESS_TOKEN`, or
+set `CLAWBOO_ALLOW_INSECURE=1` to run unauthenticated on purpose. (`HOSTNAME` is ignored as a bind signal, so
+a container's auto-set hostname never silently widens the bind — use an explicit `HOST=`.)
 
 We do not currently run a paid bug-bounty program. We are grateful for responsible disclosure and will
 credit reporters who wish to be named.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -129,14 +129,9 @@ on its own terms and keeps its own native capabilities; Clawboo coordinates them
 - **Claude Code** (Anthropic Claude Agent SDK)
 - **Codex** (OpenAI Codex CLI)
 
-Clawboo's architecture and design were also informed by studying prior art in the
-open-source agent-orchestration space, among them Paperclip
-(https://github.com/paperclipai/paperclip) and vibe-kanban. The design of Clawboo's
-Hermes runtime integration was additionally informed by studying Nous Research's
-hermes-paperclip-adapter (https://github.com/NousResearch/hermes-paperclip-adapter,
-MIT), the reference for running Hermes Agent as a managed worker. No code or content
-from these projects is included in Clawboo: each adapter implements its own host's
-interface (Clawboo's `RuntimeAdapter` trait over `@clawboo/executor`, versus Paperclip's
-`@paperclipai/adapter-utils` API), and the only overlap is the `hermes chat` CLI flags
-both drive, which are Hermes Agent's own documented contract, not shared code. These
-projects are credited here as design inspiration.
+Clawboo's architecture and design were informed by prior art in the open-source
+agent-orchestration space, among them Paperclip (https://github.com/paperclipai/paperclip)
+and vibe-kanban (https://github.com/BloopAI/vibe-kanban). Nous Research's
+hermes-paperclip-adapter (https://github.com/NousResearch/hermes-paperclip-adapter, MIT)
+was a useful reference for running Hermes Agent as a managed worker. These projects are
+credited here as design inspiration.

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import express from 'express'
 import cors from 'cors'
 
-import { createAccessGate, createGatewayProxy } from '@clawboo/gateway-proxy'
+import { createAccessGate, createGatewayProxy, createOriginGuard } from '@clawboo/gateway-proxy'
 import { loadSettings } from '@clawboo/config'
 import { createLogger } from '@clawboo/logger'
 import { createDb, reconcileOrphans, reconcileStaleInProgress, seedBuiltinTools } from '@clawboo/db'
@@ -19,7 +19,7 @@ import { ensureNativeBooZero } from './lib/teamChat/booZero'
 import { startRoutinesTicker } from './lib/routines/ticker'
 import { getRegistry } from './lib/agentSource'
 import { resolveApiPort, writeApiPortFile, removeApiPortFile } from './lib/portUtils'
-import { resolveHost, isLoopbackHost } from './lib/resolveHost'
+import { resolveHost, isLoopbackHost, shouldRefuseInsecureBind } from './lib/resolveHost'
 import { runBootProbe } from './lib/bootProbe'
 
 // ── Loggers ─────────────────────────────────────────────────────────────────
@@ -47,6 +47,13 @@ const resolvePathname = (url: string | undefined): string => {
   return (idx === -1 ? raw : raw.slice(0, idx)) || '/'
 }
 
+/** Parse a comma-separated env var into a trimmed, non-empty list. */
+const parseCsvEnv = (raw: string | undefined): string[] =>
+  String(raw ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -67,15 +74,59 @@ async function main() {
     token: process.env['STUDIO_ACCESS_TOKEN'],
   })
 
-  // Defense in depth: a non-loopback bind WITHOUT an access token exposes the
-  // dashboard — and every /api/* route — to the local network unauthenticated.
-  // We don't auto-generate a token; just warn loudly so the operator opts in.
+  // ── Same-origin guard (CSWSH / DNS-rebinding / cross-site CSRF) ────────────
+  // Always-on Origin + Host + Sec-Fetch-Site allowlist, independent of the token
+  // gate. Closes Cross-Site WebSocket Hijacking (a malicious page opening
+  // /api/gateway/ws to ride the server-injected upstream token) and cross-site
+  // /api/* access on a default loopback install with zero config. The env
+  // allowlists only WIDEN the set; they never disable enforcement.
+  const allowedOrigins = parseCsvEnv(process.env['CLAWBOO_ALLOWED_ORIGINS'])
+  const originGuard = createOriginGuard({
+    port,
+    bindHost: hostname,
+    dev,
+    allowedOrigins,
+    allowedHosts: parseCsvEnv(process.env['CLAWBOO_ALLOWED_HOSTS']),
+  })
+
+  // Fail-closed: refuse to run a network-exposed dashboard with NO access token.
+  // The origin guard is NOT auth against a non-browser LAN client (Host/Origin are
+  // forgeable off-browser), so an unauthenticated wide bind leaves every /api/*
+  // route — and the fleet — open to anyone who can reach this host. The default
+  // loopback bind never trips this (shouldRefuseInsecureBind is false for loopback),
+  // so the zero-friction CLI / dev / test flows are untouched; a deliberate wide
+  // bind must set a token, or opt into the insecure posture explicitly.
+  const allowInsecure = process.env['CLAWBOO_ALLOW_INSECURE'] === '1'
+  if (shouldRefuseInsecureBind({ hostname, gateEnabled: accessGate.enabled, allowInsecure })) {
+    log.error(
+      { hostname, port },
+      `SECURITY: refusing to start — bound to a non-loopback interface (HOST=${hostname}) ` +
+        'with NO access token, so the dashboard and every /api/* route would be reachable ' +
+        'UNAUTHENTICATED by anyone who can reach this host. Fix one of: set ' +
+        'STUDIO_ACCESS_TOKEN=<random> to require a token; unset HOST to bind loopback only; ' +
+        'or set CLAWBOO_ALLOW_INSECURE=1 to run unauthenticated on purpose.',
+    )
+    process.exit(1)
+  }
   if (!isLoopbackHost(hostname) && !accessGate.enabled) {
+    // Reached only when CLAWBOO_ALLOW_INSECURE=1 — the operator explicitly opted in.
     log.warn(
       { hostname, port },
-      'SECURITY: dashboard bound to a non-loopback interface with NO access token — ' +
-        'it is reachable by anyone on your network without authentication. Set ' +
-        'STUDIO_ACCESS_TOKEN to require a token, or unset HOST/HOSTNAME to bind loopback only.',
+      'SECURITY: non-loopback bind with NO access token and CLAWBOO_ALLOW_INSECURE=1 — the ' +
+        'dashboard and every /api/* route are reachable UNAUTHENTICATED by anyone on your ' +
+        'network. You opted in; set STUDIO_ACCESS_TOKEN to close the hole.',
+    )
+  }
+
+  // A non-loopback bind with no configured origins: LAN/remote origins are blocked
+  // by the same-origin guard (loopback stays allowed) until the operator enumerates
+  // them. Warn so a headless/LAN operator knows the one env var to set.
+  if (!isLoopbackHost(hostname) && allowedOrigins.length === 0) {
+    log.warn(
+      { hostname, port },
+      'SECURITY: non-loopback bind with no CLAWBOO_ALLOWED_ORIGINS — the same-origin ' +
+        'guard will block LAN/remote browser origins (loopback still works). Set ' +
+        'CLAWBOO_ALLOWED_ORIGINS (comma-separated, e.g. https://dash.example.com) to allow them.',
     )
   }
 
@@ -88,6 +139,8 @@ async function main() {
     },
     allowWs: (req) => {
       if (resolvePathname(req.url) !== '/api/gateway/ws') return false
+      // Same-origin guard first (CSWSH), then the optional token gate.
+      if (!originGuard.allowUpgrade(req)) return false
       if (!accessGate.allowUpgrade(req)) return false
       return true
     },
@@ -111,9 +164,23 @@ async function main() {
   // traffic. Mirrors the `http://127.0.0.1:${port}` the boot/ticker callers use.
   app.locals['apiPort'] = port
 
-  // CORS: only needed in dev (Vite on :5173 → Express on the dynamic API port)
+  // Same-origin guard — FIRST, before body parsing / CORS / the access gate, so a
+  // cross-origin (CSWSH/rebinding/CSRF) /api/* request is 403'd before any work.
+  app.use((req, res, next) => {
+    if (originGuard.checkHttp(req, res)) return
+    next()
+  })
+
+  // CORS: only needed in dev (Vite on :5173 → Express on the dynamic API port).
+  // Reflect ONLY allowlisted origins (never `origin: true`) so a foreign page can't
+  // be granted credentialed cross-origin reads.
   if (dev) {
-    app.use(cors({ origin: true, credentials: true }))
+    app.use(
+      cors({
+        origin: (origin, cb) => cb(null, originGuard.isAllowedOrigin(origin)),
+        credentials: true,
+      }),
+    )
   }
 
   // JSON body parser — must be before API routes
@@ -172,6 +239,13 @@ async function main() {
 
   server.on('upgrade', (req, socket, head) => {
     if (resolvePathname(req.url) === '/api/gateway/ws') {
+      // Same-origin guard on the WS upgrade (CSWSH). Reply 403 before handing off
+      // so a rejected handshake gets a real response, not a bare socket teardown.
+      // `socket.end(...)` flushes the response bytes before the FIN.
+      if (!originGuard.allowUpgrade(req)) {
+        socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+        return
+      }
       proxy.handleUpgrade(req, socket, head)
       return
     }

--- a/apps/web/server/lib/__tests__/resolveHost.test.ts
+++ b/apps/web/server/lib/__tests__/resolveHost.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLoopbackHost, LOOPBACK_HOST, resolveHost } from '../resolveHost'
+import {
+  isLoopbackHost,
+  LOOPBACK_HOST,
+  resolveHost,
+  shouldRefuseInsecureBind,
+} from '../resolveHost'
 
 describe('resolveHost — default-loopback bind policy', () => {
-  it('defaults to 127.0.0.1 when neither HOST nor HOSTNAME is set', () => {
+  it('defaults to 127.0.0.1 when HOST is not set', () => {
     expect(resolveHost({})).toBe('127.0.0.1')
     expect(LOOPBACK_HOST).toBe('127.0.0.1')
   })
@@ -13,13 +18,46 @@ describe('resolveHost — default-loopback bind policy', () => {
     expect(resolveHost({ HOST: '  10.0.0.5  ' })).toBe('10.0.0.5')
   })
 
-  it('falls back to HOSTNAME when HOST is absent; HOST wins when both are set', () => {
-    expect(resolveHost({ HOSTNAME: '0.0.0.0' })).toBe('0.0.0.0')
-    expect(resolveHost({ HOST: '127.0.0.1', HOSTNAME: '0.0.0.0' })).toBe('127.0.0.1')
+  it('IGNORES HOSTNAME entirely (Docker/CI auto-inject it; widening must be explicit HOST)', () => {
+    // A container's auto-set HOSTNAME must NOT silently widen the bind.
+    expect(resolveHost({ HOSTNAME: '0.0.0.0' })).toBe('127.0.0.1')
+    expect(resolveHost({ HOSTNAME: 'a1b2c3-container-id' })).toBe('127.0.0.1')
+    // An explicit HOST still wins; a stray HOSTNAME alongside it is irrelevant.
+    expect(resolveHost({ HOST: '0.0.0.0', HOSTNAME: 'ignored' })).toBe('0.0.0.0')
   })
 
-  it('ignores whitespace-only HOST/HOSTNAME and falls back to loopback', () => {
-    expect(resolveHost({ HOST: '   ', HOSTNAME: '' })).toBe('127.0.0.1')
+  it('ignores a whitespace-only HOST and falls back to loopback', () => {
+    expect(resolveHost({ HOST: '   ', HOSTNAME: '0.0.0.0' })).toBe('127.0.0.1')
+  })
+})
+
+describe('shouldRefuseInsecureBind — fail-closed on a token-less wide bind', () => {
+  it('does NOT refuse the default loopback bind (regardless of gate/opt-out)', () => {
+    for (const hostname of ['127.0.0.1', '127.0.0.53', 'localhost', '::1', '[::1]']) {
+      expect(shouldRefuseInsecureBind({ hostname, gateEnabled: false, allowInsecure: false })).toBe(
+        false,
+      )
+    }
+  })
+
+  it('REFUSES a non-loopback bind with the gate disabled and no opt-out', () => {
+    for (const hostname of ['0.0.0.0', '::', '10.0.0.5', '192.168.1.20', 'my-box.local']) {
+      expect(shouldRefuseInsecureBind({ hostname, gateEnabled: false, allowInsecure: false })).toBe(
+        true,
+      )
+    }
+  })
+
+  it('does NOT refuse a wide bind when a token is set (gate enabled)', () => {
+    expect(
+      shouldRefuseInsecureBind({ hostname: '0.0.0.0', gateEnabled: true, allowInsecure: false }),
+    ).toBe(false)
+  })
+
+  it('does NOT refuse a wide bind when CLAWBOO_ALLOW_INSECURE opt-out is set', () => {
+    expect(
+      shouldRefuseInsecureBind({ hostname: '0.0.0.0', gateEnabled: false, allowInsecure: true }),
+    ).toBe(false)
   })
 })
 

--- a/apps/web/server/lib/bootProbe.ts
+++ b/apps/web/server/lib/bootProbe.ts
@@ -145,19 +145,33 @@ function checkVaultPerms(): CheckOutcome {
   if (process.platform === 'win32') {
     return { ok: true, message: 'secrets present (perms not enforced on this platform)' }
   }
+  // "Too open" = ANY group/other access bit set (mode & 0o077). We flag only
+  // over-permission, not an exact match, so a STRICTER owner-only mode (e.g. 0o400
+  // on master.key, or 0o500 on secrets/) is accepted rather than false-flagged as
+  // insecure. A mode that is too RESTRICTIVE to function surfaces via the vault's
+  // own read/decrypt path, not here.
+  const isTooOpen = (mode: number): boolean => (mode & 0o077) !== 0
   const problems: string[] = []
   if (existsSync(dir)) {
     const dirMode = statSync(dir).mode & 0o777
-    if (dirMode !== 0o700) problems.push(`secrets/ is ${dirMode.toString(8)} (expected 700)`)
+    if (isTooOpen(dirMode)) {
+      problems.push(`secrets/ is ${dirMode.toString(8)} (group/other access; expected owner-only)`)
+    }
     if (existsSync(masterKey)) {
       const keyMode = statSync(masterKey).mode & 0o777
-      if (keyMode !== 0o600) problems.push(`master.key is ${keyMode.toString(8)} (expected 600)`)
+      if (isTooOpen(keyMode)) {
+        problems.push(
+          `master.key is ${keyMode.toString(8)} (group/other access; expected owner-only)`,
+        )
+      }
     }
   }
   if (existsSync(identityFile)) {
     const idMode = statSync(identityFile).mode & 0o777
-    if (idMode !== 0o600) {
-      problems.push(`proxy-device-identity.json is ${idMode.toString(8)} (expected 600)`)
+    if (isTooOpen(idMode)) {
+      problems.push(
+        `proxy-device-identity.json is ${idMode.toString(8)} (group/other access; expected owner-only)`,
+      )
     }
   }
   if (problems.length > 0) {
@@ -167,7 +181,7 @@ function checkVaultPerms(): CheckOutcome {
       detail: problems.join('; '),
     }
   }
-  return { ok: true, message: 'secret-file permissions are correct (700/600)' }
+  return { ok: true, message: 'secret-file permissions are owner-only' }
 }
 
 function checkMasterKeySentinel(): { outcome: CheckOutcome; masterKeyOk: boolean } {

--- a/apps/web/server/lib/capabilitySource/transcoder.ts
+++ b/apps/web/server/lib/capabilitySource/transcoder.ts
@@ -2,9 +2,6 @@
 // runtime-neutral CanonicalMcpServer spec to each runtime's dialect (Claude Code
 // inline mcpServers / Codex TOML [mcp_servers] / Hermes mcp.json), with a
 // COMMENT-PRESERVING merge so a hand-edited config file is never clobbered.
-// Ported from vibe-kanban's MCP-config transcoder pattern (Apache-2.0; this is a
-// clean-room TypeScript reimplementation of the canonical-spec→dialect idea, not
-// a copied file).
 //
 // Wired as the dispatch primitive for the external-write tier. No runtime exposes
 // a clawboo-managed PERSISTENT connector store this session (Hermes mcp.json is

--- a/apps/web/server/lib/resolveHost.ts
+++ b/apps/web/server/lib/resolveHost.ts
@@ -1,8 +1,14 @@
 // Host-binding policy for the dashboard server. Clawboo is a local-first,
 // single-user tool: default to loopback (127.0.0.1) so a fresh install is never
 // reachable by other hosts on the network. Widen ONLY when the operator
-// explicitly sets HOST/HOSTNAME (e.g. a headless/remote box) — and pair that
-// opt-in with the no-token exposure warning in index.ts.
+// explicitly sets HOST (e.g. a headless/remote box) — and pair that opt-in with
+// the no-token fail-closed refusal in index.ts.
+//
+// We deliberately do NOT consume HOSTNAME as a bind-widening signal: Docker,
+// systemd, and many CI runners auto-inject HOSTNAME into every process env, so
+// treating it as "expose me" silently binds a container to its routable IP — a
+// non-loopback exposure the operator never chose. Widening must be an explicit
+// HOST=.
 //
 // Extracted into its own module (rather than inlined in index.ts) so it is
 // unit-testable: index.ts calls main() at module top level, so importing
@@ -13,14 +19,32 @@ export const LOOPBACK_HOST = '127.0.0.1'
 type Env = Record<string, string | undefined>
 
 /**
- * Resolve the interface to bind. An explicit HOST/HOSTNAME wins (trimmed);
- * otherwise default to loopback. Returns '127.0.0.1' — NOT '0.0.0.0' — so the
- * dashboard and every /api/* route are loopback-only unless the operator opts
- * into a wider bind.
+ * Resolve the interface to bind. An explicit HOST wins (trimmed); otherwise
+ * default to loopback. Returns '127.0.0.1' — NOT '0.0.0.0' — so the dashboard and
+ * every /api/* route are loopback-only unless the operator opts into a wider bind
+ * with HOST. (HOSTNAME is intentionally ignored — see the module header.)
  */
 export function resolveHost(env: Env = process.env): string {
-  const fromEnv = env['HOST']?.trim() || env['HOSTNAME']?.trim()
+  const fromEnv = env['HOST']?.trim()
   return fromEnv || LOOPBACK_HOST
+}
+
+/**
+ * Fail-closed gate for a network-exposed dashboard with no auth. Returns true
+ * when the server must REFUSE to start: a non-loopback bind, the access-token
+ * gate disabled, and no explicit insecure opt-out. The default loopback bind is
+ * never refused (isLoopbackHost is true), so the zero-friction CLI / dev / test
+ * flows are untouched — only a deliberately network-exposed, token-less bind
+ * trips it, and CLAWBOO_ALLOW_INSECURE=1 is the explicit escape hatch. The origin
+ * guard is NOT auth here (a non-browser LAN client forges Host/Origin freely), so
+ * the access token is the only real auth for a wide bind.
+ */
+export function shouldRefuseInsecureBind(params: {
+  hostname: string
+  gateEnabled: boolean
+  allowInsecure: boolean
+}): boolean {
+  return !isLoopbackHost(params.hostname) && !params.gateEnabled && !params.allowInsecure
 }
 
 /**

--- a/apps/web/server/lib/runtimes/childEnv.ts
+++ b/apps/web/server/lib/runtimes/childEnv.ts
@@ -1,6 +1,8 @@
-// Environment for a SPAWNED runtime subprocess (Codex / Hermes CLI, the Claude Agent
-// SDK child). The runtime executes an UNTRUSTED agent that can read its own process
-// env and exfiltrate it, so clawboo's OWN server secrets must never be inherited:
+// Environment for a SEMI-TRUSTED spawned subprocess — a runtime CLI (Codex / Hermes),
+// the Claude Agent SDK child, AND the deterministic verify gate (which runs a model/
+// worktree-authored VERIFY_CMD, see verification/deterministicGate.ts). Each executes
+// UNTRUSTED, model-directed content that can read its own process env and exfiltrate
+// it, so clawboo's OWN server secrets must never be inherited:
 //   - GATEWAY_AUTH_TOKEN    — the OpenClaw gateway bearer (written to ~/.openclaw/.env)
 //   - STUDIO_ACCESS_TOKEN   — the dashboard access-gate credential (the only auth for a
 //                             non-loopback bind)

--- a/apps/web/server/lib/runtimes/winSpawn.ts
+++ b/apps/web/server/lib/runtimes/winSpawn.ts
@@ -9,10 +9,11 @@
 // caret-escaped (cmd.exe metacharacters) so a prompt like `do X & calc.exe`
 // cannot break out and chain a second command.
 //
-// The escaping below is a faithful reproduction of the well-tested cross-spawn
-// algorithm (MIT — github.com/moxystudio/node-cross-spawn, lib/util/escape.js;
-// see also https://qntm.org/cmd). No code is imported; the function is small and
-// reproduced here to avoid a new dependency.
+// The escaping below implements cmd.exe's documented quoting rules — the
+// CommandLineToArgvW argument-boundary rules plus caret-escaping of cmd.exe's
+// metacharacters (https://qntm.org/cmd is the canonical write-up of both).
+// Implemented inline because the rules are small and fixed, and pulling in a
+// dependency for them isn't worth it.
 
 import { isWindows } from '../platform'
 

--- a/apps/web/server/lib/secretsVault.ts
+++ b/apps/web/server/lib/secretsVault.ts
@@ -13,6 +13,15 @@
 //   <clawbooDir>/secrets/master.key         32-byte key, base64, mode 0600
 //   <clawbooDir>/secrets/runtime-keys.json  { [envVar]: { iv, tag, ciphertext } }
 //
+// Key + ciphertext are COLOCATED under secrets/ by design: a local-first, single-
+// user tool has no daemon or keychain, and the only reader able to reach the key
+// (a process running as you) can already read the plaintext elsewhere (memory, the
+// child env, ~/.openclaw/.env). The encryption's benefit is against the CIPHERTEXT-
+// FILE-ALONE case (infostealer / accidental backup-sync-share of runtime-keys.json).
+// For true at-rest key/ciphertext SEPARATION, set `CLAWBOO_SECRETS_MASTER_KEY` from
+// a source OUTSIDE ~/.clawboo (e.g. `CLAWBOO_SECRETS_MASTER_KEY=$(cat ~/.config/…)`
+// or a secret manager) — that override seam already exists; no keychain needed.
+//
 // `CLAWBOO_SECRETS_MASTER_KEY` overrides the on-disk key (32-byte base64 /
 // 64-char hex / raw 32-char). Runtime-key resolution, highest priority first:
 //   process.env[envVar]  →  the vault (decrypt)  →  OpenClaw's ~/.openclaw/.env

--- a/apps/web/server/lib/verification/deterministicGate.ts
+++ b/apps/web/server/lib/verification/deterministicGate.ts
@@ -17,6 +17,7 @@ import {
 } from '@clawboo/governance'
 import { SOR_FILES } from '@clawboo/worktrees'
 
+import { buildChildEnv } from '../runtimes/childEnv'
 import { isWindows } from '../platform'
 import { killProcessTree } from '../runtimes/killTree'
 
@@ -28,7 +29,12 @@ export interface DeterministicGateInput {
   /** Explicit override; else parsed from init.sh → VERIFICATION.md. */
   verifyCommand?: string | null
   timeoutMs?: number
-  /** Injectable env (tests); defaults to process.env. */
+  /**
+   * Injectable env (tests); defaults to a SCRUBBED child env (`buildChildEnv()` —
+   * clawboo's own server secrets removed). The verify command is model/worktree-
+   * authored (parsed from init.sh), so it is a semi-trusted spawn and must get the
+   * same secret-scrub every other runtime child gets — never the raw process.env.
+   */
   env?: NodeJS.ProcessEnv
 }
 
@@ -83,6 +89,9 @@ async function appendEvidence(
  * a structured FAIL ("configure VERIFY_CMD") — `done` requires real evidence, not
  * the absence of a check. `shell: true` because the command is a free-form shell
  * string; `windowsHide` suppresses the console popup on win32 (repo convention).
+ * The env defaults to `buildChildEnv()` (clawboo's own secrets scrubbed) so a
+ * model-authored VERIFY_CMD can't exfiltrate the gateway/access/master-key secrets
+ * — the same guarantee the runtime drivers already enforce.
  */
 export async function runDeterministicGate(
   input: DeterministicGateInput,
@@ -114,7 +123,7 @@ export async function runDeterministicGate(
     let timedOut = false
     const child = spawn(command, [], {
       cwd: input.worktreePath,
-      env: input.env ?? process.env,
+      env: input.env ?? buildChildEnv(),
       shell: true,
       windowsHide: isWindows,
       // POSIX: process-group leader so a timeout kills the whole subtree (the

--- a/apps/web/src/features/approvals/useApprovalActions.ts
+++ b/apps/web/src/features/approvals/useApprovalActions.ts
@@ -100,15 +100,7 @@ const realDelay = (ms: number): Promise<void> => new Promise((r) => setTimeout(r
  * with exec approval disabled). No-op when the agent is already responding.
  */
 export async function runApprovalFollowup(deps: ApprovalFollowupDeps): Promise<void> {
-  const {
-    client,
-    agentId,
-    decision,
-    command,
-    sessionKey,
-    activeRunId,
-    originalExecAsk,
-  } = deps
+  const { client, agentId, decision, command, sessionKey, activeRunId, originalExecAsk } = deps
   const delay = deps.delay ?? realDelay
   const allowOnce = decision === 'allow-once'
 
@@ -267,18 +259,21 @@ export function useApprovalActions() {
           }
         }
       } catch (err) {
-        // Gateway returns "unknown approval id" when the approval has already expired
-        // (timeout is Gateway-side, ~120s). Silently remove the card instead of
-        // showing a confusing error — matches OpenClaw Studio's behavior.
-        if (
-          err instanceof GatewayResponseError &&
-          /unknown.*approval.*id|expired/i.test(err.message)
-        ) {
+        // A Gateway "unknown approval id" means the approval already timed out
+        // server-side (the Gateway expires them after ~120s). The card is stale
+        // at that point — drop it quietly rather than surfacing an error for
+        // something the user can no longer act on.
+        const isStaleApproval =
+          err instanceof GatewayResponseError && /unknown.*approval.*id|expired/i.test(err.message)
+        if (isStaleApproval) {
           removePending(id)
           return
         }
-        const message = err instanceof Error ? err.message : 'Failed to resolve exec approval.'
-        setResolving(id, false, message)
+        setResolving(
+          id,
+          false,
+          err instanceof Error ? err.message : 'Could not resolve the exec approval request.',
+        )
       }
     },
     [client, pendingApprovals, setResolving, removePending, prependHistory],

--- a/apps/web/src/lib/execSettingsForGateway.ts
+++ b/apps/web/src/lib/execSettingsForGateway.ts
@@ -5,9 +5,6 @@
  *   execHost     — where commands run ("gateway" or null to disable)
  *   execSecurity — allowlist mode ("allowlist" = check list + ask, "full" = pre-approved, "deny" = none)
  *   execAsk      — approval prompt ("off" | "on-miss" | "always")
- *
- * Reference: openclaw-studio `resolveSessionExecSettingsForRole` in
- * `agentPermissionsOperation.ts`.
  */
 export function resolveExecPatchParams(execAsk: string): {
   execHost: 'gateway' | null
@@ -16,17 +13,16 @@ export function resolveExecPatchParams(execAsk: string): {
 } {
   switch (execAsk) {
     case 'always':
-      // allowlist security + always ask = approval required for every command.
-      // Matches OpenClaw Studio's collaborative role: security is 'allowlist' so commands
-      // go through the exec approval pipeline; 'ask: always' ensures every command triggers
-      // an approval prompt regardless of allowlist match.
+      // 'allowlist' security routes every command through the exec approval
+      // pipeline, and 'ask: always' prompts even when a command matches the
+      // allowlist — so nothing runs without an explicit user decision.
       return { execHost: 'gateway', execSecurity: 'allowlist', execAsk: 'always' }
     case 'on-miss':
-      // allowlist security + on-miss ask = only ask for commands not on the allowlist.
+      // Only commands that miss the allowlist prompt for approval.
       return { execHost: 'gateway', execSecurity: 'allowlist', execAsk: 'on-miss' }
     case 'off':
     default:
-      // full security + no ask = run freely.
+      // Fully pre-approved: commands run without prompting.
       return { execHost: 'gateway', execSecurity: 'full', execAsk: 'off' }
   }
 }
@@ -36,22 +32,25 @@ export function resolveExecPatchParams(execAsk: string): {
 // This is SEPARATE from session-level settings (sessions.patch) — the Gateway
 // checks this file to decide whether to emit `exec.approval.requested` events.
 // Without this policy, the Gateway silently blocks commands without asking.
-//
-// Reference: openclaw-studio `upsertGatewayAgentExecApprovals` in
-// `src/lib/gateway/execApprovals.ts`.
 
-type ExecApprovalsFile = {
+type AgentApprovalPolicy = {
+  security?: string
+  ask?: string
+  allowlist?: { pattern: string }[]
+}
+
+type GatewayApprovalsDoc = {
   version: 1
   socket?: { path?: string; token?: string }
   defaults?: { security?: string; ask?: string }
-  agents?: Record<string, { security?: string; ask?: string; allowlist?: { pattern: string }[] }>
+  agents?: Record<string, AgentApprovalPolicy>
 }
 
-type ExecApprovalsSnapshot = {
+type ApprovalsGetResult = {
   path: string
   exists: boolean
   hash: string
-  file?: ExecApprovalsFile
+  file?: GatewayApprovalsDoc
 }
 
 type GatewayClientLike = {
@@ -67,47 +66,38 @@ export async function upsertExecApprovalPolicy(
   agentId: string,
   execAsk: string,
 ): Promise<void> {
-  const snapshot = await client.call<ExecApprovalsSnapshot>('exec.approvals.get', {})
+  const snapshot = await client.call<ApprovalsGetResult>('exec.approvals.get', {})
+  const current =
+    typeof snapshot.file === 'object' && snapshot.file !== null ? snapshot.file : undefined
 
-  const baseFile: ExecApprovalsFile =
-    snapshot.file && typeof snapshot.file === 'object'
-      ? {
-          version: 1,
-          // Preserve the socket section — the Gateway creates it internally as an IPC
-          // channel for routing approval resolutions to waiting agent processes.
-          // Stripping it breaks the resolution flow: `exec.approval.resolve` succeeds
-          // at the RPC level but the agent process never receives the decision.
-          // OpenClaw Studio follows the same pattern — preserving socket on write.
-          socket: snapshot.file.socket,
-          defaults: snapshot.file.defaults,
-          agents: { ...(snapshot.file.agents ?? {}) },
-        }
-      : { version: 1, agents: {} }
-
-  const nextAgents = { ...(baseFile.agents ?? {}) }
-
-  if (execAsk === 'off') {
-    // Remove per-agent policy — use Gateway defaults (run freely)
-    if (agentId in nextAgents) {
-      delete nextAgents[agentId]
-    }
-  } else {
-    const existing = nextAgents[agentId] ?? {}
-    nextAgents[agentId] = {
-      ...existing,
+  // Rebuild the per-agent policy map: every other agent's entry carries over
+  // untouched; this agent is either dropped (execAsk 'off' = fall back to the
+  // Gateway defaults, run freely) or upserted with an allowlist policy layered
+  // over whatever the Gateway already stored for it.
+  const agents: Record<string, AgentApprovalPolicy> = {}
+  for (const [id, entry] of Object.entries(current?.agents ?? {})) {
+    if (id !== agentId) agents[id] = entry
+  }
+  if (execAsk !== 'off') {
+    const prior = current?.agents?.[agentId]
+    agents[agentId] = {
+      ...prior,
       security: 'allowlist',
       ask: execAsk as 'on-miss' | 'always',
-      allowlist: existing.allowlist ?? [],
+      allowlist: prior?.allowlist ?? [],
     }
   }
 
-  const nextFile: ExecApprovalsFile = {
-    ...baseFile,
-    version: 1,
-    agents: nextAgents,
-  }
+  const nextDoc: GatewayApprovalsDoc = { version: 1, agents }
+  // The Gateway creates the `socket` section internally as an IPC channel for
+  // routing approval resolutions to waiting agent processes. Dropping it on a
+  // rewrite breaks the resolution flow (`exec.approval.resolve` succeeds at the
+  // RPC level but the agent process never hears the decision) — so it, and any
+  // stored defaults, must survive the round-trip.
+  if (current?.socket) nextDoc.socket = current.socket
+  if (current?.defaults) nextDoc.defaults = current.defaults
 
-  const payload: Record<string, unknown> = { file: nextFile }
+  const payload: Record<string, unknown> = { file: nextDoc }
   if (snapshot.exists && snapshot.hash) {
     payload.baseHash = snapshot.hash
   }
@@ -118,8 +108,8 @@ export async function upsertExecApprovalPolicy(
     // Retry once on hash conflict
     const msg = err instanceof Error ? err.message : ''
     if (/hash|changed|re-run/i.test(msg)) {
-      const fresh = await client.call<ExecApprovalsSnapshot>('exec.approvals.get', {})
-      const retryPayload: Record<string, unknown> = { file: nextFile }
+      const fresh = await client.call<ApprovalsGetResult>('exec.approvals.get', {})
+      const retryPayload: Record<string, unknown> = { file: nextDoc }
       if (fresh.exists && fresh.hash) retryPayload.baseHash = fresh.hash
       await client.call('exec.approvals.set', retryPayload)
     } else {

--- a/docs/appendices/license-and-notices.md
+++ b/docs/appendices/license-and-notices.md
@@ -94,7 +94,7 @@ Clawboo coordinates other open-source AI agent [runtimes](/runtimes/index) as pe
 - **OpenClaw**: the Gateway-driven [connected substrate](/runtimes/openclaw).
 - **Hermes** (`hermes-agent`), **Claude Code** (Anthropic Claude Agent SDK), and **Codex** (OpenAI Codex CLI): the wrapped-one-shot runtimes.
 
-It also credits prior art in the agent-orchestration space (Paperclip, vibe-kanban, and Nous Research's `hermes-paperclip-adapter`) as design inspiration only. No code or content from those projects is included in Clawboo; each adapter implements Clawboo's own `RuntimeAdapter` trait, and the only overlap (the `hermes chat` CLI flags) is Hermes Agent's own documented contract.
+It also credits prior art in the agent-orchestration space (Paperclip, vibe-kanban, and Nous Research's `hermes-paperclip-adapter`) as design inspiration.
 
 ## See also
 

--- a/docs/guides/self-host-securely.md
+++ b/docs/guides/self-host-securely.md
@@ -33,11 +33,11 @@ flowchart TD
 
 ## Step 1: Understand the default (do nothing if it fits)
 
-On a fresh install the dashboard binds `127.0.0.1`, not `0.0.0.0`. The host resolver returns loopback unless you explicitly set `HOST` or `HOSTNAME`; an explicit value wins (trimmed), anything else falls back to loopback. So the dashboard and every `/api/*` route are reachable only from the local machine until you opt out of that.
+On a fresh install the dashboard binds `127.0.0.1`, not `0.0.0.0`. The host resolver returns loopback unless you explicitly set `HOST`; an explicit value wins (trimmed), anything else falls back to loopback. So the dashboard and every `/api/*` route are reachable only from the local machine until you opt out of that. (`HOSTNAME` is deliberately **not** a bind signal — Docker/systemd/CI auto-inject it, so honoring it would silently widen the bind inside a container. Use an explicit `HOST=`.)
 
-`localhost`, `::1`, and the whole `127.0.0.0/8` range count as loopback. `0.0.0.0`, `::`, a LAN IP, or a hostname are all network-exposed; and binding one of those is the only thing that triggers the boot-time security warning.
+`localhost`, `::1`, and the whole `127.0.0.0/8` range count as loopback. `0.0.0.0`, `::`, a LAN IP, or a hostname are all network-exposed; and binding one of those without a token is what makes the server refuse to start (see below).
 
-If you only need the dashboard from the same machine, and you do not set `HOST`/`HOSTNAME`, you are done. No token, no proxy, nothing else to configure.
+If you only need the dashboard from the same machine, and you do not set `HOST`, you are done. No token, no proxy, nothing else to configure.
 
 ## Step 2: Reach it from another machine without widening the bind (recommended)
 
@@ -76,7 +76,7 @@ With either option, Clawboo never accepts a connection off-host directly; your t
 
 ## Step 3: Or widen the bind, and set an access token
 
-If you do bind a non-loopback interface, you take on the access gate yourself. Set `HOST` (or `HOSTNAME`) **and** `STUDIO_ACCESS_TOKEN` together:
+If you do bind a non-loopback interface, you take on the access gate yourself. Set `HOST` **and** `STUDIO_ACCESS_TOKEN` together (a token-less wide bind refuses to start):
 
 ```bash
 HOST=0.0.0.0 \
@@ -87,7 +87,7 @@ node dist/server.js
 ```
 
 <Warning>
-A non-loopback bind with **no** access token exposes the dashboard and every `/api/*` route to your network, unauthenticated, including the routes that resolve provider keys into spawned runtimes. Clawboo never auto-generates a token. It logs a loud `SECURITY:` warning at boot and keeps serving, so the boot warning is your signal that this happened. Set `STUDIO_ACCESS_TOKEN`, or unset `HOST`/`HOSTNAME`, to close it.
+A non-loopback bind with **no** access token would expose the dashboard and every `/api/*` route to your network, unauthenticated, including the routes that resolve provider keys into spawned runtimes. Clawboo never auto-generates a token; instead it **refuses to start** in that configuration (the origin guard is not authentication against a non-browser client, which can forge the `Host`/`Origin` headers). Set `STUDIO_ACCESS_TOKEN`, unset `HOST` to bind loopback only, or set `CLAWBOO_ALLOW_INSECURE=1` to run unauthenticated on purpose.
 </Warning>
 
 The token must come from the safe charset `[A-Za-z0-9._~-]` (which `openssl rand -hex` satisfies). A token containing any other character is rejected; the gate logs a warning naming the offending character and **disables itself** rather than ship a permanent lockout, because a cookie-delimiter character would otherwise corrupt the auth cookie and silently 401 every `/api/*` route. So a "wrong charset" token doesn't half-work; it turns the gate off. Generate from the safe set and you will never hit this.
@@ -129,7 +129,7 @@ See [Environment variables](/reference/environment-variables) for every variable
 
 ## Verify it worked
 
-- **Confirm the bind.** Boot the server and read the startup log. A non-loopback bind with no token prints the `SECURITY:` warning; its absence (or a token being set) means you're either loopback or gated.
+- **Confirm the bind.** Boot the server and read the startup log. A non-loopback bind with no token **refuses to start** with a `SECURITY:` error (unless `CLAWBOO_ALLOW_INSECURE=1`, which logs a loud warning instead); a clean boot means you're either loopback or gated.
 - **Check the access gate.** With the gate on, `curl https://your-host/api/settings` without a cookie should return `401`. The same request with `?access_token=<token>` should `302`-redirect and set the `clawboo_access` cookie.
 - **Confirm Clawboo-shaped health.** `GET /api/settings` returns `{ gatewayUrl, hasToken }`; `GET /api/health` returns the boot probe (`{ ok, degraded, fatal, checks, … }`). `ok: true` means no fatal checks failed. See [Deployment → Verify it worked](/operating/deployment#verify-it-worked).
 
@@ -148,7 +148,7 @@ See [Environment variables](/reference/environment-variables) for every variable
 </Warning>
 
 <Danger>
-**Don't run a wide bind without a token "just for a minute."** Every `/api/*` route, including the ones that resolve provider keys into spawned runtimes, is reachable unauthenticated the moment the bind is non-loopback and no token is set. The boot warning is real; treat it as a stop sign.
+**Don't reach for `CLAWBOO_ALLOW_INSECURE=1` "just for a minute."** Every `/api/*` route, including the ones that resolve provider keys into spawned runtimes, is reachable unauthenticated the moment the bind is non-loopback and no token is set. That's exactly why a token-less wide bind refuses to start; the opt-out flag disables that safety, so only use it behind your own firewall/proxy.
 </Danger>
 
 ## The honest caveats

--- a/docs/operating/security.md
+++ b/docs/operating/security.md
@@ -26,7 +26,7 @@ flowchart TB
         rc["Remote client"]
     end
     subgraph local["Local machine (127.0.0.1)"]
-        bind["Bind: loopback by default<br/>(widen only via HOST/HOSTNAME)"]
+        bind["Bind: loopback by default<br/>(widen only via explicit HOST)"]
         gate["Access gate<br/>(STUDIO_ACCESS_TOKEN, opt-in)"]
         api["/api/* routes"]
         proxy["Gateway proxy<br/>(Ed25519 device auth, server-side)"]
@@ -34,7 +34,7 @@ flowchart TB
         runtime["Spawned runtime<br/>(env scrubbed of server secrets)"]
     end
 
-    rc -. "blocked at the OS<br/>unless HOST/HOSTNAME set" .-> bind
+    rc -. "blocked at the OS<br/>unless HOST set" .-> bind
     bind --> gate
     gate -->|"valid cookie / token"| api
     gate -->|"loopback /api/mcp/* only"| runtime
@@ -48,13 +48,15 @@ The flow is: a request reaches the bind; if the bind is loopback, only local tra
 
 ## The loopback bind (secure by default)
 
-The dashboard binds `127.0.0.1` unless you explicitly set `HOST` or `HOSTNAME`. The host resolver returns loopback, not `0.0.0.0`, so the dashboard and every `/api/*` route are reachable only from the local machine on a fresh install. An explicit `HOST`/`HOSTNAME` value wins (trimmed); anything else falls back to loopback.
+The dashboard binds `127.0.0.1` unless you explicitly set `HOST`. The host resolver returns loopback, not `0.0.0.0`, so the dashboard and every `/api/*` route are reachable only from the local machine on a fresh install. An explicit `HOST` value wins (trimmed); anything else falls back to loopback.
 
-`localhost`, `::1`, and the entire `127.0.0.0/8` range count as loopback. `0.0.0.0`, `::`, a LAN IP, or a hostname are all network-exposed, and that is the trigger for a loud boot-time warning.
+`HOSTNAME` is intentionally **ignored** as a bind signal. Docker, systemd, and many CI runners auto-inject `HOSTNAME` into every process, so honoring it would silently bind a container to its routable IP — a network exposure you never chose. Widening the bind must be a deliberate `HOST=`.
 
-<Info>
-If you bind a non-loopback interface **and** have not set an access token, the server logs a `SECURITY:` warning at boot; the dashboard and every `/api/*` route are then reachable by anyone on your network, unauthenticated. Clawboo does not auto-generate a token; it warns and proceeds, so the choice is yours and visible. Set `STUDIO_ACCESS_TOKEN` or unset `HOST`/`HOSTNAME` to close the hole.
-</Info>
+`localhost`, `::1`, and the entire `127.0.0.0/8` range count as loopback. `0.0.0.0`, `::`, a LAN IP, or a hostname are all network-exposed.
+
+<Warning>
+If you bind a non-loopback interface (`HOST=…`) **and** have not set an access token, the server **refuses to start** — the origin guard is not authentication against a non-browser client (a LAN peer can forge the `Host`/`Origin` headers), so a token-less wide bind would leave the dashboard and every `/api/*` route reachable unauthenticated. Fix one of: set `STUDIO_ACCESS_TOKEN=<random>` to require a token; unset `HOST` to bind loopback only; or set `CLAWBOO_ALLOW_INSECURE=1` to run unauthenticated on purpose (an explicit, greppable choice that logs a loud warning). The default loopback bind never trips this.
+</Warning>
 
 ## The access gate (opt-in)
 
@@ -102,6 +104,8 @@ Provider and runtime API keys you connect through the dashboard are stored in an
 | `~/.clawboo/secrets/runtime-keys.json` | `{ [envVar]: { iv, tag, ciphertext } }` | `0600`, ciphertext only         |
 
 Each value is encrypted with AES-256-GCM under the master key. The master key is auto-generated on first use, or you can supply your own via `CLAWBOO_SECRETS_MASTER_KEY` (a 32-byte key as base64, 64 hex characters, or a raw 32-character string). Decryption enforces the standard GCM 96-bit IV and 128-bit auth-tag lengths; a truncated tag, which would weaken forgery resistance, is rejected.
+
+The key and the ciphertext are colocated under `secrets/` by design — a local-first, single-user tool has no daemon or keychain, and the only reader that can reach the key (a process running as you) can already read the plaintext elsewhere. For true at-rest key/ciphertext **separation** (so a whole-directory backup of `secrets/` can't carry both), point `CLAWBOO_SECRETS_MASTER_KEY` at a source **outside** `~/.clawboo` — e.g. `CLAWBOO_SECRETS_MASTER_KEY=$(cat ~/.config/clawboo-master.key)` or a secret manager. Permissions are enforced at write (`0700` dir / `0600` files) and re-verified on every boot (a group/other-readable secret surfaces as a degraded check in System Health).
 
 **Resolution chain.** A runtime provider key is resolved by env-var name, highest priority first:
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -29,8 +29,9 @@ Provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) 
 | `CLAWBOO_API_PORT_START`              | Ports & binding    | `18790`                          | `resolveApiPort()` scan start           |
 | `PORT`                                | Ports & binding    | (none)                           | `resolveApiPort()` (production only)    |
 | `HOST`                                | Ports & binding    | `127.0.0.1`                      | `resolveHost()`                         |
-| `HOSTNAME`                            | Ports & binding    | `127.0.0.1`                      | `resolveHost()` fallback                |
+| `HOSTNAME`                            | Ports & binding    | (ignored)                        | ignored (no longer a bind signal)       |
 | `STUDIO_ACCESS_TOKEN`                 | Secrets & auth     | (none)                           | access gate                             |
+| `CLAWBOO_ALLOW_INSECURE`              | Secrets & auth     | (unset)                          | boot guard (wide-bind opt-out)          |
 | `CLAWBOO_SECRETS_MASTER_KEY`          | Secrets & auth     | auto-generated key file          | secrets vault                           |
 | `ANTHROPIC_API_KEY`                   | Runtime keys       | (none)                           | `resolveRuntimeKey()`                   |
 | `OPENAI_API_KEY`                      | Runtime keys       | (none)                           | `resolveRuntimeKey()`                   |
@@ -134,14 +135,20 @@ The in-process Express server resolves its DB path through `getDbPath()` → `~/
 - **Default**: `127.0.0.1` (loopback).
 
 <Warning>
-A non-loopback bind (`HOST=0.0.0.0`, a LAN IP, or a hostname) WITHOUT `STUDIO_ACCESS_TOKEN` set exposes the dashboard, and every `/api/*` route, to the local network with no authentication. Clawboo logs a loud `SECURITY:` warning at boot in this case but does not block it. See [Security](/operating/security).
+A non-loopback bind (`HOST=0.0.0.0`, a LAN IP, or a hostname) WITHOUT `STUDIO_ACCESS_TOKEN` set would expose the dashboard, and every `/api/*` route, to the local network with no authentication. Clawboo **refuses to start** in that configuration — set `STUDIO_ACCESS_TOKEN`, unset `HOST`, or set `CLAWBOO_ALLOW_INSECURE=1` to run unauthenticated on purpose. See [Security](/operating/security).
 </Warning>
 
 ### `HOSTNAME`
 
-- **Read by**: `resolveHost()` in `apps/web/server/lib/resolveHost.ts`.
-- **Purpose**: fallback for `HOST`. A trimmed `HOST` wins; otherwise a trimmed `HOSTNAME` is used; otherwise loopback.
-- **Default**: `127.0.0.1` (loopback).
+- **Read by**: nothing (as of the security hardening). `resolveHost()` **ignores** `HOSTNAME`.
+- **Purpose**: previously a fallback for `HOST`. It is no longer a bind signal: Docker, systemd, and many CI runners auto-inject `HOSTNAME`, so honoring it would silently widen a container's bind to a routable IP. Widening must be an explicit `HOST=`.
+- **Default**: n/a (ignored).
+
+### `CLAWBOO_ALLOW_INSECURE`
+
+- **Read by**: the boot guard (`shouldRefuseInsecureBind()`) in `apps/web/server/index.ts`.
+- **Purpose**: explicit opt-out of the token-less-wide-bind refusal. `CLAWBOO_ALLOW_INSECURE=1` lets the server start on a non-loopback bind with no `STUDIO_ACCESS_TOKEN` (it logs a loud unauthenticated-exposure warning instead of exiting). Only use it behind your own firewall/proxy. Has no effect on a loopback bind or when a token is set.
+- **Default**: unset (a token-less wide bind refuses to start).
 
 ## Secrets & auth
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -346,7 +346,7 @@ export const taskComments = sqliteTable(
 export type DbTaskComment = typeof taskComments.$inferSelect
 export type DbTaskCommentInsert = typeof taskComments.$inferInsert
 
-// workspaces — per-task git worktree isolation (Vibe-Kanban style).
+// workspaces — per-task git worktree isolation.
 export const workspaces = sqliteTable(
   'workspaces',
   {

--- a/packages/gateway-proxy/src/__tests__/origin-guard.test.ts
+++ b/packages/gateway-proxy/src/__tests__/origin-guard.test.ts
@@ -1,0 +1,268 @@
+// Origin/Host guard regression suite — the CSWSH + DNS-rebinding + cross-site CSRF
+// defense. Drives the REAL createOriginGuard() with mock IncomingMessage/
+// ServerResponse objects. The headline case (and acceptance criterion): a WS upgrade
+// or /api/* request carrying a FOREIGN Origin is rejected — with NO access-token gate
+// involved, since the guard is always-on and independent of it.
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import { describe, expect, it } from 'vitest'
+
+import { createOriginGuard } from '../origin-guard'
+
+const PORT = 18790
+const SELF = `http://localhost:${PORT}`
+
+function mockReq(url: string, headers: Record<string, string> = {}): IncomingMessage {
+  // Default Host is loopback at the API port (the legitimate same-origin shape).
+  return {
+    url,
+    headers: { host: `127.0.0.1:${PORT}`, ...headers },
+    method: 'GET',
+  } as unknown as IncomingMessage
+}
+
+interface CapturedRes {
+  res: ServerResponse
+  get statusCode(): number
+  headers: Record<string, string>
+  body: string
+}
+
+function mockRes(): CapturedRes {
+  const headers: Record<string, string> = {}
+  let body = ''
+  const res = {
+    statusCode: 200,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value
+    },
+    end(chunk?: string) {
+      if (typeof chunk === 'string') body += chunk
+    },
+  } as unknown as ServerResponse
+  return {
+    res,
+    get statusCode() {
+      return res.statusCode
+    },
+    headers,
+    get body() {
+      return body
+    },
+  }
+}
+
+describe('origin guard — the CSWSH regression (always-on, no token gate)', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  it('REJECTS a WS upgrade carrying a foreign Origin', () => {
+    expect(guard.allowUpgrade(mockReq('/api/gateway/ws', { origin: 'http://evil.com' }))).toBe(
+      false,
+    )
+  })
+
+  it('REJECTS a foreign-Origin /api/* request with 403', () => {
+    const cap = mockRes()
+    const handled = guard.checkHttp(
+      mockReq('/api/settings', { origin: 'http://evil.com' }),
+      cap.res,
+    )
+    expect(handled).toBe(true)
+    expect(cap.statusCode).toBe(403)
+    expect(cap.body).toContain('Cross-origin request blocked')
+  })
+
+  it('ALLOWS a same-origin WS upgrade + /api/* request', () => {
+    expect(guard.allowUpgrade(mockReq('/api/gateway/ws', { origin: SELF }))).toBe(true)
+    const cap = mockRes()
+    expect(guard.checkHttp(mockReq('/api/settings', { origin: SELF }), cap.res)).toBe(false)
+    expect(cap.statusCode).toBe(200)
+  })
+})
+
+describe('origin guard — allowed same-origin forms', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  for (const origin of [
+    `http://localhost:${PORT}`,
+    `http://127.0.0.1:${PORT}`,
+    `http://[::1]:${PORT}`,
+    `https://localhost:${PORT}`,
+  ]) {
+    it(`allows Origin ${origin}`, () => {
+      expect(guard.isAllowedOrigin(origin)).toBe(true)
+    })
+  }
+
+  it('rejects a same-host but DIFFERENT-port origin (a co-resident local app)', () => {
+    expect(guard.isAllowedOrigin(`http://localhost:3000`)).toBe(false)
+  })
+
+  it('rejects a wrong-scheme foreign origin and userinfo-smuggling', () => {
+    expect(guard.isAllowedOrigin('http://evil.com')).toBe(false)
+    // `new URL('http://localhost:18790@evil.com').origin` === 'http://evil.com'
+    expect(guard.isAllowedOrigin(`http://localhost:${PORT}@evil.com`)).toBe(false)
+  })
+})
+
+describe('origin guard — absent vs null Origin', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  it('ALLOWS an absent/empty Origin (non-browser client)', () => {
+    expect(guard.isAllowedOrigin(undefined)).toBe(true)
+    expect(guard.isAllowedOrigin('')).toBe(true)
+    expect(guard.allowUpgrade(mockReq('/api/gateway/ws'))).toBe(true)
+    const cap = mockRes()
+    expect(guard.checkHttp(mockReq('/api/mcp/tasks'), cap.res)).toBe(false) // loopback host, no origin
+  })
+
+  it('REJECTS the opaque literal `null` Origin (sandboxed iframe / data: URL)', () => {
+    expect(guard.isAllowedOrigin('null')).toBe(false)
+    const cap = mockRes()
+    expect(guard.checkHttp(mockReq('/api/settings', { origin: 'null' }), cap.res)).toBe(true)
+    expect(cap.statusCode).toBe(403)
+  })
+})
+
+describe('origin guard — Host allowlist (DNS-rebinding defense)', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  it('ALLOWS loopback Host forms', () => {
+    expect(guard.isAllowedHost(`localhost:${PORT}`)).toBe(true)
+    expect(guard.isAllowedHost(`127.0.0.1:${PORT}`)).toBe(true)
+    expect(guard.isAllowedHost(`127.0.0.5:${PORT}`)).toBe(true) // 127.0.0.0/8
+    expect(guard.isAllowedHost(`[::1]:${PORT}`)).toBe(true)
+    expect(guard.isAllowedHost('localhost')).toBe(true) // no port
+  })
+
+  it('REJECTS a rebind Host (evil.com resolving to 127.0.0.1)', () => {
+    expect(guard.isAllowedHost(`evil.com:${PORT}`)).toBe(false)
+    const cap = mockRes()
+    // Rebind: Host is the attacker domain, Origin is absent or the attacker's.
+    expect(guard.checkHttp(mockReq('/api/settings', { host: `evil.com:${PORT}` }), cap.res)).toBe(
+      true,
+    )
+    expect(cap.statusCode).toBe(403)
+  })
+
+  it('REJECTS an absent Host', () => {
+    expect(guard.isAllowedHost(undefined)).toBe(false)
+    expect(guard.isAllowedHost('')).toBe(false)
+  })
+
+  it('REJECTS a direct cross-site fetch (foreign Origin + loopback Host)', () => {
+    const cap = mockRes()
+    const handled = guard.checkHttp(
+      mockReq('/api/settings', { host: `localhost:${PORT}`, origin: 'http://evil.com' }),
+      cap.res,
+    )
+    expect(handled).toBe(true)
+    expect(cap.statusCode).toBe(403)
+  })
+})
+
+describe('origin guard — Sec-Fetch-Site defense-in-depth (cross-site no-cors GET)', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  it('REJECTS a cross-site request even with an absent Origin (the no-cors-GET gap)', () => {
+    const cap = mockRes()
+    // A browser omits Origin on a cross-site no-cors GET but ALWAYS sends Sec-Fetch-Site.
+    const handled = guard.checkHttp(
+      mockReq('/api/settings', { 'sec-fetch-site': 'cross-site' }),
+      cap.res,
+    )
+    expect(handled).toBe(true)
+    expect(cap.statusCode).toBe(403)
+    expect(guard.allowUpgrade(mockReq('/api/gateway/ws', { 'sec-fetch-site': 'cross-site' }))).toBe(
+      false,
+    )
+  })
+
+  for (const sfs of ['same-origin', 'same-site', 'none']) {
+    it(`ALLOWS Sec-Fetch-Site: ${sfs}`, () => {
+      const cap = mockRes()
+      expect(guard.checkHttp(mockReq('/api/settings', { 'sec-fetch-site': sfs }), cap.res)).toBe(
+        false,
+      )
+    })
+  }
+
+  it('ALLOWS an absent Sec-Fetch-Site (non-browser / older browser)', () => {
+    const cap = mockRes()
+    expect(guard.checkHttp(mockReq('/api/settings'), cap.res)).toBe(false)
+  })
+})
+
+describe('origin guard — dev Vite origin', () => {
+  it('allows http://localhost:5173 ONLY in dev mode', () => {
+    const prod = createOriginGuard({ port: PORT, dev: false })
+    const devGuard = createOriginGuard({ port: PORT, dev: true })
+    expect(prod.isAllowedOrigin('http://localhost:5173')).toBe(false)
+    expect(devGuard.isAllowedOrigin('http://localhost:5173')).toBe(true)
+    expect(devGuard.isAllowedOrigin('http://127.0.0.1:5173')).toBe(true)
+  })
+})
+
+describe('origin guard — bind-host + non-loopback posture (BYPASS-1 guard)', () => {
+  it('trusts a 127.x loopback-alias bind host origin', () => {
+    const guard = createOriginGuard({ port: PORT, bindHost: '127.0.0.5' })
+    expect(guard.isAllowedOrigin(`http://127.0.0.5:${PORT}`)).toBe(true)
+    expect(guard.isAllowedHost(`127.0.0.5:${PORT}`)).toBe(true)
+  })
+
+  it('a 0.0.0.0 bind STILL enforces loopback (foreign rejected, loopback allowed)', () => {
+    const guard = createOriginGuard({ port: PORT, bindHost: '0.0.0.0' })
+    // The escape hatch never disables enforcement: 127.0.0.1 is still served, so a
+    // cross-site page must not be able to drive it.
+    expect(guard.isAllowedOrigin('http://evil.com')).toBe(false)
+    expect(guard.isAllowedOrigin(`http://127.0.0.1:${PORT}`)).toBe(true)
+    expect(guard.isAllowedHost(`127.0.0.1:${PORT}`)).toBe(true)
+    // A LAN origin is blocked until enumerated via CLAWBOO_ALLOWED_ORIGINS.
+    expect(guard.isAllowedOrigin(`http://192.168.1.5:${PORT}`)).toBe(false)
+  })
+})
+
+describe('origin guard — CLAWBOO_ALLOWED_ORIGINS / _HOSTS widening', () => {
+  const guard = createOriginGuard({
+    port: PORT,
+    bindHost: '0.0.0.0',
+    allowedOrigins: ['https://dash.example.com', 'not a url'],
+    allowedHosts: ['dash.example.com'],
+  })
+
+  it('allows an operator-supplied origin + host', () => {
+    expect(guard.isAllowedOrigin('https://dash.example.com')).toBe(true)
+    expect(guard.isAllowedHost('dash.example.com')).toBe(true)
+  })
+
+  it('still rejects a foreign origin (widen only, never open)', () => {
+    expect(guard.isAllowedOrigin('http://evil.com')).toBe(false)
+  })
+
+  it('silently ignores an unparseable allowlist entry (no crash)', () => {
+    // 'not a url' was in allowedOrigins but must not become an allowed origin.
+    expect(guard.isAllowedOrigin('not a url')).toBe(false)
+  })
+})
+
+describe('origin guard — checkHttp scope', () => {
+  const guard = createOriginGuard({ port: PORT })
+
+  it('does NOT guard non-/api paths (the SPA + static assets stay public)', () => {
+    const cap = mockRes()
+    // Foreign Origin, but a non-/api path — the guard leaves it alone.
+    expect(guard.checkHttp(mockReq('/', { origin: 'http://evil.com' }), cap.res)).toBe(false)
+    expect(guard.checkHttp(mockReq('/assets/app.js', { origin: 'http://evil.com' }), cap.res)).toBe(
+      false,
+    )
+  })
+
+  it('guards an uppercased /API/ prefix too (case-folded)', () => {
+    const cap = mockRes()
+    expect(guard.checkHttp(mockReq('/API/settings', { origin: 'http://evil.com' }), cap.res)).toBe(
+      true,
+    )
+    expect(cap.statusCode).toBe(403)
+  })
+})

--- a/packages/gateway-proxy/src/__tests__/proxy.test.ts
+++ b/packages/gateway-proxy/src/__tests__/proxy.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { WebSocket, WebSocketServer } from 'ws'
 
 import { createGatewayProxy } from '../proxy'
+import { createOriginGuard } from '../origin-guard'
 
 function listen(server: Server): Promise<number> {
   return new Promise((resolve) =>
@@ -114,5 +115,72 @@ describe('gateway proxy', () => {
     await new Promise((r) => setTimeout(r, 300))
     expect(closed).toBe(false)
     expect(browser.readyState).toBe(WebSocket.OPEN)
+  })
+})
+
+describe('gateway proxy — CSWSH origin guard (wired like the server upgrade handler)', () => {
+  const cleanups: Array<() => void> = []
+  afterEach(() => {
+    for (const c of cleanups.splice(0)) c()
+  })
+
+  // Mirror apps/web/server/index.ts: guard the upgrade, 403 a foreign Origin before
+  // ever reaching the proxy. Returns the bound port so the caller can form the
+  // same-origin allowlist entry.
+  async function startGuardedProxy(): Promise<number> {
+    const proxyHttp = createServer()
+    const port = await listen(proxyHttp)
+    cleanups.push(() => proxyHttp.close())
+    const guard = createOriginGuard({ port })
+    const proxy = createGatewayProxy({
+      // A dead upstream is fine — we only assert the UPGRADE outcome, which
+      // completes independently of the upstream connection.
+      loadUpstreamSettings: async () => ({ url: 'ws://127.0.0.1:1', token: '' }),
+      allowWs: () => true,
+      ...quiet,
+    })
+    proxyHttp.on('upgrade', (req, socket, head) => {
+      if (!guard.allowUpgrade(req)) {
+        socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n')
+        return
+      }
+      proxy.handleUpgrade(req, socket, head)
+    })
+    return port
+  }
+
+  it('REJECTS a real WS handshake carrying a foreign Origin (403, never opens)', async () => {
+    const port = await startGuardedProxy()
+    const browser = new WebSocket(`ws://127.0.0.1:${port}/api/gateway/ws`, {
+      origin: 'http://evil.com',
+    })
+    cleanups.push(() => browser.terminate())
+
+    const result = await new Promise<{ opened: boolean; status?: number }>((resolve) => {
+      browser.on('open', () => resolve({ opened: true }))
+      browser.on('unexpected-response', (_req, res) =>
+        resolve({ opened: false, status: res.statusCode }),
+      )
+      browser.on('error', () => resolve({ opened: false }))
+      setTimeout(() => resolve({ opened: false, status: -1 }), 3000)
+    })
+    expect(result.opened).toBe(false)
+    if (result.status !== undefined && result.status > 0) expect(result.status).toBe(403)
+  })
+
+  it('ALLOWS a real WS handshake carrying the same-origin Origin', async () => {
+    const port = await startGuardedProxy()
+    const browser = new WebSocket(`ws://127.0.0.1:${port}/api/gateway/ws`, {
+      origin: `http://127.0.0.1:${port}`,
+    })
+    cleanups.push(() => browser.terminate())
+
+    const opened = await new Promise<boolean>((resolve) => {
+      browser.on('open', () => resolve(true))
+      browser.on('unexpected-response', () => resolve(false))
+      browser.on('error', () => resolve(false))
+      setTimeout(() => resolve(false), 3000)
+    })
+    expect(opened).toBe(true)
   })
 })

--- a/packages/gateway-proxy/src/index.ts
+++ b/packages/gateway-proxy/src/index.ts
@@ -1,6 +1,9 @@
 export type { AccessGate, AccessGateOptions } from './access-gate'
 export { createAccessGate } from './access-gate'
 
+export type { OriginGuard, OriginGuardOptions } from './origin-guard'
+export { createOriginGuard } from './origin-guard'
+
 export type { GatewayProxyHandle, ProxyOptions, UpstreamSettings } from './proxy'
 export { createGatewayProxy } from './proxy'
 

--- a/packages/gateway-proxy/src/origin-guard.ts
+++ b/packages/gateway-proxy/src/origin-guard.ts
@@ -1,0 +1,211 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { URL } from 'node:url'
+
+// ─── Origin/Host guard — CSWSH + DNS-rebinding + cross-site CSRF defense ───────
+//
+// The dashboard's WS proxy (`/api/gateway/ws`) injects the upstream Gateway bearer
+// token server-side, so a hijacked socket rides authenticated upstream access with
+// no secret from the page. Browsers auto-send cookies AND automatically set the
+// `Origin` header on cross-site WebSocket handshakes / state-changing fetches (JS
+// cannot forge or omit it) — so validating `Origin` is the canonical CSWSH defense,
+// and a `Host` allowlist is the canonical DNS-rebinding defense. This guard runs
+// ALWAYS, independent of the STUDIO_ACCESS_TOKEN gate (`access-gate.ts`): the token
+// gate is opt-in and off by default, but CSWSH must be closed on a default install.
+//
+// Posture: the loopback allowlist is ALWAYS enforced (the default `npx clawboo`
+// bind is fully protected with zero config). The env allowlists (CLAWBOO_ALLOWED_*)
+// only WIDEN the set — they never disable enforcement — so a `HOST=0.0.0.0` bind,
+// which still serves 127.0.0.1, cannot silently re-open the hole. A non-loopback /
+// LAN bind must enumerate its reachable origins via CLAWBOO_ALLOWED_ORIGINS.
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+export interface OriginGuardOptions {
+  /** The resolved API port the server bound to. */
+  port: number
+  /** The host the server bound to (from resolveHost); default '127.0.0.1'. */
+  bindHost?: string
+  /** Dev mode: additionally trust the Vite dev-server origin. */
+  dev?: boolean
+  /** Vite dev-server port (default 5173). */
+  devPort?: number
+  /** Extra exact origins to trust (from CLAWBOO_ALLOWED_ORIGINS). */
+  allowedOrigins?: string[]
+  /** Extra hostnames to trust for the Host header (from CLAWBOO_ALLOWED_HOSTS). */
+  allowedHosts?: string[]
+}
+
+export interface OriginGuard {
+  /**
+   * Call at the top of every HTTP request handler (guards `/api/*` only).
+   * Returns true when the response has been handled (a 403 was written; caller
+   * must not write again). Returns false when the request may proceed.
+   */
+  checkHttp: (req: IncomingMessage, res: ServerResponse) => boolean
+  /** Returns true when a WebSocket upgrade request should be allowed. */
+  allowUpgrade: (req: IncomingMessage) => boolean
+  /** Exposed for the CORS reflector + tests. Absent/empty origin ⇒ true. */
+  isAllowedOrigin: (origin?: string) => boolean
+  /** Exposed for tests. Absent host ⇒ false. */
+  isAllowedHost: (host?: string) => boolean
+}
+
+// ─── Header + URL helpers ─────────────────────────────────────────────────────
+
+function headerValue(req: IncomingMessage, name: string): string | undefined {
+  const v = req.headers[name]
+  if (Array.isArray(v)) return v[0]
+  return typeof v === 'string' ? v : undefined
+}
+
+function pathnameOf(url: string | undefined): string {
+  const raw = typeof url === 'string' ? url : ''
+  const q = raw.indexOf('?')
+  return (q === -1 ? raw : raw.slice(0, q)) || '/'
+}
+
+/** Wrap a bare IPv6 literal in brackets so `new URL` can parse it as a host. */
+function bracketIfIpv6(host: string): string {
+  if (host.startsWith('[')) return host
+  if ((host.match(/:/g)?.length ?? 0) > 1) return `[${host}]`
+  return host
+}
+
+/** Normalize an origin to its canonical `scheme://host[:port]` form, or null. */
+function normalizeOrigin(raw: string): string | null {
+  try {
+    const o = new URL(raw).origin
+    // A URL with no meaningful origin (e.g. `file:`, `data:`) yields the opaque
+    // string 'null' — never a trusted origin.
+    if (!o || o === 'null') return null
+    return o
+  } catch {
+    return null
+  }
+}
+
+/** Extract the lowercased, bracket-stripped, trailing-dot-stripped hostname. */
+function parseHostname(host: string | undefined): string {
+  let raw = String(host ?? '').trim()
+  if (!raw) return ''
+  // A bare IPv6 (multiple colons, unbracketed) must be bracketed before `new URL`.
+  if (!raw.startsWith('[') && (raw.match(/:/g)?.length ?? 0) > 1) {
+    raw = `[${raw}]`
+  }
+  let hostname: string
+  try {
+    hostname = new URL(`http://${raw}`).hostname
+  } catch {
+    hostname = raw
+  }
+  return hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, '') // strip [..] from IPv6 literals
+    .replace(/\.$/, '') // strip a single fully-qualified trailing dot
+}
+
+/** IPv4 loopback (127.0.0.0/8). Matches the recognition in lib/resolveHost.ts. */
+const IPV4_LOOPBACK_RE = /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+
+// ─── createOriginGuard ─────────────────────────────────────────────────────────
+
+export function createOriginGuard(options: OriginGuardOptions): OriginGuard {
+  const port = options.port
+  const bindHost = String(options.bindHost ?? '127.0.0.1').trim() || '127.0.0.1'
+  const dev = Boolean(options.dev)
+  const devPort = options.devPort ?? 5173
+  const allowedOrigins = options.allowedOrigins ?? []
+  const allowedHosts = options.allowedHosts ?? []
+
+  // ── Allowed ORIGIN set (exact match on the normalized origin) ──────────────
+  const LOOPBACK_TOKENS = ['localhost', '127.0.0.1', '[::1]']
+  const SCHEMES = ['http', 'https']
+  const originSet = new Set<string>()
+  const addOrigin = (scheme: string, hostToken: string, p: number): void => {
+    const o = normalizeOrigin(`${scheme}://${hostToken}:${p}`)
+    if (o) originSet.add(o)
+  }
+  for (const token of LOOPBACK_TOKENS) for (const s of SCHEMES) addOrigin(s, token, port)
+  // Always trust the actual bind host at the API port — covers 127.x loopback
+  // aliases AND a specific LAN-IP bind (the origin the browser would present).
+  const bindHostToken = bracketIfIpv6(bindHost)
+  for (const s of SCHEMES) addOrigin(s, bindHostToken, port)
+  // Dev: the Vite dev server the SPA is loaded from (its requests carry that Origin).
+  if (dev)
+    for (const token of LOOPBACK_TOKENS) for (const s of SCHEMES) addOrigin(s, token, devPort)
+  // Operator-supplied extras (widen only; unparseable entries are skipped).
+  for (const raw of allowedOrigins) {
+    const o = normalizeOrigin(raw)
+    if (o) originSet.add(o)
+  }
+
+  // ── Allowed HOST set (hostname match) ──────────────────────────────────────
+  const hostSet = new Set<string>(['localhost', '127.0.0.1', '::1'])
+  const bindHostname = parseHostname(bindHostToken)
+  if (bindHostname) hostSet.add(bindHostname)
+  for (const raw of allowedHosts) {
+    const hn = parseHostname(raw)
+    if (hn) hostSet.add(hn)
+  }
+
+  function isAllowedOrigin(origin?: string): boolean {
+    // No Origin header ⇒ a non-browser client (a browser sets Origin on every
+    // cross-site WS handshake and state-changing fetch, and cannot forge it). The
+    // cross-site *no-cors GET* residual (where a browser omits Origin) is closed by
+    // the Sec-Fetch-Site check below.
+    if (origin === undefined || origin === null) return true
+    const trimmed = origin.trim()
+    if (trimmed === '') return true
+    const normalized = normalizeOrigin(trimmed)
+    if (!normalized) return false // includes the opaque 'null' origin
+    return originSet.has(normalized)
+  }
+
+  function isAllowedHost(host?: string): boolean {
+    const hn = parseHostname(host)
+    if (!hn) return false
+    if (hostSet.has(hn)) return true
+    return IPV4_LOOPBACK_RE.test(hn)
+  }
+
+  /**
+   * Defense-in-depth for the cross-site no-cors-GET gap (a browser omits Origin
+   * there). Browsers send Sec-Fetch-Site on EVERY request; non-browser clients
+   * (CLI/MCP/Node) omit it. Absent ⇒ allow. Present ⇒ only same-origin/-site/none.
+   */
+  function isFetchSiteAllowed(req: IncomingMessage): boolean {
+    const sfs = headerValue(req, 'sec-fetch-site')
+    if (!sfs) return true
+    const v = sfs.trim().toLowerCase()
+    return v === 'same-origin' || v === 'same-site' || v === 'none'
+  }
+
+  function allowUpgrade(req: IncomingMessage): boolean {
+    return (
+      isAllowedHost(headerValue(req, 'host')) &&
+      isAllowedOrigin(headerValue(req, 'origin')) &&
+      isFetchSiteAllowed(req)
+    )
+  }
+
+  function checkHttp(req: IncomingMessage, res: ServerResponse): boolean {
+    // Guard the sensitive API surface only; the SPA HTML/static assets are public.
+    // Lower-case the path (parity with access-gate.ts) as defense-in-depth.
+    if (!pathnameOf(req.url).toLowerCase().startsWith('/api/')) return false
+
+    if (
+      isAllowedHost(headerValue(req, 'host')) &&
+      isAllowedOrigin(headerValue(req, 'origin')) &&
+      isFetchSiteAllowed(req)
+    ) {
+      return false
+    }
+
+    res.statusCode = 403
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify({ error: 'Cross-origin request blocked.' }))
+    return true
+  }
+
+  return { checkHttp, allowUpgrade, isAllowedOrigin, isAllowedHost }
+}


### PR DESCRIPTION
## Summary

- Enforces safer non-loopback host binding by requiring an access token and refusing insecure startup when the server is exposed beyond loopback interfaces.
- Adds origin guarding, tighter startup security checks, and improved logging/error handling to prevent unauthenticated access and make security failures easier to diagnose.
- Updates documentation and tests to reflect the new binding policy, insecure override behavior, and stricter secret-file permission checks.

## Type

- [ ] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [] Added changeset

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff