### PR TITLE
docs(security): expand security model and clarify environment variable behavior

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,8 +20,27 @@ Please include: the affected version, a description, and a minimal reproduction 
 Clawboo is a **local-first** tool: by default the dashboard binds to loopback (`127.0.0.1`) so it is not
 reachable from other hosts on your network, all state lives under `~/.clawboo/`, and runtime API keys are
 stored in an AES-256-GCM encrypted vault. The threat model that the codebase defends against includes
-malicious agent/model output, untrusted capability/skill content, untrusted peer-chat posts, and a single
-compromised runtime attempting to read another's state. Reports that match this model are especially valuable.
+malicious agent/model output, untrusted capability/skill content, untrusted peer-chat posts, a single
+compromised runtime attempting to read another's state, and a browser-based drive-by attacker: a malicious
+web page you visit while Clawboo is running that tries to reach the loopback API from your own browser (a
+cross-site `fetch`/`no-cors` POST, or a Cross-Site WebSocket Hijack, against `http://127.0.0.1:<port>/api/*`).
+Reports that match this model are especially valuable.
+
+**Loopback is not the whole story.** A loopback bind stops other hosts on your network, but it does not stop
+code running in your own browser, because your browser originates the connection to `127.0.0.1`. Clawboo
+closes this with an always-on same-origin guard that validates the `Origin`, `Host` (the DNS-rebinding
+defense), and `Sec-Fetch-Site` headers on every `/api/*` request and WebSocket upgrade. The guard runs
+independently of the access token, so the default `npx clawboo` install is protected against the drive-by,
+CSWSH, and DNS-rebinding attacker with zero configuration; a foreign origin is answered with a 403. Reaching
+the dashboard from a LAN or remote browser origin requires enumerating it via `CLAWBOO_ALLOWED_ORIGINS` (and
+hostnames via `CLAWBOO_ALLOWED_HOSTS`); the loopback allowlist is always enforced and env vars only widen it.
+
+**Spawned runtimes run with a scrubbed environment.** The runtime subprocesses (Codex, Hermes, the Claude
+Agent SDK child) and the verify gate never inherit Clawboo's own server secrets, nor a curated set of the
+operator's third-party shell credentials (cloud, CI, package-registry, and database tokens such as
+`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, `DATABASE_URL`). This is best-effort by name, not a
+sandbox: an un-sandboxed agent can still read on-disk credentials, so treat the tasks you run as code you are
+choosing to execute locally.
 
 ### Exposing the dashboard beyond loopback
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -135,3 +135,61 @@ and vibe-kanban (https://github.com/BloopAI/vibe-kanban). Nous Research's
 hermes-paperclip-adapter (https://github.com/NousResearch/hermes-paperclip-adapter, MIT)
 was a useful reference for running Hermes Agent as a managed worker. These projects are
 credited here as design inspiration.
+
+---
+
+## Additional licenses
+
+### node-cross-spawn
+
+**Source**: https://github.com/moxystudio/node-cross-spawn
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Made With MOXY Lda <hello@moxy.studio>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### OpenClaw and openclaw-studio
+
+**Source**: https://github.com/openclaw/openclaw,
+https://github.com/grp06/openclaw-studio
+
+MIT License
+
+Copyright (c) 2026 OpenClaw Foundation
+Copyright (c) 2026 George Pickett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/web/server/lib/runtimes/__tests__/childEnv.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/childEnv.test.ts
@@ -1,6 +1,7 @@
-// buildChildEnv is what every spawned runtime's env flows through. It must strip
-// clawboo's OWN server secrets (so an untrusted agent subprocess can't read them) while
-// preserving PATH/HOME/etc and merging the caller's granted provider keys.
+// buildChildEnv is what every spawned runtime's env flows through. It must strip clawboo's
+// OWN server secrets AND the operator's curated third-party shell secrets (so an untrusted
+// agent subprocess can't `env`-dump them) while preserving PATH/HOME/infra + the ambient
+// provider-auth the CLIs read + merging the caller's granted provider keys on top.
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
@@ -11,6 +12,18 @@ const SAVED = [
   'STUDIO_ACCESS_TOKEN',
   'CLAWBOO_SECRETS_MASTER_KEY',
   'BETTER_AUTH_SECRET',
+  // operator third-party secrets
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_REGION',
+  'GITHUB_TOKEN',
+  'NPM_TOKEN',
+  'DATABASE_URL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  // ambient provider-auth the CLIs legitimately read (must survive)
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
 ] as const
 
 describe('buildChildEnv', () => {
@@ -21,6 +34,8 @@ describe('buildChildEnv', () => {
     process.env['STUDIO_ACCESS_TOKEN'] = 'studio-secret'
     process.env['CLAWBOO_SECRETS_MASTER_KEY'] = 'master-secret'
     process.env['BETTER_AUTH_SECRET'] = 'better-secret'
+    // Clear the Bedrock flag by default so AWS creds are scrubbed unless a test opts in.
+    delete process.env['CLAUDE_CODE_USE_BEDROCK']
   })
   afterEach(() => {
     for (const k of SAVED) {
@@ -38,6 +53,43 @@ describe('buildChildEnv', () => {
     expect(env['PATH']).toBe(process.env['PATH'])
   })
 
+  it('strips the operator third-party shell secrets (env-dump defense)', () => {
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'aws-secret'
+    process.env['AWS_ACCESS_KEY_ID'] = 'aws-id'
+    process.env['GITHUB_TOKEN'] = 'gh-secret'
+    process.env['NPM_TOKEN'] = 'npm-secret'
+    process.env['DATABASE_URL'] = 'postgres://user:pw@host/db'
+    const env = buildChildEnv()
+    expect(env['AWS_SECRET_ACCESS_KEY']).toBeUndefined()
+    expect(env['AWS_ACCESS_KEY_ID']).toBeUndefined()
+    expect(env['GITHUB_TOKEN']).toBeUndefined()
+    expect(env['NPM_TOKEN']).toBeUndefined()
+    expect(env['DATABASE_URL']).toBeUndefined()
+  })
+
+  it('preserves ambient provider-auth the CLIs read + infra config (never a name heuristic)', () => {
+    // These would be caught by a broad /API_KEY|TOKEN/ regex, but the CLIs authenticate
+    // with them from the ambient env, so they MUST survive.
+    process.env['OPENAI_API_KEY'] = 'codex-key' // Codex reads this from ambient env
+    process.env['GEMINI_API_KEY'] = 'hermes-key' // Hermes' configured provider key
+    process.env['ANTHROPIC_AUTH_TOKEN'] = 'cc-token' // Claude Code alt auth
+    process.env['AWS_REGION'] = 'us-east-1' // config, not a secret
+    const env = buildChildEnv()
+    expect(env['OPENAI_API_KEY']).toBe('codex-key')
+    expect(env['GEMINI_API_KEY']).toBe('hermes-key')
+    expect(env['ANTHROPIC_AUTH_TOKEN']).toBe('cc-token')
+    expect(env['AWS_REGION']).toBe('us-east-1')
+  })
+
+  it('keeps AWS creds ONLY when Claude Code Bedrock mode is explicitly enabled', () => {
+    process.env['AWS_SECRET_ACCESS_KEY'] = 'aws-secret'
+    process.env['AWS_ACCESS_KEY_ID'] = 'aws-id'
+    process.env['CLAUDE_CODE_USE_BEDROCK'] = '1'
+    const env = buildChildEnv()
+    expect(env['AWS_SECRET_ACCESS_KEY']).toBe('aws-secret')
+    expect(env['AWS_ACCESS_KEY_ID']).toBe('aws-id')
+  })
+
   it('merges the granted provider key on top, even when scrubbing ran', () => {
     const env = buildChildEnv({ ANTHROPIC_API_KEY: 'granted-key' })
     expect(env['ANTHROPIC_API_KEY']).toBe('granted-key')
@@ -46,11 +98,20 @@ describe('buildChildEnv', () => {
     expect(env['STUDIO_ACCESS_TOKEN']).toBeUndefined()
   })
 
+  it('a granted key is restored even if its name is in a scrub list', () => {
+    process.env['GITHUB_TOKEN'] = 'ambient-gh'
+    // A caller that explicitly grants a scrubbed-name key gets it back (grant wins).
+    const env = buildChildEnv({ GITHUB_TOKEN: 'granted-gh' })
+    expect(env['GITHUB_TOKEN']).toBe('granted-gh')
+  })
+
   it('the serialized env never contains the secret VALUES', () => {
+    process.env['GITHUB_TOKEN'] = 'gh-operator-secret'
     const blob = JSON.stringify(buildChildEnv({ OPENROUTER_API_KEY: 'or-key' }))
     expect(blob).not.toContain('gw-secret')
     expect(blob).not.toContain('studio-secret')
     expect(blob).not.toContain('master-secret')
+    expect(blob).not.toContain('gh-operator-secret')
     expect(blob).toContain('or-key')
   })
 })

--- a/apps/web/server/lib/runtimes/childEnv.ts
+++ b/apps/web/server/lib/runtimes/childEnv.ts
@@ -1,20 +1,33 @@
 // Environment for a SEMI-TRUSTED spawned subprocess — a runtime CLI (Codex / Hermes),
 // the Claude Agent SDK child, AND the deterministic verify gate (which runs a model/
 // worktree-authored VERIFY_CMD, see verification/deterministicGate.ts). Each executes
-// UNTRUSTED, model-directed content that can read its own process env and exfiltrate
-// it, so clawboo's OWN server secrets must never be inherited:
-//   - GATEWAY_AUTH_TOKEN    — the OpenClaw gateway bearer (written to ~/.openclaw/.env)
-//   - STUDIO_ACCESS_TOKEN   — the dashboard access-gate credential (the only auth for a
-//                             non-loopback bind)
-//   - CLAWBOO_SECRETS_MASTER_KEY — the vault master key
-//   - BETTER_AUTH_*         — any future server-auth secret in that family
+// UNTRUSTED, model-directed content that can read its own process env and exfiltrate it
+// (one `env` command), so we scrub secrets before the child inherits them. Two families:
 //
-// We DENYLIST clawboo's own secrets rather than allowlisting "what the runtime needs":
-// the provider keys a runtime legitimately uses are granted EXPLICITLY by the caller
-// (apiKeyEnv) and merged on top, and a broad credential-name heuristic would strip the
-// provider-auth / PATH / HOME / PYTHONUSERBASE / proxy env the heterogeneous CLI runtimes
-// genuinely depend on. So this closes the named leak deterministically without risking a
-// silent break of a runtime.
+//   1. clawboo's OWN server secrets — MUST never be inherited:
+//      - GATEWAY_AUTH_TOKEN    — the OpenClaw gateway bearer (written to ~/.openclaw/.env)
+//      - STUDIO_ACCESS_TOKEN   — the dashboard access-gate credential (the only auth for a
+//                                non-loopback bind)
+//      - CLAWBOO_SECRETS_MASTER_KEY — the vault master key
+//      - BETTER_AUTH_*         — any future server-auth secret in that family
+//
+//   2. the OPERATOR's third-party shell secrets — the cloud/CI/registry credentials a
+//      developer routinely exports (GITHUB_TOKEN, NPM_TOKEN, STRIPE_SECRET_KEY, AWS keys,
+//      DATABASE_URL, …). A prompt-injected task shouldn't be able to dump these.
+//
+// We DENYLIST BY EXACT NAME, never a broad `*KEY*`/`*TOKEN*` regex: the provider auth a
+// runtime legitimately uses is either granted EXPLICITLY by the caller (apiKeyEnv, merged
+// on top below) OR read from the AMBIENT env (Codex reads OPENAI_API_KEY; Hermes reads its
+// configured provider's key e.g. GEMINI_API_KEY / MISTRAL_API_KEY; Claude Code reads
+// ANTHROPIC_AUTH_TOKEN). A name heuristic would strip exactly those and silently break a
+// runtime — which is why the denylist enumerates only well-known operator secrets that NO
+// clawboo runtime authenticates with, plus PATH / HOME / PYTHONUSERBASE / proxy / AWS_REGION
+// (infra config, not secrets) always survive.
+//
+// This is BEST-EFFORT by name, NOT a sandbox: the child still runs un-sandboxed and can read
+// on-disk credentials (~/.aws/credentials, ~/.config/gh/hosts.yml, project .env files). It
+// closes the single most trivial vector (the `env` dump) and the env-only secrets — CI-
+// injected session tokens that never touch disk and so are reachable no other way.
 
 const CLAWBOO_SECRET_ENV_KEYS = new Set([
   'GATEWAY_AUTH_TOKEN',
@@ -22,20 +35,106 @@ const CLAWBOO_SECRET_ENV_KEYS = new Set([
   'CLAWBOO_SECRETS_MASTER_KEY',
 ])
 
-function isClawbooServerSecret(key: string): boolean {
-  return CLAWBOO_SECRET_ENV_KEYS.has(key) || key.toUpperCase().startsWith('BETTER_AUTH')
+// Well-known THIRD-PARTY operator credentials that no clawboo runtime uses for auth.
+// Exact-match, UPPERCASE-normalized. Add a name here only if you are certain no runtime
+// (Codex / Hermes / Claude Code / native / the verify gate) authenticates with it.
+const THIRD_PARTY_SECRET_ENV_KEYS = new Set([
+  // Version control
+  'GITHUB_TOKEN',
+  'GH_TOKEN',
+  'GH_ENTERPRISE_TOKEN',
+  'GITHUB_PAT',
+  'GITLAB_TOKEN',
+  'GITLAB_PERSONAL_ACCESS_TOKEN',
+  'BITBUCKET_TOKEN',
+  // Package registries
+  'NPM_TOKEN',
+  'NODE_AUTH_TOKEN',
+  'PYPI_TOKEN',
+  'TWINE_PASSWORD',
+  'CARGO_REGISTRY_TOKEN',
+  // Cloud / platform (non-LLM)
+  'DIGITALOCEAN_TOKEN',
+  'DIGITALOCEAN_ACCESS_TOKEN',
+  'DO_API_TOKEN',
+  'VERCEL_TOKEN',
+  'NETLIFY_AUTH_TOKEN',
+  'CLOUDFLARE_API_TOKEN',
+  'CLOUDFLARE_API_KEY',
+  'CF_API_TOKEN',
+  'HEROKU_API_KEY',
+  'FLY_API_TOKEN',
+  'RAILWAY_TOKEN',
+  // Payments / comms
+  'STRIPE_SECRET_KEY',
+  'STRIPE_API_KEY',
+  'TWILIO_AUTH_TOKEN',
+  'SENDGRID_API_KEY',
+  'MAILGUN_API_KEY',
+  'SLACK_TOKEN',
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  // Databases
+  'DATABASE_URL',
+  'DATABASE_PASSWORD',
+  'PGPASSWORD',
+  'MYSQL_PWD',
+  'MONGODB_URI',
+  'REDIS_URL',
+  // Secret managers
+  'VAULT_TOKEN',
+  'OP_SERVICE_ACCOUNT_TOKEN',
+  'DOPPLER_TOKEN',
+  // Error tracking / CI
+  'SENTRY_AUTH_TOKEN',
+  'CODECOV_TOKEN',
+  'TURBO_TOKEN',
+  'CIRCLE_TOKEN',
+  // Container registries
+  'DOCKERHUB_TOKEN',
+  'DOCKER_PASSWORD',
+])
+
+// AWS access keys are BOTH a headline operator secret AND the auth for a Claude Code
+// "Amazon Bedrock" run. Strip them by default; keep them ONLY when the operator has
+// explicitly enabled that backend (CLAUDE_CODE_USE_BEDROCK is truthy) — the signal a
+// runtime genuinely needs them. AWS_REGION / AWS_DEFAULT_REGION / AWS_PROFILE are config,
+// not secrets, and are never in this set, so a Bedrock run keeps its region either way.
+const AWS_CRED_ENV_KEYS = new Set([
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+])
+
+function isTruthyFlag(v: string | undefined): boolean {
+  if (v === undefined) return false
+  const s = v.trim().toLowerCase()
+  return s !== '' && s !== '0' && s !== 'false'
+}
+
+function isScrubbedSecret(key: string, opts: { keepAwsCreds: boolean }): boolean {
+  const upper = key.toUpperCase()
+  if (CLAWBOO_SECRET_ENV_KEYS.has(upper)) return true
+  if (upper.startsWith('BETTER_AUTH')) return true
+  if (THIRD_PARTY_SECRET_ENV_KEYS.has(upper)) return true
+  if (!opts.keepAwsCreds && AWS_CRED_ENV_KEYS.has(upper)) return true
+  return false
 }
 
 /**
- * Build a child-process env from the server env minus clawboo's own secrets, then
- * merge the caller's explicit grant (provider keys / isolated HOME) on top — so a
- * granted key is restored even if a same-named key was scrubbed.
+ * Build a child-process env from the server env minus clawboo's own server secrets AND a
+ * curated set of the operator's third-party shell secrets, then merge the caller's explicit
+ * grant (provider keys / isolated HOME) on top — so a granted key is always restored even if
+ * a same-named key was scrubbed. Infra config (PATH/HOME/PYTHONUSERBASE/proxy/AWS_REGION) and
+ * the ambient provider-auth the CLIs read (OPENAI_API_KEY / GEMINI_API_KEY / …) are preserved.
  */
 export function buildChildEnv(extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  // Keep AWS creds only when the operator explicitly runs Claude Code against Bedrock.
+  const keepAwsCreds = isTruthyFlag(process.env['CLAUDE_CODE_USE_BEDROCK'])
   const env: NodeJS.ProcessEnv = {}
   for (const [key, value] of Object.entries(process.env)) {
     if (value === undefined) continue
-    if (isClawbooServerSecret(key)) continue
+    if (isScrubbedSecret(key, { keepAwsCreds })) continue
     env[key] = value
   }
   for (const [key, value] of Object.entries(extra)) {

--- a/docs/operating/security.md
+++ b/docs/operating/security.md
@@ -3,15 +3,16 @@ title: Security model and safe exposure
 description: How Clawboo authenticates, isolates secrets, and redacts output, and how to expose the dashboard safely.
 ---
 
-Clawboo is a local-first, single-user tool. A fresh install binds loopback only, holds no public credential, and runs every API route behind that boundary. The security model is built around that default: the network boundary is the primary control, the optional access gate is the opt-in second wall when you widen the bind, the secrets vault keeps provider keys off disk in plaintext, and a display-layer redaction pass keeps credentials out of responses and logs.
+Clawboo is a local-first, single-user tool. A fresh install binds loopback only, holds no public credential, and runs every API route behind that boundary. The security model is built around that default: the network boundary is the primary control against other hosts, an always-on same-origin guard stops a malicious web page in your own browser from reaching the loopback API, the optional access gate is the opt-in second wall when you widen the bind, the secrets vault keeps provider keys off disk in plaintext, and a display-layer redaction pass keeps credentials out of responses and logs.
 
-This page explains the model end to end: the loopback bind, the access gate, server-side device authentication, the encrypted secrets vault, and redact-on-display, and then gives honest guidance for exposing Clawboo beyond `localhost`. It is deliberately candid about what each control does and does not protect against.
+This page explains the model end to end: the loopback bind, the same-origin guard, the access gate, server-side device authentication, the encrypted secrets vault, and redact-on-display, and then gives honest guidance for exposing Clawboo beyond `localhost`. It is deliberately candid about what each control does and does not protect against.
 
 ## What it is, and what it isn't
 
 Clawboo's security posture is **single-tenant, local-first**. The defaults assume one operator on one machine. Every shipped control is designed to make that default safe and to make widening it a conscious, opt-in act:
 
 - **The bind is the first wall.** By default nothing off the local machine can reach the dashboard or any `/api/*` route. This is the control you rely on for a normal install.
+- **The same-origin guard is always on.** Loopback stops other hosts, but not a page running in your own browser, because your browser originates the connection to `127.0.0.1`. The guard validates the `Origin`, `Host`, and `Sec-Fetch-Site` headers on every `/api/*` request and WebSocket upgrade, independent of the access gate, so a malicious page you visit cannot drive the loopback API. It ships enforced with zero configuration.
 - **The access gate is the opt-in second wall.** It is a single shared bearer token, off by default. It exists for the case where you deliberately bind a non-loopback interface.
 - **The vault is defense in depth for provider keys**, not a targeted-attacker boundary. It defeats commodity infostealers and accidental backup/share of the vault file; it does not protect against a process running as you.
 - **Redaction is a display-and-log boundary**, distinct from the storage-layer scrub. It is the last line that keeps a credential out of an API body or a log line.
@@ -27,15 +28,17 @@ flowchart TB
     end
     subgraph local["Local machine (127.0.0.1)"]
         bind["Bind: loopback by default<br/>(widen only via explicit HOST)"]
+        guard["Same-origin guard<br/>(Origin + Host + Sec-Fetch-Site,<br/>always on)"]
         gate["Access gate<br/>(STUDIO_ACCESS_TOKEN, opt-in)"]
         api["/api/* routes"]
         proxy["Gateway proxy<br/>(Ed25519 device auth, server-side)"]
         vault["Secrets vault<br/>(AES-256-GCM)"]
-        runtime["Spawned runtime<br/>(env scrubbed of server secrets)"]
+        runtime["Spawned runtime<br/>(env scrubbed of server<br/>+ operator secrets)"]
     end
 
     rc -. "blocked at the OS<br/>unless HOST set" .-> bind
-    bind --> gate
+    bind --> guard
+    guard -->|"same-origin only<br/>(else 403)"| gate
     gate -->|"valid cookie / token"| api
     gate -->|"loopback /api/mcp/* only"| runtime
     api --> proxy
@@ -44,7 +47,7 @@ flowchart TB
     proxy -->|"signed connect frame"| upstream["Upstream OpenClaw Gateway"]
 ```
 
-The flow is: a request reaches the bind; if the bind is loopback, only local traffic gets that far. If the access gate is enabled, the request must carry a valid token (cookie or one-time query param), except a loopback `/api/mcp/*` request, which is the server's own spawned runtime and is exempt. Past the gate, the gateway proxy signs upstream connect frames with a server-held Ed25519 device key, and the secrets vault resolves provider keys into spawned-runtime env only, never into a response or a log.
+The flow is: a request reaches the bind; if the bind is loopback, only local traffic gets that far. The same-origin guard then checks the `Origin`, `Host`, and `Sec-Fetch-Site` headers and answers any cross-origin `/api/*` request with a `403`, so a malicious page in your browser is turned away before any work. If the access gate is enabled, the request must carry a valid token (cookie or one-time query param), except a loopback `/api/mcp/*` request, which is the server's own spawned runtime and is exempt. Past the gate, the gateway proxy signs upstream connect frames with a server-held Ed25519 device key, and the secrets vault resolves provider keys into spawned-runtime env only, never into a response or a log.
 
 ## The loopback bind (secure by default)
 
@@ -57,6 +60,24 @@ The dashboard binds `127.0.0.1` unless you explicitly set `HOST`. The host resol
 <Warning>
 If you bind a non-loopback interface (`HOST=…`) **and** have not set an access token, the server **refuses to start** — the origin guard is not authentication against a non-browser client (a LAN peer can forge the `Host`/`Origin` headers), so a token-less wide bind would leave the dashboard and every `/api/*` route reachable unauthenticated. Fix one of: set `STUDIO_ACCESS_TOKEN=<random>` to require a token; unset `HOST` to bind loopback only; or set `CLAWBOO_ALLOW_INSECURE=1` to run unauthenticated on purpose (an explicit, greppable choice that logs a loud warning). The default loopback bind never trips this.
 </Warning>
+
+## The same-origin guard (always on)
+
+The loopback bind stops other hosts on your network, but it does not stop code running in your own browser: a web page you visit can still issue a `fetch` to (or open a WebSocket against) `http://127.0.0.1:<port>/api/*`, and because your browser originates the request, it reaches the loopback server. Left unguarded, a malicious page could drive the whole `/api/*` surface (start runtime work that spends provider credits, read your team chat and board), and a Cross-Site WebSocket Hijack could ride the server-injected upstream Gateway token. A loopback bind alone does not close this, and neither does CORS: the same-origin policy does not block the requests that matter here (a no-cors POST is still sent; a hijacked WebSocket still connects).
+
+Clawboo closes it with a same-origin guard that runs on **every** `/api/*` request and WebSocket upgrade, **independent of the access token**, so it protects the default token-less install. It validates three things:
+
+- **`Origin`** against an exact-match allowlist. A browser sets `Origin` on every cross-site WebSocket handshake and state-changing fetch and cannot forge or omit it, so this is the core Cross-Site WebSocket Hijacking (CSWSH) and cross-site-request defense. A foreign origin is answered with a `403`.
+- **`Host`** against a hostname allowlist. This is the DNS-rebinding defense: an attacker who rebinds their own domain to `127.0.0.1` still sends `Host: their-domain`, which is not on the allowlist, so the request is rejected.
+- **`Sec-Fetch-Site`** as defense in depth, covering the cross-site no-cors GET case where a browser omits `Origin`. Only `same-origin`, `same-site`, and `none` are accepted; a `cross-site` value is rejected.
+
+A request that carries neither `Origin` nor `Sec-Fetch-Site` is allowed, because a browser cannot omit both on a cross-site request, while non-browser clients (the CLI, a spawned runtime's loopback MCP attach, an SSE/`EventSource` stream) legitimately do. That is why the loopback `/api/mcp/*` attach and the team-chat streams keep working.
+
+**Posture.** The loopback allowlist (localhost, the `127.0.0.0/8` range, `::1`, plus the actual bind host) is always enforced with zero configuration, so the default `npx clawboo` install is protected out of the box. The environment allowlists only **widen** the set, never disable it: to reach the dashboard from a non-loopback browser origin (a LAN IP or a reverse-proxy hostname), enumerate the origins in `CLAWBOO_ALLOWED_ORIGINS` (and hostnames in `CLAWBOO_ALLOWED_HOSTS`). Because the allowlist can only be widened, a `HOST=0.0.0.0` bind cannot silently re-open the hole while `127.0.0.1` stays reachable.
+
+<Note>
+The same-origin guard is not authentication against a non-browser client on a wide bind: a LAN peer can forge `Host` and `Origin` with a plain HTTP client, which the guard cannot detect. That is why a non-loopback bind still requires `STUDIO_ACCESS_TOKEN` (and the server refuses to start without it). The guard defends against the browser attacker; the token defends against the network peer. They are complementary, not substitutes.
+</Note>
 
 ## The access gate (opt-in)
 
@@ -123,9 +144,18 @@ The vault is **defense in depth, not targeted-attacker-proof.** It defeats commo
 
 ### Secrets never reach spawned runtimes
 
-A spawned runtime (a Codex or Hermes CLI, the Claude Agent SDK child) executes an _untrusted_ agent that can read its own process environment. Clawboo's own server secrets must therefore never be inherited by it. The child-environment builder denylists Clawboo's named server secrets: `GATEWAY_AUTH_TOKEN`, `STUDIO_ACCESS_TOKEN`, `CLAWBOO_SECRETS_MASTER_KEY`, and any `BETTER_AUTH*` key, then merges the caller's explicit provider-key grant on top.
+A spawned runtime (a Codex or Hermes CLI, the Claude Agent SDK child, and the deterministic verify gate) executes an _untrusted_ agent that can read its own process environment with a single `env` dump. The child-environment builder scrubs two families of secrets before the child inherits them, then merges the caller's explicit provider-key grant on top:
 
-This denylist is exactly why the loopback `/api/mcp/*` access-gate exemption exists: the runtime's env has been stripped of `STUDIO_ACCESS_TOKEN`, so it _cannot_ present the gate cookie, and the loopback exemption is the controlled way to let only the server's own runtime through.
+- **Clawboo's own server secrets**, which must never leak: `GATEWAY_AUTH_TOKEN`, `STUDIO_ACCESS_TOKEN`, `CLAWBOO_SECRETS_MASTER_KEY`, and any `BETTER_AUTH*` key.
+- **A curated set of the operator's third-party shell credentials** that no runtime uses for auth: cloud, CI, package-registry, and database tokens such as `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, `STRIPE_SECRET_KEY`, and `DATABASE_URL`. This keeps a prompt-injected task from dumping the credentials you happen to have exported into your shell, including env-only secrets (CI-injected session tokens) that never touch disk and so are reachable no other way.
+
+The scrub is **by exact name, not a broad heuristic**. The provider auth a runtime legitimately reads from the ambient env (`OPENAI_API_KEY` for Codex, a configured provider key for Hermes, `ANTHROPIC_AUTH_TOKEN` for Claude Code) and infra config (`PATH`, `HOME`, `PYTHONUSERBASE`, proxy variables, `AWS_REGION`) are preserved, so tightening the scrub never silently breaks a runtime. AWS access keys are the one conditional case: they are scrubbed by default but kept when you explicitly run Claude Code against Amazon Bedrock (`CLAUDE_CODE_USE_BEDROCK`), the signal that a runtime needs them.
+
+<Warning>
+This is defense in depth, **best-effort by name, not a sandbox.** The agent still runs un-sandboxed and can read on-disk credentials (`~/.aws/credentials`, `~/.config/gh/hosts.yml`, a project `.env`), so treat every task you run as code you are choosing to execute locally. The scrub closes the trivial `env`-dump vector and the env-only secrets; it does not isolate the runtime.
+</Warning>
+
+Scrubbing `STUDIO_ACCESS_TOKEN` is also exactly why the loopback `/api/mcp/*` access-gate exemption exists: the runtime's env has been stripped of the token, so it _cannot_ present the gate cookie, and the loopback exemption is the controlled way to let only the server's own runtime through.
 
 ## Redact-on-display
 
@@ -158,7 +188,7 @@ A non-loopback bind with no access token is the single most dangerous misconfigu
 
 ## Design rationale and trade-offs
 
-The model optimizes for a frictionless single-user local install while keeping a clear, opt-in path to a locked-down exposed one. Loopback-by-default means a fresh install is never accidentally on the network. A single shared token (rather than accounts) keeps the exposed-but-single-user case trivial to set up. Server-side device auth keeps key management out of the browser entirely, so any browser context connects. The vault is a pragmatic "raise the bar against the common threats without pretending to defeat a local attacker" choice, and it says so plainly. Redaction is a cheap, broad backstop layered behind a narrow structural guarantee (secrets only enter child env).
+The model optimizes for a frictionless single-user local install while keeping a clear, opt-in path to a locked-down exposed one. Loopback-by-default means a fresh install is never accidentally on the network, and the always-on same-origin guard means a malicious web page in your own browser cannot reach the loopback API either, so the zero-config install is safe against both the remote host and the drive-by browser attacker. A single shared token (rather than accounts) keeps the exposed-but-single-user case trivial to set up. Server-side device auth keeps key management out of the browser entirely, so any browser context connects. The vault is a pragmatic "raise the bar against the common threats without pretending to defeat a local attacker" choice, and it says so plainly. Redaction is a cheap, broad backstop layered behind a narrow structural guarantee (secrets only enter child env).
 
 The trade-offs are equally plain: there is no multi-user authorization, the token is all-or-nothing, and the vault cannot defend against a process running as you. Each is a conscious scope boundary, not an oversight.
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,6 +30,8 @@ Provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`) 
 | `PORT`                                | Ports & binding    | (none)                           | `resolveApiPort()` (production only)    |
 | `HOST`                                | Ports & binding    | `127.0.0.1`                      | `resolveHost()`                         |
 | `HOSTNAME`                            | Ports & binding    | (ignored)                        | ignored (no longer a bind signal)       |
+| `CLAWBOO_ALLOWED_ORIGINS`             | Ports & binding    | (loopback only)                  | same-origin guard (widen)               |
+| `CLAWBOO_ALLOWED_HOSTS`               | Ports & binding    | (loopback only)                  | same-origin guard (widen)               |
 | `STUDIO_ACCESS_TOKEN`                 | Secrets & auth     | (none)                           | access gate                             |
 | `CLAWBOO_ALLOW_INSECURE`              | Secrets & auth     | (unset)                          | boot guard (wide-bind opt-out)          |
 | `CLAWBOO_SECRETS_MASTER_KEY`          | Secrets & auth     | auto-generated key file          | secrets vault                           |
@@ -150,6 +152,18 @@ A non-loopback bind (`HOST=0.0.0.0`, a LAN IP, or a hostname) WITHOUT `STUDIO_AC
 - **Purpose**: explicit opt-out of the token-less-wide-bind refusal. `CLAWBOO_ALLOW_INSECURE=1` lets the server start on a non-loopback bind with no `STUDIO_ACCESS_TOKEN` (it logs a loud unauthenticated-exposure warning instead of exiting). Only use it behind your own firewall/proxy. Has no effect on a loopback bind or when a token is set.
 - **Default**: unset (a token-less wide bind refuses to start).
 
+### `CLAWBOO_ALLOWED_ORIGINS`
+
+- **Read by**: the always-on same-origin guard (`createOriginGuard`), constructed at server boot in `apps/web/server/index.ts`.
+- **Purpose**: a comma-separated list of extra browser origins to trust on `/api/*` requests and WebSocket upgrades, e.g. `https://dash.example.com`. The guard blocks every cross-origin request by default (the loopback origins are always allowed); this variable **widens** the allowlist, it never disables enforcement. Set it when you reach the dashboard from a non-loopback browser origin (a LAN IP or a reverse-proxy hostname). See [Security](/operating/security#the-same-origin-guard-always-on).
+- **Default**: none (only the loopback origins, plus the Vite dev origin in `--dev`, are trusted).
+
+### `CLAWBOO_ALLOWED_HOSTS`
+
+- **Read by**: the always-on same-origin guard (`createOriginGuard`), constructed at server boot in `apps/web/server/index.ts`.
+- **Purpose**: a comma-separated list of extra hostnames to accept in the HTTP `Host` header (the guard's DNS-rebinding defense). Like `CLAWBOO_ALLOWED_ORIGINS`, it only widens the always-enforced loopback allowlist. Set it when a reverse proxy forwards a public hostname to the dashboard.
+- **Default**: none (only loopback hostnames plus the actual bind host are accepted).
+
 ## Secrets & auth
 
 ### `STUDIO_ACCESS_TOKEN`
@@ -159,7 +173,7 @@ A non-loopback bind (`HOST=0.0.0.0`, a LAN IP, or a hostname) WITHOUT `STUDIO_AC
 - **Default**: none (access gate disabled).
 
 <Danger>
-`STUDIO_ACCESS_TOKEN` is one of the server secrets that are explicitly denylisted from a spawned runtime subprocess's environment, alongside `GATEWAY_AUTH_TOKEN`, `CLAWBOO_SECRETS_MASTER_KEY`, and any `BETTER_AUTH_*` key. Untrusted agents never inherit these.
+`STUDIO_ACCESS_TOKEN` is one of the server secrets explicitly scrubbed from a spawned runtime subprocess's environment, alongside `GATEWAY_AUTH_TOKEN`, `CLAWBOO_SECRETS_MASTER_KEY`, and any `BETTER_AUTH_*` key. The same scrub also drops a curated set of the operator's third-party shell credentials (cloud, CI, package-registry, and database tokens such as `AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, `NPM_TOKEN`, `DATABASE_URL`) so an untrusted agent cannot dump them from its own environment. It is best-effort by name, not a sandbox. See [Secrets never reach spawned runtimes](/operating/security#secrets-never-reach-spawned-runtimes).
 </Danger>
 
 ### `CLAWBOO_SECRETS_MASTER_KEY`

--- a/packages/gateway-client/src/__tests__/autoRetry.test.ts
+++ b/packages/gateway-client/src/__tests__/autoRetry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { resolveGatewayAutoRetryDelayMs } from '../helpers'
+import type { AutoRetryDelayParams } from '../types'
+
+const params = (overrides: Partial<AutoRetryDelayParams> = {}): AutoRetryDelayParams => ({
+  status: 'disconnected',
+  didAutoConnect: true,
+  wasManualDisconnect: false,
+  gatewayUrl: 'ws://localhost:18789',
+  errorMessage: null,
+  connectErrorCode: null,
+  attempt: 0,
+  ...overrides,
+})
+
+describe('resolveGatewayAutoRetryDelayMs', () => {
+  it('schedules a backoff delay for a plain disconnect', () => {
+    expect(resolveGatewayAutoRetryDelayMs(params())).toBe(2_000)
+  })
+
+  it('backs off exponentially and caps the delay', () => {
+    expect(resolveGatewayAutoRetryDelayMs(params({ attempt: 1 }))).toBe(3_000)
+    expect(resolveGatewayAutoRetryDelayMs(params({ attempt: 12 }))).toBe(30_000)
+  })
+
+  it('stops retrying on each fatal proxy configuration code', () => {
+    for (const code of [
+      'clawboo.gateway_url_missing',
+      'clawboo.gateway_url_invalid',
+      'clawboo.settings_load_failed',
+    ]) {
+      expect(resolveGatewayAutoRetryDelayMs(params({ connectErrorCode: code }))).toBeNull()
+    }
+  })
+
+  it('matches fatal codes case-insensitively and ignores padding', () => {
+    expect(
+      resolveGatewayAutoRetryDelayMs(params({ connectErrorCode: ' CLAWBOO.GATEWAY_URL_MISSING ' })),
+    ).toBeNull()
+  })
+
+  it('keeps retrying on an unrecognized error code', () => {
+    expect(
+      resolveGatewayAutoRetryDelayMs(params({ connectErrorCode: 'gateway.unavailable' })),
+    ).toBe(2_000)
+  })
+
+  it('gives up after the attempt cap', () => {
+    expect(resolveGatewayAutoRetryDelayMs(params({ attempt: 20 }))).toBeNull()
+  })
+
+  it('never retries a manual disconnect', () => {
+    expect(resolveGatewayAutoRetryDelayMs(params({ wasManualDisconnect: true }))).toBeNull()
+  })
+})

--- a/packages/gateway-client/src/helpers.ts
+++ b/packages/gateway-client/src/helpers.ts
@@ -187,11 +187,13 @@ const MAX_AUTO_RETRY_ATTEMPTS = 20
 const INITIAL_RETRY_DELAY_MS = 2_000
 const MAX_RETRY_DELAY_MS = 30_000
 
+// The fatal close reasons the clawboo proxy emits for configuration errors a
+// reconnect can never fix (see gateway-proxy's upstream-settings handling) —
+// retrying against these just burns attempts.
 const NON_RETRYABLE_CONNECT_ERROR_CODES = new Set([
-  'studio.gateway_url_missing',
-  'studio.gateway_token_missing',
-  'studio.gateway_url_invalid',
-  'studio.settings_load_failed',
+  'clawboo.gateway_url_missing',
+  'clawboo.gateway_url_invalid',
+  'clawboo.settings_load_failed',
 ])
 
 export const resolveGatewayAutoRetryDelayMs = (params: AutoRetryDelayParams): number | null => {


### PR DESCRIPTION
## Summary

- Expands the security documentation to better explain the overall security model, including the same-origin guard and its role in protecting against browser-based attacks.
- Clarifies the purpose and default behavior of security-related environment variables such as `CLAWBOO_ALLOWED_ORIGINS` and `CLAWBOO_ALLOWED_HOSTS`.
- Adds more complete guidance on secret scrubbing and safely exposing the dashboard beyond loopback interfaces.

## Type

- [ ] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [x] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (not needed — documentation-only change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff