### PR TITLE
chore(ci): implement least-privilege permissions for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default: every CI job only reads the repo (checkout + install +
+# run checks) and never writes to the repo or PR. A job needing more must opt in
+# with its own permissions: block.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -15,6 +15,10 @@ concurrency:
   group: evals
   cancel-in-progress: true
 
+# Least-privilege default: the eval job only reads the repo and runs tests.
+permissions:
+  contents: read
+
 jobs:
   evals:
     name: Orchestration evals + ablation scorecard


### PR DESCRIPTION
## Summary

* Adds explicit permissions to `ci.yml` and `evals.yml` to enforce a least-privilege security model.
* Restricts workflow jobs to read-only repository access unless broader permissions are explicitly required.
* Improves CI security posture by preventing unintended write access in default workflow execution.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [x] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — CI/workflow-only change)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff
