### PR TITLE
fix(graph): update gatewayUrl handling for native mode persistence

### DIFF
--- a/apps/web/server/api/graphLayout.ts
+++ b/apps/web/server/api/graphLayout.ts
@@ -47,7 +47,11 @@ export async function graphLayoutPOST(req: Request, res: Response): Promise<void
   const name = body.name ?? 'default'
   const { positions, gatewayUrl } = body
 
-  if (!gatewayUrl) {
+  // gatewayUrl is the persistence SCOPE key, not a live connection. Native mode
+  // (no Gateway) legitimately keys layouts under '' — the same value the GET
+  // reads back — so accept any string, including empty. Only a missing /
+  // non-string field is rejected.
+  if (typeof gatewayUrl !== 'string') {
     res.status(400).json({ ok: false, error: 'gatewayUrl required' })
     return
   }

--- a/apps/web/src/features/graph/__tests__/useGraphPersistence.test.tsx
+++ b/apps/web/src/features/graph/__tests__/useGraphPersistence.test.tsx
@@ -49,11 +49,11 @@ describe('useGraphPersistence — the graph renders without a Gateway (native mo
   })
 
   it('persists positions under the empty-url scope key (POST fires in native mode)', async () => {
-    let posted: { gatewayUrl?: string } | null = null
+    const posted: Array<{ gatewayUrl?: string }> = []
     server.use(
       http.get('/api/graph-layout', () => HttpResponse.json({ positions: {} })),
       http.post('/api/graph-layout', async ({ request }) => {
-        posted = (await request.json()) as { gatewayUrl?: string }
+        posted.push((await request.json()) as { gatewayUrl?: string })
         return HttpResponse.json({ ok: true })
       }),
     )
@@ -66,7 +66,7 @@ describe('useGraphPersistence — the graph renders without a Gateway (native mo
     })
 
     // Debounced 800ms — waitFor polls until the POST lands.
-    await waitFor(() => expect(posted).not.toBeNull(), { timeout: 2000 })
-    expect(posted?.gatewayUrl).toBe('')
+    await waitFor(() => expect(posted.length).toBeGreaterThan(0), { timeout: 2000 })
+    expect(posted[0]?.gatewayUrl).toBe('')
   })
 })

--- a/apps/web/src/features/graph/__tests__/useGraphPersistence.test.tsx
+++ b/apps/web/src/features/graph/__tests__/useGraphPersistence.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// Regression guard: the Ghost Graph must lay out (and therefore RENDER) without
+// an OpenClaw Gateway. `useGraphPersistence` used to early-return when
+// `!gatewayUrl`, which left `isLoaded` stuck at `false` in native mode — and
+// `GhostGraph` gates its ELK layout on `isLoaded`, so the layout never ran,
+// `hasRunLayout` stayed false, and the graph wrapper sat at `opacity: 0`. Net
+// symptom: the Ghost Graph appeared ONLY once an OpenClaw Gateway was connected
+// (a URL was set) and vanished the moment it disconnected. Native mode has no
+// Gateway, so it keys layouts under the empty ('') url — a valid scope key the
+// server GET/POST both accept.
+
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { server } from '../../../__vitest__/mswServer'
+import { useConnectionStore } from '@/stores/connection'
+import { useTeamStore } from '@/stores/team'
+import { useGraphPersistence } from '../useGraphPersistence'
+
+beforeEach(() => {
+  // Native mode: no Gateway → gatewayUrl is '' (enterNativeMode sets it empty).
+  useConnectionStore.setState({ gatewayUrl: '' })
+  useTeamStore.setState({ selectedTeamId: null })
+})
+
+afterEach(() => {
+  useConnectionStore.setState({ gatewayUrl: null })
+})
+
+describe('useGraphPersistence — the graph renders without a Gateway (native mode)', () => {
+  it('loads (isLoaded → true) instead of skipping when gatewayUrl is empty', async () => {
+    let requestedUrl: string | null = null
+    server.use(
+      http.get('/api/graph-layout', ({ request }) => {
+        requestedUrl = request.url
+        return HttpResponse.json({ positions: {} })
+      }),
+    )
+
+    const { result } = renderHook(() => useGraphPersistence('team'))
+
+    // The load must resolve — without this, GhostGraph never runs ELK.
+    await waitFor(() => expect(result.current.isLoaded).toBe(true))
+    // It did NOT early-return: it fetched under the empty-url scope key.
+    expect(requestedUrl).toContain('/api/graph-layout')
+    expect(requestedUrl).toContain('url=')
+  })
+
+  it('persists positions under the empty-url scope key (POST fires in native mode)', async () => {
+    let posted: { gatewayUrl?: string } | null = null
+    server.use(
+      http.get('/api/graph-layout', () => HttpResponse.json({ positions: {} })),
+      http.post('/api/graph-layout', async ({ request }) => {
+        posted = (await request.json()) as { gatewayUrl?: string }
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const { result } = renderHook(() => useGraphPersistence('team'))
+    await waitFor(() => expect(result.current.isLoaded).toBe(true))
+
+    act(() => {
+      result.current.savePositions({ 'boo-1': { x: 10, y: 20 } })
+    })
+
+    // Debounced 800ms — waitFor polls until the POST lands.
+    await waitFor(() => expect(posted).not.toBeNull(), { timeout: 2000 })
+    expect(posted?.gatewayUrl).toBe('')
+  })
+})

--- a/apps/web/src/features/graph/useGraphPersistence.ts
+++ b/apps/web/src/features/graph/useGraphPersistence.ts
@@ -48,12 +48,27 @@ export function useGraphPersistence(scope: GhostGraphScope = 'team') {
         ? `team-${selectedTeamId}`
         : 'default'
 
-  // Load on mount / when connected gateway, team, or atlasLayout changes
+  // The persistence scope key. In NATIVE mode there is no Gateway, so
+  // `gatewayUrl` is '' (or null before hydration) — a valid key on its own, NOT
+  // a reason to skip loading. The server keys graph layouts by (name, url) and
+  // already treats '' as a real key (GET returns empty positions for it), so we
+  // persist native-mode positions under the empty-url scope.
+  const scopeUrl = gatewayUrl ?? ''
+
+  // Load on mount / when the gateway URL, team, or atlasLayout changes.
+  //
+  // Load-bearing: this does NOT gate on `gatewayUrl` being truthy. It used to
+  // early-return when `!gatewayUrl`, which left `isLoaded` stuck at `false`
+  // forever in native mode (no Gateway) — and `GhostGraph`'s ELK layout effect
+  // is gated on `isLoaded`, so the layout never ran, `hasRunLayout` stayed
+  // false, and the graph wrapper sat at `opacity: 0`. Net effect: the Ghost
+  // Graph only appeared once an OpenClaw Gateway was connected (a URL was set)
+  // and vanished the moment it disconnected. The graph is fleet + capability
+  // driven (all REST / SQLite-backed) and must render without OpenClaw.
   useEffect(() => {
-    if (!gatewayUrl) return
     setIsLoaded(false) // Reset on team / mode switch — wait for fresh positions
 
-    const url = `/api/graph-layout?name=${encodeURIComponent(layoutName)}&url=${encodeURIComponent(gatewayUrl)}`
+    const url = `/api/graph-layout?name=${encodeURIComponent(layoutName)}&url=${encodeURIComponent(scopeUrl)}`
     void fetch(url)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: LayoutData | null) => {
@@ -71,24 +86,26 @@ export function useGraphPersistence(scope: GhostGraphScope = 'team') {
         setSavedPositions({})
         setIsLoaded(true)
       })
-  }, [gatewayUrl, selectedTeamId, layoutName, setSavedPositions])
+  }, [scopeUrl, selectedTeamId, layoutName, setSavedPositions])
 
-  // Debounced save (called on node drag stop)
+  // Debounced save (called on node drag stop). Persists under the same scope
+  // key as the load (`scopeUrl`), so native-mode ('' url) drag positions survive
+  // a reload just like Gateway-mode ones. The server POST accepts the empty-url
+  // key (matching the GET).
   const savePositions = useCallback(
     (positions: LayoutData['positions']) => {
-      if (!gatewayUrl) return
       if (saveTimer.current) clearTimeout(saveTimer.current)
       saveTimer.current = setTimeout(() => {
         void fetch('/api/graph-layout', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: layoutName, positions, gatewayUrl }),
+          body: JSON.stringify({ name: layoutName, positions, gatewayUrl: scopeUrl }),
         }).catch(() => {
           // Non-fatal
         })
       }, 800)
     },
-    [gatewayUrl, layoutName],
+    [scopeUrl, layoutName],
   )
 
   return { savePositions, isLoaded }


### PR DESCRIPTION
## Summary

* Fixes native-mode graph layout persistence by allowing `gatewayUrl` to be stored and validated as any string, including an empty value.
* Updates graph position loading and saving logic so persistence works correctly even when native mode does not use a truthy `gatewayUrl`.
* Clarifies comments around `gatewayUrl` handling and its role as a persistence key for graph layouts.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff
