### PR TITLE
chore(docs): update installation guidance and onboarding docs for Clawboo v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@
 
 ## Quickstart
 
+Install Clawboo, then run it:
+
 ```bash
-npx clawboo
+npm install -g clawboo
+clawboo
 ```
+
+The global install gives you a persistent `clawboo` command and one-click in-app updates. Just trying it out? `npx clawboo` runs the latest with no install.
 
 Node.js 22+ is the only prerequisite. The first run opens an onboarding wizard:
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -287,6 +287,9 @@ async function run(): Promise<void> {
         env: {
           ...process.env,
           NODE_ENV: 'production',
+          // The running clawboo version, so the server's self-version check
+          // ("update available" chip) knows what it is without a disk read.
+          CLAWBOO_VERSION: VERSION,
           // Where the bundled MCP stdio bins live (dist/bin next to server.js), so
           // the server's /api/mcp/config emits the right `node <bin>` attach snippet.
           CLAWBOO_MCP_BIN_DIR: path.join(__dirname, 'bin'),
@@ -298,7 +301,7 @@ async function run(): Promise<void> {
     } else {
       const child = spawn('npx', ['tsx', devServerPath!], {
         cwd: monorepoRoot!,
-        env: { ...process.env, NODE_ENV: 'production' },
+        env: { ...process.env, NODE_ENV: 'production', CLAWBOO_VERSION: VERSION },
         detached: true,
         stdio: 'ignore',
       })

--- a/apps/web/server/api/index.ts
+++ b/apps/web/server/api/index.ts
@@ -20,6 +20,7 @@ import {
   systemModelsGET,
   approveDevicePOST,
 } from './system'
+import { selfVersionGET, selfUpdatePOST } from './systemUpdate'
 import {
   teamsGET,
   teamsPOST,
@@ -182,6 +183,11 @@ router.get('/api/system/openclaw-config', openclawConfigGET)
 router.patch('/api/system/openclaw-config', openclawConfigPATCH)
 router.get('/api/system/models', systemModelsGET)
 router.post('/api/system/approve-device', approveDevicePOST)
+// Self-update ("update available" chip): version check + SSE apply. The check
+// probes the npm registry server-side (cached, fail-silent); the apply installs
+// clawboo@latest and restarts into it (global installs only).
+router.get('/api/system/self-version', selfVersionGET)
+router.post('/api/system/self-update', selfUpdatePOST)
 
 // Teams
 router.get('/api/teams', teamsGET)

--- a/apps/web/server/api/systemUpdate.ts
+++ b/apps/web/server/api/systemUpdate.ts
@@ -1,0 +1,158 @@
+/**
+ * apps/web/server/api/systemUpdate.ts
+ *
+ * Self-update surface for the "update available" chip:
+ *   - GET  /api/system/self-version  → current vs latest + install method
+ *   - POST /api/system/self-update   → SSE: npm install -g clawboo@latest, then
+ *                                       restart into the new version.
+ *
+ * The POST only proceeds for a `global` install (the running dist/server.js is
+ * replaced in place). npx / dev installs get an `unsupported` event and the
+ * copy-command fallback — the chip hides its "Update now" button in those cases
+ * anyway, so this is defense-in-depth.
+ */
+import { spawn } from 'node:child_process'
+import type { Request, Response } from 'express'
+
+import { isWindows, resolveShimName } from '../lib/platform'
+import {
+  buildUpdateCommand,
+  computeSelfVersion,
+  detectInstallMethod,
+  readVersionFromDisk,
+} from '../lib/updateCheck'
+import { restartIntoLatest } from '../lib/selfRestart'
+
+function sendEvent(res: Response, data: Record<string, unknown>): void {
+  res.write(`data: ${JSON.stringify(data)}\n\n`)
+}
+
+export async function selfVersionGET(_req: Request, res: Response): Promise<void> {
+  const info = await computeSelfVersion()
+  res.json(info)
+}
+
+export async function selfUpdatePOST(req: Request, res: Response): Promise<void> {
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  res.flushHeaders()
+
+  const method = detectInstallMethod()
+  if (method !== 'global') {
+    sendEvent(res, {
+      type: 'unsupported',
+      method,
+      command: buildUpdateCommand(method),
+      message:
+        method === 'npx'
+          ? 'This is an npx run (ephemeral). Install globally to enable in-app updates: npm install -g clawboo@latest'
+          : 'In-app update is only available for a global install.',
+    })
+    res.end()
+    return
+  }
+
+  const versionBefore = readVersionFromDisk()
+  sendEvent(res, {
+    type: 'progress',
+    step: 'installing',
+    message: 'Installing the latest Clawboo…',
+  })
+
+  // Mirrors installOpenclawPOST's Windows-safe launch: resolveShimName('npm')
+  // (npm.cmd on Windows), shell:isWindows (CVE-2024-27980 guard), windowsHide.
+  // Fixed literal args, no user input — no injection surface.
+  let child
+  try {
+    child = spawn(resolveShimName('npm'), ['install', '-g', 'clawboo@latest'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: isWindows,
+      windowsHide: isWindows,
+    })
+  } catch (err) {
+    sendEvent(res, {
+      type: 'error',
+      code: 'SPAWN_THROW',
+      message: err instanceof Error ? err.message : String(err),
+    })
+    res.end()
+    return
+  }
+
+  child.stdout?.on('data', (chunk: Buffer) => {
+    for (const line of chunk.toString().split('\n').filter(Boolean)) {
+      sendEvent(res, { type: 'output', line })
+    }
+  })
+
+  child.stderr?.on('data', (chunk: Buffer) => {
+    const text = chunk.toString()
+    if (text.includes('EACCES') || text.toLowerCase().includes('permission denied')) {
+      sendEvent(res, {
+        type: 'error',
+        code: 'EACCES',
+        message:
+          'Permission denied. A global install needs elevated permissions. Try: sudo npm install -g clawboo@latest',
+      })
+    }
+    for (const line of text.split('\n').filter(Boolean)) {
+      sendEvent(res, { type: 'output', line })
+    }
+  })
+
+  child.on('error', (err) => {
+    sendEvent(res, { type: 'error', code: 'SPAWN_ERROR', message: String(err) })
+    res.end()
+  })
+
+  child.on('close', (code) => {
+    if (code !== 0) {
+      sendEvent(res, {
+        type: 'error',
+        code: `EXIT_${code}`,
+        message: `Update failed with exit code ${code}. Try running it manually: npm install -g clawboo@latest`,
+      })
+      res.end()
+      return
+    }
+
+    // Confirm the in-place package actually changed before restarting into it.
+    // If the global install landed somewhere this running copy doesn't point at
+    // (a local checkout mis-detected as global), restarting would re-run stale
+    // bytes — so surface a manual-restart note instead of a broken hot-swap.
+    const versionAfter = readVersionFromDisk()
+    const restartSafe = versionAfter != null && versionAfter !== versionBefore
+    if (!restartSafe) {
+      sendEvent(res, {
+        type: 'installed-elsewhere',
+        version: versionAfter,
+        message: 'Update installed. Restart Clawboo to use it: clawboo',
+      })
+      res.end()
+      return
+    }
+
+    const port = Number(req.app.locals['apiPort']) || Number(process.env['CLAWBOO_API_PORT']) || 0
+    if (!port) {
+      sendEvent(res, {
+        type: 'installed-elsewhere',
+        version: versionAfter,
+        message: 'Update installed. Restart Clawboo to use it: clawboo',
+      })
+      res.end()
+      return
+    }
+
+    sendEvent(res, { type: 'installed', version: versionAfter })
+    sendEvent(res, { type: 'restarting', port, version: versionAfter })
+    res.end()
+    // Launch the successor on the same port and exit so it can bind. The browser
+    // is already polling /api/settings and reloads once the successor answers.
+    restartIntoLatest(port)
+  })
+
+  res.on('close', () => {
+    if (!child.killed) child.kill()
+  })
+}

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -18,7 +18,12 @@ import { startApprovalReaper } from './lib/approvalReaper'
 import { ensureNativeBooZero } from './lib/teamChat/booZero'
 import { startRoutinesTicker } from './lib/routines/ticker'
 import { getRegistry } from './lib/agentSource'
-import { resolveApiPort, writeApiPortFile, removeApiPortFile } from './lib/portUtils'
+import {
+  resolveApiPort,
+  writeApiPortFile,
+  removeApiPortFile,
+  waitForPortFree,
+} from './lib/portUtils'
 import { resolveHost, isLoopbackHost, shouldRefuseInsecureBind } from './lib/resolveHost'
 import { runBootProbe } from './lib/bootProbe'
 
@@ -59,6 +64,17 @@ const parseCsvEnv = (raw: string | undefined): string[] =>
 async function main() {
   const dev = process.argv.includes('--dev')
   const hostname = resolveHost()
+
+  // If we were launched as a self-restart successor by an in-app update, the
+  // exiting parent still holds the API port for a brief moment. Wait for it to
+  // free before resolveApiPort — which throws on an explicit-but-taken
+  // CLAWBOO_API_PORT — so the successor rebinds the SAME port the browser is
+  // already pointed at. A missing/invalid value is a no-op (the common path).
+  const awaitPortRaw = Number(process.env['CLAWBOO_AWAIT_PORT'])
+  if (Number.isInteger(awaitPortRaw) && awaitPortRaw > 0 && awaitPortRaw <= 65535) {
+    log.info({ port: awaitPortRaw }, 'Self-restart: waiting for the previous port to free')
+    await waitForPortFree(awaitPortRaw, 15_000)
+  }
 
   // Pick the API port up front. In dev mode the orchestrator script picks
   // a port first and exports it as `CLAWBOO_API_PORT` so the Vite proxy

--- a/apps/web/server/lib/__tests__/updateCheck.test.ts
+++ b/apps/web/server/lib/__tests__/updateCheck.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  buildUpdateCommand,
+  computeSelfVersion,
+  detectInstallMethod,
+  fetchLatestClawbooVersion,
+  invalidateLatestCache,
+  semverGt,
+} from '../updateCheck'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  invalidateLatestCache()
+  delete process.env['CLAWBOO_VERSION']
+})
+
+describe('semverGt', () => {
+  it('compares major.minor.patch', () => {
+    expect(semverGt('0.4.0', '0.3.0')).toBe(true)
+    expect(semverGt('1.0.0', '0.9.9')).toBe(true)
+    expect(semverGt('0.3.1', '0.3.0')).toBe(true)
+    expect(semverGt('0.3.0', '0.3.0')).toBe(false)
+    expect(semverGt('0.3.0', '0.4.0')).toBe(false)
+  })
+
+  it('treats a release as greater than a prerelease of the same core', () => {
+    expect(semverGt('0.3.0', '0.3.0-beta.1')).toBe(true)
+    expect(semverGt('0.3.0-beta.1', '0.3.0')).toBe(false)
+  })
+
+  it('tolerates a leading v and returns false on unparseable input', () => {
+    expect(semverGt('v0.4.0', '0.3.0')).toBe(true)
+    expect(semverGt('nonsense', '0.3.0')).toBe(false)
+    expect(semverGt('0.4.0', 'nonsense')).toBe(false)
+  })
+})
+
+describe('buildUpdateCommand', () => {
+  it('uses npx for an npx install, npm -g otherwise', () => {
+    expect(buildUpdateCommand('npx')).toBe('npx clawboo@latest')
+    expect(buildUpdateCommand('global')).toBe('npm install -g clawboo@latest')
+    expect(buildUpdateCommand('dev')).toBe('npm install -g clawboo@latest')
+  })
+})
+
+describe('detectInstallMethod', () => {
+  const orig = process.argv[1]
+  afterEach(() => {
+    process.argv[1] = orig
+  })
+
+  it('global for a bundled dist/server.js entry', () => {
+    process.argv[1] = '/usr/local/lib/node_modules/clawboo/dist/server.js'
+    expect(detectInstallMethod()).toBe('global')
+  })
+
+  it('npx for an _npx cache entry', () => {
+    process.argv[1] = '/home/u/.npm/_npx/abc123/node_modules/clawboo/dist/server.js'
+    expect(detectInstallMethod()).toBe('npx')
+  })
+
+  it('dev for a tsx source entry', () => {
+    process.argv[1] = '/repo/apps/web/server/index.ts'
+    expect(detectInstallMethod()).toBe('dev')
+  })
+})
+
+describe('fetchLatestClawbooVersion', () => {
+  it('returns null and never throws when the registry is unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline')
+      }),
+    )
+    await expect(fetchLatestClawbooVersion()).resolves.toBeNull()
+  })
+
+  it('caches a successful read (one network call for two lookups)', async () => {
+    const f = vi.fn(async () => ({ ok: true, json: async () => ({ version: '0.9.0' }) }))
+    vi.stubGlobal('fetch', f)
+    expect(await fetchLatestClawbooVersion()).toBe('0.9.0')
+    expect(await fetchLatestClawbooVersion()).toBe('0.9.0')
+    expect(f).toHaveBeenCalledTimes(1)
+  })
+
+  it('serves the cached value when a later probe fails', async () => {
+    const ok = vi.fn(async () => ({ ok: true, json: async () => ({ version: '0.9.0' }) }))
+    vi.stubGlobal('fetch', ok)
+    // Prime the cache, then force a re-fetch by expiring it and failing the call.
+    expect(await fetchLatestClawbooVersion(0)).toBe('0.9.0')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('registry down')
+      }),
+    )
+    // A far-future "now" expires the 6h TTL → re-fetch → fails → last cache wins.
+    expect(await fetchLatestClawbooVersion(1e13)).toBe('0.9.0')
+  })
+})
+
+describe('computeSelfVersion', () => {
+  it('flags updateAvailable when latest > current', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '9.9.9' }) })),
+    )
+    process.env['CLAWBOO_VERSION'] = '0.3.0'
+    const info = await computeSelfVersion()
+    expect(info.current).toBe('0.3.0')
+    expect(info.latest).toBe('9.9.9')
+    expect(info.updateAvailable).toBe(true)
+    expect(info.updateCommand).toContain('clawboo@latest')
+  })
+
+  it('flags a PATCH release as an update (0.3.0 → 0.3.1)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '0.3.1' }) })),
+    )
+    process.env['CLAWBOO_VERSION'] = '0.3.0'
+    const info = await computeSelfVersion()
+    expect(info.latest).toBe('0.3.1')
+    expect(info.updateAvailable).toBe(true)
+  })
+
+  it('never nags a dev version', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '9.9.9' }) })),
+    )
+    process.env['CLAWBOO_VERSION'] = '0.0.0-dev'
+    const info = await computeSelfVersion()
+    expect(info.updateAvailable).toBe(false)
+  })
+
+  it('offline: latest null, updateAvailable false (silent no-op)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline')
+      }),
+    )
+    process.env['CLAWBOO_VERSION'] = '0.3.0'
+    const info = await computeSelfVersion()
+    expect(info.latest).toBeNull()
+    expect(info.updateAvailable).toBe(false)
+  })
+
+  it('marks a 0.1.x current as deprecated', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, json: async () => ({ version: '0.3.0' }) })),
+    )
+    process.env['CLAWBOO_VERSION'] = '0.1.5'
+    const info = await computeSelfVersion()
+    expect(info.isDeprecated).toBe(true)
+    expect(info.updateAvailable).toBe(true)
+  })
+})

--- a/apps/web/server/lib/portUtils.ts
+++ b/apps/web/server/lib/portUtils.ts
@@ -178,6 +178,29 @@ export function readApiPortFile(): number | null {
   }
 }
 
+/**
+ * Poll until `port` is free (nothing bound on it), up to `timeoutMs`. Used by a
+ * self-restart successor (in-app update): the exiting parent still holds the
+ * port for a brief window, so the fresh process waits for the parent to release
+ * it before binding — otherwise `resolveApiPort` throws on an explicit-but-taken
+ * `CLAWBOO_API_PORT`. Returns true once free, false on timeout (caller proceeds
+ * and lets the bind surface the real error). `isPortFree` probes on `0.0.0.0`,
+ * which conflicts with any specific-interface bind on the same port, so a parent
+ * bound on loopback is correctly seen as "still taken" here.
+ */
+export async function waitForPortFree(
+  port: number,
+  timeoutMs: number,
+  intervalMs = 250,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    if (await isPortFree(port)) return true
+    if (Date.now() >= deadline) return false
+    await new Promise((r) => setTimeout(r, intervalMs))
+  }
+}
+
 /** Resolve home dir reliably even when env is sandboxed. */
 export function resolveHomeDir(): string {
   return os.homedir()

--- a/apps/web/server/lib/selfRestart.ts
+++ b/apps/web/server/lib/selfRestart.ts
@@ -1,0 +1,74 @@
+/**
+ * apps/web/server/lib/selfRestart.ts
+ *
+ * The restart-into-the-new-version primitive for an in-app update. After a
+ * successful global `npm install -g clawboo@latest`, the NEW bytes are on disk
+ * but the running process is still the OLD `dist/server.js` loaded in memory —
+ * a process cannot swap its own code. So we launch a successor and exit:
+ *
+ *   1. Start a fresh `node <this server entry>` DETACHED (survives our exit),
+ *      pinned to the same API port and told to WAIT for that port to free
+ *      (CLAWBOO_AWAIT_PORT — honored in server/index.ts before it binds).
+ *   2. Exit so the OS frees the port; the waiting successor then binds it and
+ *      rewrites api-port.txt.
+ *   3. The browser (already polling /api/settings on the same origin) reloads
+ *      once the successor answers, landing on the freshly-installed UI.
+ *
+ * CLAWBOO_VERSION is deliberately DROPPED from the successor's env so it reads
+ * its (now-updated) version from the on-disk package.json instead of the stale
+ * value the CLI injected at first launch.
+ *
+ * Only ever called for a `global` install (detectInstallMethod), where the
+ * running entry path was replaced in place — so restarting into it runs new code.
+ */
+import { spawn } from 'node:child_process'
+
+const FLUSH_DELAY_MS = 400
+
+export interface SelfRestartDeps {
+  log?: { info: (...a: unknown[]) => void; error: (...a: unknown[]) => void }
+  /** Test seam: override the process exit (defaults to process.exit). */
+  exit?: (code: number) => void
+}
+
+/**
+ * Launch a successor server on `port` and exit so it can take over the port.
+ * Best-effort: if the launch fails we still exit (the user re-runs `clawboo`).
+ */
+export function restartIntoLatest(port: number, deps: SelfRestartDeps = {}): void {
+  const entry = process.argv[1]
+  const doExit = deps.exit ?? ((code: number) => process.exit(code))
+  if (!entry) {
+    // No resolvable entry to relaunch — leave the current process running so the
+    // user isn't dropped; they can restart manually to pick up the update.
+    deps.log?.error('self-restart: no process entry to relaunch')
+    return
+  }
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLAWBOO_API_PORT: String(port),
+    CLAWBOO_AWAIT_PORT: String(port),
+  }
+  // Force the successor to recompute its version from the freshly-installed
+  // package.json (the inherited env var is the pre-update version).
+  delete env['CLAWBOO_VERSION']
+
+  try {
+    const child = spawn(process.execPath, [entry], {
+      detached: true,
+      stdio: 'ignore',
+      env,
+    })
+    child.unref()
+    deps.log?.info(`self-restart: launched successor pid=${child.pid ?? '?'} on port ${port}`)
+  } catch (err) {
+    deps.log?.error('self-restart: failed to launch successor', err)
+    // Fall through to exit anyway — a lingering old process is worse than a
+    // clean stop the user can relaunch.
+  }
+
+  // Give the SSE 'restarting' frame time to reach the browser, then exit so the
+  // port frees and the waiting successor can bind it.
+  setTimeout(() => doExit(0), FLUSH_DELAY_MS)
+}

--- a/apps/web/server/lib/updateCheck.ts
+++ b/apps/web/server/lib/updateCheck.ts
@@ -1,0 +1,214 @@
+/**
+ * apps/web/server/lib/updateCheck.ts
+ *
+ * Self-version awareness: what version of `clawboo` is running, what the
+ * latest published version is, and whether an in-app update is even possible.
+ *
+ * WHY THE SERVER OWNS THIS (not a browser fetch to the registry):
+ *   - Centralizes the registry probe + its cache in one place (mirrors
+ *     `openclawDetect.ts` / `providerModels.ts`), so multiple browser tabs
+ *     share one outbound call.
+ *   - Avoids any registry-CORS dependency from the SPA.
+ *   - The browser only ever sees a same-origin `/api/system/self-version`.
+ *
+ * FAIL-SILENT is a hard requirement (network posture): clawboo is a local-first
+ * tool. When the registry is unreachable (offline, air-gapped, firewalled) the
+ * probe returns null and `updateAvailable` is false — never an error, never a nag.
+ *
+ * This module is pure version/HTTP logic — no process control. The restart
+ * primitive that an in-app update needs lives in `selfRestart.ts`.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+// ─── Current (running) version ────────────────────────────────────────────────
+
+/**
+ * Candidate paths for the shipped `clawboo` package.json. In the bundled server,
+ * `dist/server.js` runs with its dir one level under the package root, so
+ * `<dir>/../package.json` is the clawboo manifest (npm always ships package.json
+ * in the tarball). We try the running entry's dir first (robust for a global
+ * install replaced in place), then `__dirname`.
+ */
+function packageJsonCandidates(): string[] {
+  const out: string[] = []
+  const entry = process.argv[1]
+  if (entry) out.push(path.join(path.dirname(entry), '..', 'package.json'))
+  // In the bundled server, `__dirname` is the dist dir (same place server.js
+  // lives), so `../package.json` is the package root — identical to the entry
+  // path above. In dev (tsx) this resolves to apps/web/package.json, whose
+  // `name` is `@clawboo/web` (not `clawboo`), so the name guard below skips it.
+  out.push(path.join(__dirname, '..', 'package.json'))
+  return out
+}
+
+/**
+ * Read the `clawboo` package version straight from disk. Prefers the shipped
+ * manifest so it is always FRESH after a self-update (an env var injected at
+ * first launch would be stale in the restarted successor). The `name` guard
+ * ensures we never mistake apps/web/package.json (0.0.0) for the release.
+ */
+export function readVersionFromDisk(): string | null {
+  for (const p of packageJsonCandidates()) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(p, 'utf8')) as { name?: string; version?: string }
+      if (pkg.name === 'clawboo' && typeof pkg.version === 'string' && pkg.version.trim()) {
+        return pkg.version.trim()
+      }
+    } catch {
+      // not found / unparsable — try the next candidate
+    }
+  }
+  return null
+}
+
+/**
+ * The running clawboo version. `CLAWBOO_VERSION` (injected by the CLI at launch)
+ * is the fast path; the on-disk manifest is the fallback AND the source of truth
+ * after a self-update (the successor is started WITHOUT the stale env var so it
+ * recomputes from the freshly-installed package.json).
+ */
+export function getCurrentVersion(): string {
+  const fromEnv = (process.env['CLAWBOO_VERSION'] ?? '').trim()
+  if (fromEnv) return fromEnv
+  return readVersionFromDisk() ?? '0.0.0-dev'
+}
+
+// ─── Install method (drives whether in-app apply is possible) ──────────────────
+
+export type InstallMethod = 'global' | 'npx' | 'dev'
+
+/**
+ * How this server was launched — determines whether an in-app `npm install -g`
+ * + self-restart can actually pick up the new bytes:
+ *   - `global`: `npm install -g clawboo` → `dist/server.js` is replaced in place
+ *     at the same path, so restarting into `process.argv[1]` runs the NEW code. ✅
+ *   - `npx`: the entry lives in npm's version-hashed `_npx` cache; a global
+ *     install lands elsewhere and the running process can't reach it. ✗
+ *   - `dev`: running the TS source via tsx — never self-update a checkout. ✗
+ */
+export function detectInstallMethod(): InstallMethod {
+  const entry = (process.argv[1] ?? __filename).replace(/\\/g, '/')
+  if (entry.includes('/_npx/')) return 'npx'
+  // The bundled server always runs from `.../dist/server.js`. Anything else
+  // (e.g. `apps/web/server/index.ts` under tsx) is a dev checkout.
+  if (!/\/dist\/server\.js$/.test(entry)) return 'dev'
+  return 'global'
+}
+
+/** The exact command a user runs to update, tailored to their install shape. */
+export function buildUpdateCommand(method: InstallMethod): string {
+  return method === 'npx' ? 'npx clawboo@latest' : 'npm install -g clawboo@latest'
+}
+
+// ─── Latest published version (npm registry probe) ─────────────────────────────
+
+const REGISTRY_LATEST_URL = 'https://registry.npmjs.org/clawboo/latest'
+const FETCH_TIMEOUT_MS = 5_000
+// The registry value changes over time (unlike a local binary version), so it
+// carries a real TTL. 6h keeps outbound calls rare for a long-lived dashboard
+// while still surfacing a fresh release within a working day.
+const LATEST_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+
+let latestCache: { version: string; fetchedAt: number } | null = null
+
+/**
+ * Probe the npm registry for the latest published `clawboo` version. Cached
+ * (~6h), timeout-bounded, and NEVER throws — a failure returns the last cached
+ * value (or null), so an offline/air-gapped install is a silent no-op. Modeled
+ * on `openclawDetect.ts` (cache successes, never cache/propagate a failure).
+ */
+export async function fetchLatestClawbooVersion(now: number = Date.now()): Promise<string | null> {
+  if (latestCache && now - latestCache.fetchedAt < LATEST_CACHE_TTL_MS) {
+    return latestCache.version
+  }
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    const res = await fetch(REGISTRY_LATEST_URL, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json', 'User-Agent': 'clawboo-update-check' },
+    })
+    clearTimeout(timer)
+    if (!res.ok) return latestCache?.version ?? null
+    const body = (await res.json()) as { version?: unknown }
+    if (typeof body.version !== 'string' || !body.version.trim()) {
+      return latestCache?.version ?? null
+    }
+    latestCache = { version: body.version.trim(), fetchedAt: now }
+    return latestCache.version
+  } catch {
+    // offline / registry down / firewalled — fail silent, keep any cache
+    return latestCache?.version ?? null
+  }
+}
+
+/** Drop the latest-version cache (tests + a forced re-check). */
+export function invalidateLatestCache(): void {
+  latestCache = null
+}
+
+// ─── Semver compare (release-focused) ─────────────────────────────────────────
+
+function parseSemver(v: string): { core: [number, number, number]; pre: string } | null {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(v.trim())
+  if (!m) return null
+  return { core: [Number(m[1]), Number(m[2]), Number(m[3])], pre: m[4] ?? '' }
+}
+
+/**
+ * `a > b`? Compares major.minor.patch, then treats a release (`1.0.0`) as
+ * greater than a prerelease of the same core (`1.0.0-beta`). Coarse prerelease
+ * ordering is fine — the update target (`dist-tags.latest`) is always a release.
+ */
+export function semverGt(a: string, b: string): boolean {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return false
+  for (let i = 0; i < 3; i++) {
+    if (pa.core[i] !== pb.core[i]) return pa.core[i] > pb.core[i]
+  }
+  if (pa.pre === pb.pre) return false
+  if (pa.pre === '') return true // a is a release, b is a prerelease of the same core
+  if (pb.pre === '') return false // b is the release → a (prerelease) is lower
+  return pa.pre > pb.pre
+}
+
+// ─── Assembled endpoint payload ───────────────────────────────────────────────
+
+export interface SelfVersionInfo {
+  /** The running clawboo version (e.g. "0.3.0"), or "0.0.0-dev" in a checkout. */
+  current: string
+  /** Latest published version, or null when the registry is unreachable. */
+  latest: string | null
+  /** True only for a real (non-dev) current with a strictly-greater latest. */
+  updateAvailable: boolean
+  /** The exact command for THIS install shape (npm -g / npx). */
+  updateCommand: string
+  installMethod: InstallMethod
+  /** Whether an in-app apply (`POST /api/system/self-update`) can succeed. */
+  applyable: boolean
+  /** The current version is on the npm-deprecated 0.1.x line. */
+  isDeprecated: boolean
+  /** When `latest` was last fetched (ms), or null if never/unreachable. */
+  checkedAt: number | null
+}
+
+export async function computeSelfVersion(): Promise<SelfVersionInfo> {
+  const current = getCurrentVersion()
+  const latest = await fetchLatestClawbooVersion()
+  const method = detectInstallMethod()
+  // A dev checkout reads as "0.0.0*"; never nag a developer about updates.
+  const isRealVersion = !current.startsWith('0.0.0')
+  const updateAvailable = isRealVersion && latest != null && semverGt(latest, current)
+  return {
+    current,
+    latest,
+    updateAvailable,
+    updateCommand: buildUpdateCommand(method),
+    installMethod: method,
+    applyable: method === 'global',
+    isDeprecated: /^0\.1\./.test(current),
+    checkedAt: latestCache?.fetchedAt ?? null,
+  }
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import { TeamSidebar } from '@/features/layout/TeamSidebar'
 import { AgentListColumn } from '@/features/layout/AgentListColumn'
 import { ContentArea } from '@/features/layout/ContentArea'
 import { FirstRunNudge } from '@/features/fleet/FirstRunNudge'
+import { UpdateChip } from '@/features/promo/UpdateChip'
 import { AppTopBar } from '@/features/promo/AppTopBar'
 import { SettingsModal } from '@/features/settings/SettingsModal'
 import { ConfirmDialog } from '@/features/shared/ConfirmDialog'
@@ -53,6 +54,9 @@ export function App() {
         </main>
       </div>
       {onDashboard && <FirstRunNudge />}
+      {/* Bottom-left "update available" chip — appears when a newer clawboo
+          version is published; click to copy the update command or apply it. */}
+      {onDashboard && <UpdateChip />}
       <SettingsModal />
       {/* App-root confirmation dialog (design-system replacement for
           window.confirm). Outside the inert app-shell + above the settings

--- a/apps/web/src/features/promo/UpdateChip.tsx
+++ b/apps/web/src/features/promo/UpdateChip.tsx
@@ -1,0 +1,272 @@
+// UpdateChip — a subtle, dismissible "update available" chip pinned bottom-left
+// (like Claude Code's). Appears when a newer `clawboo` version is published.
+//
+// The chip IS the action (no popover, no second click):
+//   - Global npm install (applyable): one click installs clawboo@latest, restarts
+//     the server into it, and reloads the page. The chip reads "Click to update".
+//   - npx / dev (can't self-update in place): one click copies the exact command
+//     (`npx clawboo@latest`) instead, since the running process can't hot-swap.
+// A small × dismisses it (keyed to the latest version, so a newer release brings
+// it back). The check always targets npm's single `latest`, so accumulated
+// releases collapse to just the newest version, never a list.
+//
+// Visual: MINT accent dot ("new / available", non-alarming); the version and CTA
+// are the calm muted subtext colour.
+
+import { useCallback, useRef, useState } from 'react'
+import { motion } from 'framer-motion'
+import { AlertCircle, Check, Copy, X } from 'lucide-react'
+import { consumeApiSSE, type SSEEvent } from '@clawboo/control-client'
+
+import { Spinner } from '@/features/shared/Spinner'
+import { useUpdateCheck } from './useUpdateCheck'
+
+const muted = (o: number) => `rgb(var(--foreground-rgb) / ${o})`
+
+type Phase = 'idle' | 'applying' | 'restarting' | 'manual' | 'error'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+/**
+ * After the server signals it's restarting, poll same-origin /api/settings until
+ * the successor answers, then hard-reload onto the freshly-installed UI. Gives up
+ * after ~90s and surfaces a manual note.
+ */
+async function pollThenReload(onTimeout: () => void): Promise<void> {
+  const deadline = Date.now() + 90_000
+  while (Date.now() < deadline) {
+    await sleep(1000)
+    try {
+      const res = await fetch('/api/settings', { cache: 'no-store' })
+      if (res.ok) {
+        const body = (await res.json()) as { gatewayUrl?: unknown }
+        if (typeof body.gatewayUrl === 'string') {
+          window.location.reload()
+          return
+        }
+      }
+    } catch {
+      /* server still restarting — keep polling */
+    }
+  }
+  onTimeout()
+}
+
+export function UpdateChip() {
+  const { info, shouldShow, dismiss } = useUpdateCheck()
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [statusText, setStatusText] = useState('')
+  const [copied, setCopied] = useState(false)
+
+  // phaseRef lets the SSE error handler tell a real failure from the expected
+  // stream-drop when the server exits to restart.
+  const phaseRef = useRef<Phase>('idle')
+  phaseRef.current = phase
+
+  const copyCommand = useCallback(async () => {
+    if (!info) return
+    try {
+      await navigator.clipboard.writeText(info.updateCommand)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1600)
+    } catch {
+      /* clipboard blocked — nothing else to do here */
+    }
+  }, [info])
+
+  const startUpdate = useCallback(() => {
+    setPhase('applying')
+    setStatusText('')
+    consumeApiSSE(
+      '/api/system/self-update',
+      { method: 'POST' },
+      {
+        onError: (e: SSEEvent) => {
+          // The stream drops when the server exits to restart — expected, not a
+          // failure. Ignore errors once we're past 'installed'.
+          if (phaseRef.current === 'restarting') return
+          setStatusText(e.message ?? 'Update failed.')
+          setPhase('error')
+        },
+        onEvent: (e: SSEEvent) => {
+          switch (e.type) {
+            case 'restarting':
+              setPhase('restarting')
+              void pollThenReload(() => {
+                setStatusText('Update installed. Restart Clawboo to finish.')
+                setPhase('manual')
+              })
+              break
+            case 'unsupported':
+            case 'installed-elsewhere':
+              setStatusText(
+                typeof e.message === 'string'
+                  ? e.message
+                  : 'Update installed. Restart Clawboo to finish.',
+              )
+              setPhase('manual')
+              break
+            default:
+              break
+          }
+        },
+      },
+    )
+  }, [])
+
+  // One click = the whole action. Global install → update in place; otherwise
+  // copy the command (the running npx/dev process can't hot-swap itself).
+  const handlePrimary = useCallback(() => {
+    if (!info) return
+    if (info.applyable) startUpdate()
+    else void copyCommand()
+  }, [info, startUpdate, copyCommand])
+
+  if (!shouldShow || !info) return null
+
+  const busy = phase === 'applying' || phase === 'restarting'
+
+  return (
+    <motion.div
+      data-testid="update-chip"
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 26 }}
+      style={{
+        position: 'fixed',
+        bottom: 16,
+        left: 72,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'stretch',
+        borderRadius: 8,
+        border: '1px solid var(--border)',
+        background: 'var(--surface)',
+        overflow: 'hidden',
+      }}
+    >
+      {busy ? (
+        <div
+          className="flex items-center gap-2 px-2.5 py-1.5 text-[12.5px]"
+          style={{ color: 'var(--foreground)' }}
+        >
+          <span style={{ color: 'var(--mint)', display: 'flex' }}>
+            <Spinner size={14} />
+          </span>
+          {phase === 'restarting' ? 'Restarting…' : 'Installing update…'}
+        </div>
+      ) : phase === 'manual' || phase === 'error' ? (
+        <div className="flex items-center gap-2 px-2.5 py-1.5">
+          <AlertCircle
+            size={14}
+            style={{ color: phase === 'error' ? 'var(--primary)' : muted(0.5), flexShrink: 0 }}
+          />
+          <span
+            className="text-[11.5px]"
+            style={{ color: phase === 'error' ? 'var(--primary)' : muted(0.7), maxWidth: 190 }}
+          >
+            {statusText || (phase === 'error' ? 'Update failed.' : 'Update installed.')}
+          </span>
+          <button
+            type="button"
+            aria-label="Copy update command"
+            data-testid="update-chip-copy"
+            onClick={() => void copyCommand()}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: copied ? 'var(--mint)' : muted(0.55),
+              cursor: 'pointer',
+              display: 'flex',
+              padding: 2,
+            }}
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+          </button>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            data-testid="update-chip-dismiss"
+            onClick={dismiss}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              color: muted(0.4),
+              cursor: 'pointer',
+              display: 'flex',
+              padding: 2,
+            }}
+          >
+            <X size={13} />
+          </button>
+        </div>
+      ) : (
+        <>
+          <button
+            type="button"
+            data-testid="update-chip-action"
+            onClick={handlePrimary}
+            title={
+              info.applyable
+                ? `Update to v${info.latest} and restart`
+                : `Copy: ${info.updateCommand}`
+            }
+            className="group flex items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-foreground/[0.03]"
+            style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: 'var(--mint)',
+                flexShrink: 0,
+                animation: 'clawboo-status-pulse 2s ease-in-out infinite',
+              }}
+            />
+            <span className="flex flex-col leading-tight">
+              <span className="text-[12.5px] font-semibold text-foreground">Update available</span>
+              <span
+                data-testid="update-chip-version"
+                className="mt-0.5 text-[10.5px]"
+                style={{ fontFamily: 'var(--font-mono)', color: muted(0.55) }}
+              >
+                v{info.latest}
+                {' · '}
+                {info.applyable ? (
+                  <span style={{ color: muted(0.8), fontWeight: 500 }}>Click to update →</span>
+                ) : copied ? (
+                  <span style={{ color: 'var(--mint)', fontWeight: 500 }}>Copied ✓</span>
+                ) : (
+                  <span style={{ color: muted(0.8), fontWeight: 500 }}>Copy command</span>
+                )}
+              </span>
+            </span>
+          </button>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            data-testid="update-chip-dismiss"
+            onClick={dismiss}
+            className="transition-colors hover:bg-foreground/[0.06]"
+            style={{
+              border: 'none',
+              borderLeft: '1px solid var(--border)',
+              background: 'transparent',
+              color: muted(0.4),
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              padding: '0 7px',
+            }}
+          >
+            <X size={13} />
+          </button>
+        </>
+      )}
+    </motion.div>
+  )
+}

--- a/apps/web/src/features/promo/__tests__/UpdateChip.test.tsx
+++ b/apps/web/src/features/promo/__tests__/UpdateChip.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SelfVersionInfo, UseUpdateCheck } from '../useUpdateCheck'
+
+// Mock the hook so the chip is driven by fixed props — no network / msw needed.
+const hookState = vi.fn()
+vi.mock('../useUpdateCheck', () => ({ useUpdateCheck: (): UseUpdateCheck => hookState() }))
+
+// Mock the SSE client so clicking "Update now" doesn't hit a real endpoint.
+const consumeApiSSE = vi.fn()
+vi.mock('@clawboo/control-client', () => ({
+  consumeApiSSE: (...args: unknown[]) => consumeApiSSE(...args),
+}))
+
+import { UpdateChip } from '../UpdateChip'
+
+const writeText = vi.fn().mockResolvedValue(undefined)
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function info(over: Partial<SelfVersionInfo> = {}): SelfVersionInfo {
+  return {
+    current: '0.3.0',
+    latest: '0.4.0',
+    updateAvailable: true,
+    updateCommand: 'npm install -g clawboo@latest',
+    installMethod: 'global',
+    applyable: true,
+    isDeprecated: false,
+    checkedAt: 1,
+    ...over,
+  }
+}
+
+function setHook(over: Partial<UseUpdateCheck> = {}): { dismiss: ReturnType<typeof vi.fn> } {
+  const dismiss = vi.fn()
+  hookState.mockReturnValue({ info: info(), shouldShow: true, dismiss, recheck: vi.fn(), ...over })
+  return { dismiss }
+}
+
+describe('UpdateChip', () => {
+  it('renders the pill with the label + target-only version + click-to-update CTA (global)', () => {
+    setHook()
+    render(<UpdateChip />)
+    expect(screen.getByTestId('update-chip')).toBeInTheDocument()
+    expect(screen.getByText('Update available')).toBeInTheDocument()
+    const ver = screen.getByTestId('update-chip-version')
+    expect(ver).toHaveTextContent('v0.4.0')
+    expect(ver).toHaveTextContent(/click to update/i)
+    // only the target version — never the current one
+    expect(ver).not.toHaveTextContent('0.3.0')
+  })
+
+  it('renders nothing when shouldShow is false', () => {
+    setHook({ shouldShow: false })
+    const { container } = render(<UpdateChip />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows ONLY the newest version (accumulated releases collapse to latest)', () => {
+    // Behind several releases → the endpoint returns npm's single `latest`.
+    hookState.mockReturnValue({
+      info: info({ latest: '0.9.0' }),
+      shouldShow: true,
+      dismiss: vi.fn(),
+      recheck: vi.fn(),
+    })
+    render(<UpdateChip />)
+    const ver = screen.getByTestId('update-chip-version')
+    expect(ver).toHaveTextContent('v0.9.0')
+    expect(ver).not.toHaveTextContent('0.3.0')
+  })
+
+  it('one click on a global install starts the in-app update (no popover)', async () => {
+    const user = userEvent.setup()
+    setHook()
+    render(<UpdateChip />)
+    await user.click(screen.getByTestId('update-chip-action'))
+    // Fires the SSE apply directly — no intermediate confirm/popover.
+    expect(consumeApiSSE).toHaveBeenCalledWith(
+      '/api/system/self-update',
+      { method: 'POST' },
+      expect.anything(),
+    )
+    // The chip flips to an inline progress state.
+    expect(screen.getByText(/installing update/i)).toBeInTheDocument()
+  })
+
+  it('one click on an npx install copies the command instead of self-updating', async () => {
+    hookState.mockReturnValue({
+      info: info({ installMethod: 'npx', applyable: false, updateCommand: 'npx clawboo@latest' }),
+      shouldShow: true,
+      dismiss: vi.fn(),
+      recheck: vi.fn(),
+    })
+    render(<UpdateChip />)
+    // npx path shows "Copy command", not "Click to update".
+    expect(screen.getByTestId('update-chip-version')).toHaveTextContent(/copy command/i)
+    fireEvent.click(screen.getByTestId('update-chip-action'))
+    expect(writeText).toHaveBeenCalledWith('npx clawboo@latest')
+    expect(consumeApiSSE).not.toHaveBeenCalled()
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+  })
+
+  it('the × dismisses via the hook', async () => {
+    const user = userEvent.setup()
+    const { dismiss } = setHook()
+    render(<UpdateChip />)
+    await user.click(screen.getByTestId('update-chip-dismiss'))
+    expect(dismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/features/promo/useUpdateCheck.ts
+++ b/apps/web/src/features/promo/useUpdateCheck.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// useUpdateCheck — polls the server's self-version endpoint and decides whether
+// to surface the "update available" chip. Mirrors GitHubStarButton's
+// fetch+localStorage-cache+focus-refetch pattern so multiple mounts share one
+// call and rapid tab-switching doesn't spam the endpoint.
+//
+// The endpoint itself does the registry probe server-side (cached ~6h,
+// fail-silent), so the client cache here is just to avoid a fetch on every
+// mount. Dismiss is keyed to the LATEST version, so a dismissed chip reappears
+// only when a newer version ships.
+
+export interface SelfVersionInfo {
+  current: string
+  latest: string | null
+  updateAvailable: boolean
+  updateCommand: string
+  installMethod: 'global' | 'npx' | 'dev'
+  applyable: boolean
+  isDeprecated: boolean
+  checkedAt: number | null
+}
+
+const ENDPOINT = '/api/system/self-version'
+const CACHE_KEY = 'clawboo.updateCheck'
+const DISMISS_KEY = 'clawboo.updateDismissedVersion'
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1h client cache (server caches the registry ~6h)
+
+interface CachedInfo {
+  info: SelfVersionInfo
+  fetchedAt: number
+}
+
+function readCache(): SelfVersionInfo | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as CachedInfo
+    if (!parsed || typeof parsed.fetchedAt !== 'number') return null
+    if (Date.now() - parsed.fetchedAt > CACHE_TTL_MS) return null
+    if (typeof parsed.info?.current !== 'string') return null
+    return parsed.info
+  } catch {
+    return null
+  }
+}
+
+function writeCache(info: SelfVersionInfo): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify({ info, fetchedAt: Date.now() }))
+  } catch {
+    /* localStorage unavailable — fall through */
+  }
+}
+
+function readDismissed(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage.getItem(DISMISS_KEY)
+  } catch {
+    return null
+  }
+}
+
+function writeDismissed(version: string | null): void {
+  if (typeof window === 'undefined') return
+  try {
+    if (version) window.localStorage.setItem(DISMISS_KEY, version)
+    else window.localStorage.removeItem(DISMISS_KEY)
+  } catch {
+    /* best-effort */
+  }
+}
+
+export interface UseUpdateCheck {
+  info: SelfVersionInfo | null
+  /** True when an update is available AND not dismissed for this latest version. */
+  shouldShow: boolean
+  dismiss: () => void
+  recheck: () => void
+}
+
+export function useUpdateCheck(): UseUpdateCheck {
+  const [info, setInfo] = useState<SelfVersionInfo | null>(() => readCache())
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(() => readDismissed())
+  // Prevents mount + focus + recheck from racing into concurrent fetches.
+  const inflight = useRef(false)
+
+  const fetchInfo = useCallback(async (force = false) => {
+    if (inflight.current) return
+    if (!force && readCache()) return
+    inflight.current = true
+    try {
+      const res = await fetch(ENDPOINT, { cache: 'no-store' })
+      if (!res.ok) return
+      const data = (await res.json()) as SelfVersionInfo
+      if (typeof data.current !== 'string') return
+      setInfo(data)
+      writeCache(data)
+    } catch {
+      /* offline / endpoint absent — keep whatever we have, never nag */
+    } finally {
+      inflight.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchInfo()
+  }, [fetchInfo])
+
+  // Refetch when the tab regains focus — catches "a new version shipped while I
+  // was away". Cache-gated, so quick tab-switching doesn't hit the endpoint.
+  useEffect(() => {
+    const onFocus = () => {
+      void fetchInfo()
+    }
+    const onVisibilityChange = () => {
+      if (!document.hidden) void fetchInfo()
+    }
+    window.addEventListener('focus', onFocus)
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      window.removeEventListener('focus', onFocus)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [fetchInfo])
+
+  const dismiss = useCallback(() => {
+    const v = info?.latest ?? null
+    setDismissedVersion(v)
+    writeDismissed(v)
+  }, [info])
+
+  const recheck = useCallback(() => {
+    void fetchInfo(true)
+  }, [fetchInfo])
+
+  const shouldShow = Boolean(
+    info?.updateAvailable && info.latest && info.latest !== dismissedVersion,
+  )
+
+  return { info, shouldShow, dismiss, recheck }
+}

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -3,7 +3,7 @@ title: Getting started
 description: 'The two install paths: native-first (paste a key, no Gateway) or the OpenClaw Gateway, plus prerequisites.'
 ---
 
-Clawboo runs the same way for everyone: one command, `npx clawboo`, which launches a local dashboard and walks you through a first-run wizard. Onboarding is **native-first**: you paste one provider key and land in a working team, with no runtime to pick up front. The OpenClaw Gateway and the coding-agent runtimes are **opt-in**, connected during the optional Add-runtimes step or later from Settings. This page explains the fast native path and the OpenClaw path so you can choose which quickstart to follow.
+Clawboo runs the same way for everyone. Install it with `npm install -g clawboo` and run `clawboo` (or `npx clawboo` to try it without installing), which launches a local dashboard and walks you through a first-run wizard. Onboarding is **native-first**: you paste one provider key and land in a working team, with no runtime to pick up front. The OpenClaw Gateway and the coding-agent runtimes are **opt-in**, connected during the optional Add-runtimes step or later from Settings. This page explains the fast native path and the OpenClaw path so you can choose which quickstart to follow.
 
 <Note>
 These docs describe Clawboo **v0.3.0**, the current release.
@@ -14,7 +14,7 @@ These docs describe Clawboo **v0.3.0**, the current release.
 <Note>
 - **Node.js 22 or newer**: Clawboo's `engines` field requires `node >=22.0.0`. The OpenClaw path also enforces this: the wizard's detection step flags Node older than 22.
 - **A provider API key** if you choose the native path: Anthropic (`sk-ant-…`), OpenAI (`sk-…`), or OpenRouter (`sk-or-…`). A running local Ollama works with no key, and a **ChatGPT subscription** works with no key too (the OpenAI card's Sign in with ChatGPT connects the [Codex runtime](/runtimes/codex)). The OpenClaw path needs a provider key too, entered during Gateway configuration.
-- Nothing is installed globally to *run* Clawboo; `npx clawboo` downloads and launches the bundled dashboard server. (The OpenClaw path can install the `openclaw` CLI for you from inside the wizard.)
+- A global install (`npm i -g clawboo`) is recommended for a persistent `clawboo` command and one-click updates, but not required; `npx clawboo` downloads and launches the bundled dashboard server without one. (The OpenClaw path can install the `openclaw` CLI for you from inside the wizard.)
 </Note>
 
 That is the full list. You do not need OpenClaw, a Gateway, Docker, or any database; Clawboo bundles its own SQLite store and dashboard server.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Install Clawboo
-description: Run npx clawboo to launch the dashboard. Prerequisites, what the launcher does, port discovery, and where Clawboo keeps its state.
+description: Install Clawboo with npm i -g clawboo or npx clawboo, launch the dashboard, and see the launch sequence, port discovery, and where Clawboo keeps its state.
 ---
 
 By the end of this tutorial you'll have the Clawboo dashboard running locally and open in your browser, ready for the onboarding wizard. Installation is a single command; there is nothing to configure first.
@@ -14,7 +14,7 @@ These docs describe Clawboo **v0.3.0**, the current release.
 <Note>
 - **Node.js 22 or newer.** Clawboo's `engines` field requires `node >=22.0.0`. `npx` ships with Node, so if you have a recent Node you already have everything you need.
 - **A terminal and a web browser.** The launcher opens your default browser automatically.
-- **No global install, no OpenClaw, no provider key required to launch.** You pick a runtime and (optionally) paste a provider key *inside* the onboarding wizard, not before it.
+- **No OpenClaw and no provider key required to launch.** You pick a runtime and (optionally) paste a provider key *inside* the onboarding wizard, not before it. A global install (`npm i -g clawboo`) is recommended for a persistent `clawboo` command and one-click updates, but `npx clawboo` works too.
 </Note>
 
 Check your Node version:
@@ -27,13 +27,16 @@ If it prints `v22.x` or higher, you're set. If not, install a current Node from 
 
 ## Steps
 
-### 1. Run the launcher
+### 1. Install and run
+
+Install Clawboo globally, then run it:
 
 ```bash
-npx clawboo
+npm install -g clawboo
+clawboo
 ```
 
-`npx` downloads the `clawboo` package (currently `0.3.0`) on first run and executes its CLI entry point. There is no separate "install" step and nothing is added to your global `node_modules`; `npx` caches the package and runs it.
+The global install gives you a persistent `clawboo` command and one-click in-app updates from the dashboard. Prefer not to install? `npx clawboo` downloads and runs the latest package (currently `0.3.0`) without adding anything to your global `node_modules`.
 
 **Expected result:** the terminal prints the Clawboo ASCII logo and a version line like `Clawboo v0.3.0`, then begins starting the dashboard.
 

--- a/docs/getting-started/quickstart-native.md
+++ b/docs/getting-started/quickstart-native.md
@@ -1,6 +1,6 @@
 ---
 title: 'Quickstart: the native runtime (no Gateway)'
-description: Run npx clawboo, connect the built-in native runtime with a provider key, pick and deploy a starter team, and land in it with no OpenClaw Gateway.
+description: Install Clawboo, connect the built-in native runtime with a provider key, pick and deploy a starter team, and land in it with no OpenClaw Gateway.
 ---
 
 By the end of this tutorial you'll have a working team, picked from Clawboo's built-in marketplace and running entirely inside Clawboo, with no OpenClaw Gateway, started from a single pasted provider API key.
@@ -16,20 +16,21 @@ These docs describe Clawboo **v0.3.0**, the current release.
 <Note>
 - **Node.js 22 or newer**: Clawboo's `engines` field requires `node >=22.0.0`.
 - **A provider API key** for one of: Anthropic (`sk-ant-…`), OpenAI (`sk-…`), or OpenRouter (`sk-or-…`). Or a running local Ollama, in which case no key is needed.
-- No OpenClaw, no Gateway, no global install required.
+- No OpenClaw or Gateway required.
 </Note>
 
 ## Steps
 
-### 1. Launch Clawboo
+### 1. Install and launch Clawboo
 
-Run the launcher:
+Install Clawboo globally, then run it:
 
 ```bash
-npx clawboo
+npm install -g clawboo
+clawboo
 ```
 
-The CLI prints the Clawboo logo, does a quick informational probe of the OpenClaw Gateway port (`localhost:18789`), starts the bundled dashboard server, then opens your browser at the discovered URL.
+The global install gives you a persistent `clawboo` command and one-click in-app updates; prefer not to install? `npx clawboo` runs the latest instead. Either way, the CLI prints the Clawboo logo, does a quick informational probe of the OpenClaw Gateway port (`localhost:18789`), starts the bundled dashboard server, then opens your browser at the discovered URL.
 
 **Expected result:** your terminal shows `Dashboard started` and `Clawboo opened at http://localhost:18790` (or the next free port in the `18790–18809` range), and the dashboard loads in your browser. Because this is a fresh machine, the onboarding wizard appears.
 

--- a/docs/getting-started/quickstart-openclaw.md
+++ b/docs/getting-started/quickstart-openclaw.md
@@ -1,6 +1,6 @@
 ---
 title: 'Quickstart: the OpenClaw Gateway'
-description: Run npx clawboo, connect the native runtime, then add OpenClaw by detecting, installing, and configuring it, starting the Gateway, and approving the device.
+description: Install Clawboo, connect the native runtime, then add OpenClaw by detecting, installing, and configuring it, starting the Gateway, and approving the device.
 ---
 
 By the end of this tutorial you'll have a running OpenClaw Gateway connected to Clawboo, set up from the onboarding wizard's **Add more runtimes** step. Onboarding is native-first, so you connect the native runtime first, then add OpenClaw through its setup detour: detect your environment, install OpenClaw if needed, configure a model provider, start the Gateway, and approve the one-time device pairing. Once OpenClaw is connected you deploy an OpenClaw team from the dashboard.
@@ -24,15 +24,16 @@ OpenClaw is a separate project; Clawboo connects to a Gateway you run locally, i
 
 ## Steps
 
-### 1. Launch Clawboo
+### 1. Install and launch Clawboo
 
-Run the launcher:
+Install Clawboo globally, then run it:
 
 ```bash
-npx clawboo
+npm install -g clawboo
+clawboo
 ```
 
-The CLI prints the Clawboo logo, does a quick informational probe of the OpenClaw Gateway port (`localhost:18789`), starts the bundled dashboard server, then opens your browser at the discovered URL.
+Prefer not to install? `npx clawboo` runs the latest instead. Either way, the CLI prints the Clawboo logo, does a quick informational probe of the OpenClaw Gateway port (`localhost:18789`), starts the bundled dashboard server, then opens your browser at the discovered URL.
 
 **Expected result:** your terminal shows `Dashboard started` and `Clawboo opened at http://localhost:18790` (or the next free port in the `18790–18809` range), and the dashboard loads. Because this is a fresh machine, the onboarding wizard appears.
 

--- a/packages/evals/vitest.config.ts
+++ b/packages/evals/vitest.config.ts
@@ -5,5 +5,12 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     environment: 'node',
     globals: true,
+    // These suites are deterministic + network-free but genuinely slow: each
+    // trial spins up a fresh temp-SQLite board with full DDL bootstrap (the
+    // smoke suite runs 7 tasks x 3 trials; the ablation runs 4 flag configs).
+    // Locally that lands ~5-8s; a slower CI runner pushes past vitest's 5s
+    // default and times out. Match the apps/web node-project headroom (30s).
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
   },
 })

--- a/website/src/components/InstallCommand.astro
+++ b/website/src/components/InstallCommand.astro
@@ -1,5 +1,5 @@
 ---
-/** Glass install-command pill: `$ npx clawboo` + copy button. */
+/** Glass install-command pill: `$ npm install -g clawboo` + copy button. */
 import Icon from './Icon.astro'
 import { site } from '../lib/site'
 interface Props {

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -34,7 +34,7 @@ import { nav, links, site } from '../lib/site'
     <div class="ml-auto hidden items-center gap-2.5 md:flex">
       <ThemeToggle />
       <GitHubStars variant="pill" />
-      <Button href="#how" variant="primary" size="md" icon="terminal" class="font-data">npx clawboo</Button>
+      <Button href="#how" variant="primary" size="md" icon="terminal" class="font-data">npm i -g clawboo</Button>
     </div>
 
     <!-- Mobile cluster -->
@@ -74,7 +74,7 @@ import { nav, links, site } from '../lib/site'
     </div>
     <div class="mt-4 flex flex-col gap-2.5">
       <GitHubStars variant="pill" class="w-full justify-center" />
-      <Button href="#how" variant="primary" size="lg" icon="terminal" class="w-full font-data" data-sheet-link>npx clawboo</Button>
+      <Button href="#how" variant="primary" size="lg" icon="terminal" class="w-full font-data" data-sheet-link>npm i -g clawboo</Button>
     </div>
     <p class="font-data mt-4 text-center text-[11px] text-secondary">{site.tagline}</p>
   </div>

--- a/website/src/lib/site.ts
+++ b/website/src/lib/site.ts
@@ -1,6 +1,6 @@
 /**
  * Central site config: canonical URLs, nav, and shared copy constants.
- * Copy law: no em dashes; claims match the shipped v0.2.1 surface only.
+ * Copy law: no em dashes; claims match the shipped v0.3.0 surface only.
  */
 
 export const REPO = 'clawboo/clawboo'
@@ -23,13 +23,14 @@ export const site = {
   wordmark: 'clawboo',
   url: 'https://www.claw.boo',
   domain: 'www.claw.boo',
-  install: 'npx clawboo',
-  version: 'v0.2.1',
+  install: 'npm install -g clawboo',
+  tryInstall: 'npx clawboo',
+  version: 'v0.3.0',
   tagline: 'A TypeScript orchestrator for heterogeneous AI agent runtimes.',
   subhead:
     'Deploy a team of agents and watch them collaborate live. Native agents are built in: paste one key and go. Claude Code, Codex, Hermes, and OpenClaw join as peer teammates in one chat, sharing one board, one memory, and one capability dashboard.',
   description:
-    'Deploy a team of AI agents and watch them collaborate live. Native agents are built in, and Claude Code, Codex, Hermes, and OpenClaw join as peer teammates in one chat. Open-source, MIT, local-first. Run npx clawboo.',
+    'Deploy a team of AI agents and watch them collaborate live. Native agents are built in, and Claude Code, Codex, Hermes, and OpenClaw join as peer teammates in one chat. Open-source, MIT, local-first. Install with npm i -g clawboo, or try npx clawboo.',
 } as const
 
 export const nav = [

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -7,7 +7,7 @@ import { booAvatarToDataUrl } from '../lib/boo-avatar'
 
 const boo = booAvatarToDataUrl({ seed: 'lost-boo', isBooZero: true })
 ---
-<BaseLayout title="Page not found · Clawboo" description="That page drifted off. Head back home or run npx clawboo.">
+<BaseLayout title="Page not found · Clawboo" description="That page drifted off. Head back home or install Clawboo with npm i -g clawboo.">
   <section class="relative flex min-h-[100svh] flex-col items-center justify-center overflow-hidden px-5 text-center bg-[#8fb9ee] dark:bg-[#070d1e]">
     <SignatureSky boos={5} />
     <div class="relative z-10 flex flex-col items-center">
@@ -19,7 +19,7 @@ const boo = booAvatarToDataUrl({ seed: 'lost-boo', isBooZero: true })
       </p>
       <div class="mt-7 flex flex-col items-center gap-4">
         <Button href="/" variant="primary" size="lg" iconRight="arrow-right">Back home</Button>
-        <InstallCommand onSky />
+        <InstallCommand caption="Or try npx clawboo, no install." onSky />
       </div>
     </div>
   </section>

--- a/website/src/sections/Faq.astro
+++ b/website/src/sections/Faq.astro
@@ -22,7 +22,7 @@ const faqs = [
   },
   {
     q: 'Is it production-ready?',
-    a: 'Treat it as an early, working release. The current version is v0.2.1: a real studio you can run today, not a sealed 1.0. Core surfaces are covered by end-to-end tests, and releases ship as features land.',
+    a: 'Treat it as an early, working release. The current version is v0.3.0: a real studio you can run today, not a sealed 1.0. Core surfaces are covered by end-to-end tests, and releases ship as features land.',
   },
   {
     q: 'How is this different from just using one coding agent?',
@@ -30,7 +30,7 @@ const faqs = [
   },
   {
     q: 'Can I add my own agents, skills, and teams?',
-    a: 'Yes. v0.2.1 ships 304 first-class agents across 15 domains and 82 workflow teams, browsable in a 3-tab marketplace for Skills, Agents, and Teams. You compose teams from these and connect the runtimes you want behind them.',
+    a: 'Yes. v0.3.0 ships 304 first-class agents across 15 domains and 82 workflow teams, browsable in a 3-tab marketplace for Skills, Agents, and Teams. You compose teams from these and connect the runtimes you want behind them.',
   },
   {
     q: 'How does Clawboo control cost?',

--- a/website/src/sections/FinalCta.astro
+++ b/website/src/sections/FinalCta.astro
@@ -18,7 +18,7 @@ import { links } from '../lib/site'
     </p>
 
     <div class="mt-8">
-      <InstallCommand onSky />
+      <InstallCommand caption="Or try npx clawboo, no install." onSky />
     </div>
 
     <div class="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">

--- a/website/src/sections/Hero.astro
+++ b/website/src/sections/Hero.astro
@@ -7,7 +7,7 @@ import Button from '../components/Button.astro'
 import Icon from '../components/Icon.astro'
 import { site, links } from '../lib/site'
 
-const trust = ['npm v0.2.1', 'MIT licensed', 'TypeScript strict', 'Node.js 22+']
+const trust = ['npm v0.3.0', 'MIT licensed', 'TypeScript strict', 'Node.js 22+']
 ---
 <section
   id="hero"
@@ -36,7 +36,7 @@ const trust = ['npm v0.2.1', 'MIT licensed', 'TypeScript strict', 'Node.js 22+']
     </p>
 
     <div class="mt-8">
-      <InstallCommand caption="Node.js 22+. No flags, no cloud account." onSky />
+      <InstallCommand caption="Node.js 22+. Or try npx clawboo, no install." onSky />
     </div>
 
     <div class="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">

--- a/website/src/sections/HowItWorks.astro
+++ b/website/src/sections/HowItWorks.astro
@@ -8,7 +8,7 @@ const steps = [
   {
     num: '01',
     title: 'Install and run',
-    body: 'Run npx clawboo. Node.js 22+ is the only prerequisite. The first run opens an onboarding wizard.',
+    body: 'Install with npm install -g clawboo, then run clawboo. Node.js 22+ is the only prerequisite, and the first run opens an onboarding wizard. Or try it instantly with npx clawboo, no install.',
     copy: true,
   },
   {
@@ -46,8 +46,8 @@ const steps = [
               {s.copy && (
                 <div class="mt-3">
                   <CopyButton
-                    text="npx clawboo"
-                    label="npx clawboo"
+                    text="npm install -g clawboo"
+                    label="npm install -g clawboo"
                     class="font-data rounded-lg bg-foreground/[0.06] px-3 py-1.5 text-[12.5px] text-foreground/80 hover:bg-foreground/[0.1]"
                   />
                 </div>

--- a/website/src/sections/Surface.astro
+++ b/website/src/sections/Surface.astro
@@ -16,13 +16,13 @@ const stats = [
   <div class="absolute inset-0 -z-10" style="background:radial-gradient(100% 60% at 50% 100%, rgb(var(--mint-rgb) / 0.05), transparent 55%)"></div>
   <div class="mx-auto max-w-7xl px-5 sm:px-8">
     <Reveal class="mx-auto max-w-3xl text-center">
-      <Kicker text="Shipped in v0.2.1" color="var(--mint)" />
+      <Kicker text="Shipped in v0.3.0" color="var(--mint)" />
       <h2 class="font-display mt-4 text-[28px] font-extrabold leading-tight text-foreground sm:text-[40px]">
         Not a demo. A working studio you can run today.
       </h2>
       <p class="mt-4 text-[16px] leading-relaxed text-secondary">
         This is what ships in the current release. Clawboo is brand new and moves fast, so treat it as
-        an early, working v0.2.1, not a sealed 1.0.
+        an early, working v0.3.0, not a sealed 1.0.
       </p>
     </Reveal>
 


### PR DESCRIPTION
## Summary

* Updates installation documentation to recommend `npm install -g clawboo` instead of `npx clawboo`, with clearer guidance on persistent command access and easier updates.
* Improves quickstart and onboarding documentation to better explain prerequisites, the native-first setup flow, and the option to try Clawboo without installation.
* Refreshes FAQs and related docs for `v0.3.0` so version references, onboarding language, and installation guidance are more consistent and easier to follow.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [x] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — documentation-only change)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff
