### PR TITLE
feat(server): checkpoint SQLite WAL on graceful shutdown

### DIFF
--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -419,8 +419,21 @@ async function main() {
   // stale entries don't mislead the CLI on the next launch. We don't rely
   // on this for correctness (the file is just a hint — the CLI probes the
   // port before opening the browser).
+  //
+  // We also checkpoint the SQLite WAL so a naive single-file copy of
+  // `clawboo.db` captures all recent committed writes without the WAL
+  // sidecars. This is defense-in-depth only — the WAL is crash-safe and
+  // recovered on the next open — so a checkpoint failure is logged and
+  // never blocks shutdown or changes the exit code.
   const cleanup = () => {
     removeApiPortFile()
+    try {
+      const db = createDb(getDbPath())
+      db.$client.pragma('wal_checkpoint(TRUNCATE)')
+      db.$client.close()
+    } catch (err) {
+      log.warn({ err }, 'WAL checkpoint on shutdown failed (non-fatal)')
+    }
   }
   process.once('SIGINT', () => {
     cleanup()


### PR DESCRIPTION
## Summary

- On `SIGINT`/`SIGTERM`/`exit`, run `PRAGMA wal_checkpoint(TRUNCATE)` against the Clawboo DB before the process exits, so a naive single-file copy of `clawboo.db` captures all recent committed writes without the WAL sidecars.
- Failure is logged and swallowed — it never blocks shutdown or changes the exit code. `wal_autocheckpoint = 50` is left untouched so runtime lean-WAL behavior is preserved.

## Type

- [x] Feature (`feat:`)

## Changeset

- [x] Not needed: apps/web-only change (the dashboard is not published)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes — didn't run the full suite locally (no DB/Playwright env here), happy to run it if the branch CI doesn't cover it
- [x] Self-reviewed the diff

Closes #85