### PR TITLE
chore: add .prettierignore for generated lockfiles

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,14 @@
+# Generated / machine-managed files that must not be reformatted.
+# Prettier is run over YAML/JSON via the format script and the lint-staged
+# pre-commit hook; without this, committing a dependency change rewrites the
+# entire lockfile in Prettier's style (thousands of lines of churn).
+
+# pnpm lockfiles (root workspace + standalone website)
+pnpm-lock.yaml
+website/pnpm-lock.yaml
+
+# Build output and caches
+dist/
+**/dist/
+.turbo/
+coverage/


### PR DESCRIPTION
## Summary

* Adds a `.prettierignore` file to exclude generated lockfiles from formatting.
* Prevents format hooks from reformatting machine-generated files that should remain untouched.
* Reduces formatting noise and avoids unnecessary diffs in generated artifacts.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [x] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — tooling/config-only change)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff
