### PR TITLE
board: manual affordances over the agent-driven board

### DIFF
--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { CornerDownRight, KanbanSquare, RefreshCw } from 'lucide-react'
+import { Bot, CornerDownRight, KanbanSquare, Plus, RefreshCw, Sparkles } from 'lucide-react'
 
 import { useTeamStore } from '@/stores/team'
 import { fetchBoardResult, type BoardTask } from '@/lib/boardClient'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { PanelHeader } from '@/features/shared/PanelHeader'
 import { Button } from '@/features/shared/Button'
+import { EmptyState } from '@/features/shared/EmptyState'
 import { FormattedAlert } from '@/features/shared/FormattedAlert'
 import { Skeleton } from '@/features/shared/Skeleton'
 import { StatusPill, type StatusTone } from '@/features/shared/StatusPill'
@@ -16,21 +17,21 @@ import { ENTER_SPRING, listDelay } from '@/lib/motion'
 
 import { TaskDetailDrawer } from './TaskDetailDrawer'
 import { ApprovalsColumn } from './ApprovalsColumn'
+import { NewTaskDialog } from './NewTaskDialog'
+import { STATUS_LABEL, TASK_STATUSES } from './boardStatus'
 
 const SECTION_LABEL =
   'font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/45'
 const COUNT_PILL =
   'font-data rounded-full bg-foreground/[0.06] px-2.5 py-0.5 text-[11px] font-semibold text-foreground/55'
 
-const COLUMNS: { id: string; label: string }[] = [
-  { id: 'backlog', label: 'Backlog' },
-  { id: 'todo', label: 'To do' },
-  { id: 'in_progress', label: 'In progress' },
-  { id: 'in_review', label: 'In review' },
-  { id: 'blocked', label: 'Blocked' },
-  { id: 'done', label: 'Done' },
-  { id: 'cancelled', label: 'Cancelled' },
-]
+// One column per canonical status, in lifecycle order. Derived from the shared
+// status metadata so the columns, the New-task composer, and the drawer's status
+// editor never drift on labels or ordering.
+const COLUMNS: { id: string; label: string }[] = TASK_STATUSES.map((id) => ({
+  id,
+  label: STATUS_LABEL[id],
+}))
 const COLUMN_IDS = new Set(COLUMNS.map((c) => c.id))
 // A task with a status outside the canonical 7 lands here instead of being
 // silently dropped (counted in the header but rendered nowhere).
@@ -101,6 +102,7 @@ export function BoardPanel() {
   const [teamFilter, setTeamFilter] = useState<string>(selectedTeamId ?? 'all')
   const [tasks, setTasks] = useState<BoardTask[]>([])
   const [openTaskId, setOpenTaskId] = useState<string | null>(null)
+  const [composerOpen, setComposerOpen] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [loaded, setLoaded] = useState(false) // false until the first fetch resolves → skeleton
   const [fetchOk, setFetchOk] = useState(true) // false when the last fetch failed → error/retry
@@ -136,6 +138,20 @@ export function BoardPanel() {
     const id = setInterval(() => void refresh(), 5000)
     return () => clearInterval(id)
   }, [refresh])
+
+  // A manually-created task: show it instantly (optimistic prepend) unless the
+  // active team filter would exclude it, then reconcile against the server. The
+  // authoritative `refresh` corrects any drift (e.g. server-assigned fields).
+  const handleCreated = useCallback(
+    (task: BoardTask) => {
+      const matchesFilter = teamFilter === 'all' || task.teamId === teamFilter
+      if (matchesFilter) {
+        setTasks((prev) => (prev.some((t) => t.id === task.id) ? prev : [task, ...prev]))
+      }
+      void refresh()
+    },
+    [teamFilter, refresh],
+  )
 
   const byStatus = useMemo(() => {
     const map: Record<string, BoardTask[]> = {}
@@ -178,14 +194,39 @@ export function BoardPanel() {
                 </option>
               ))}
             </Select>
-            <Button variant="secondary" size="sm" onClick={() => void refresh()} aria-label="Refresh">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void refresh()}
+              aria-label="Refresh"
+            >
               {refreshing ? <Spinner size={13} /> : <RefreshCw size={13} strokeWidth={2} />}
               Refresh
+            </Button>
+            <Button variant="primary" size="sm" onClick={() => setComposerOpen(true)}>
+              <Plus size={14} strokeWidth={2.4} />
+              New task
             </Button>
             <GitHubStarButton />
           </>
         }
       />
+
+      {/* The board is a live projection of agent work — cards are created and
+          moved by agents through chat. A Kanban invites drag/create, so without a
+          word this reads as broken rather than intentional. This one-liner sets
+          the expectation the moment the board opens, while the header's New-task
+          button and the drawer's status editor make the manual path real. */}
+      <div
+        data-testid="board-agent-hint"
+        className="flex items-center gap-2 border-b border-border px-6 py-2 text-[12px] text-foreground/50"
+      >
+        <Bot size={13} strokeWidth={2} className="shrink-0 text-foreground/40" />
+        <span>
+          AI agents continuously create and move work.{' '}
+          <span className="text-foreground/35">You can also manage tasks manually.</span>
+        </span>
+      </div>
 
       <div className="flex-1 overflow-auto px-6 py-5">
         <div className="flex min-h-full items-start gap-4">
@@ -224,6 +265,27 @@ export function BoardPanel() {
                   </Button>
                 </span>
               </FormattedAlert>
+            </div>
+          ) : tasks.length === 0 ? (
+            // A genuinely empty board (fetch OK, zero tasks) → one board-level
+            // empty state with a manual CTA, rather than seven identical "No
+            // tasks" columns. Reinforces the agent-driven model and offers the
+            // manual escape hatch in the same place a first-time user looks.
+            <div
+              data-testid="board-empty"
+              className="flex flex-1 items-center justify-center py-16"
+            >
+              <EmptyState
+                icon={Sparkles}
+                tone="primary"
+                title="No tasks yet"
+                helper="Agents populate this board automatically as work is delegated in chat. You can also add the first task yourself."
+                action={
+                  <Button variant="primary" size="sm" onClick={() => setComposerOpen(true)}>
+                    <Plus size={14} strokeWidth={2.4} /> New task
+                  </Button>
+                }
+              />
             </div>
           ) : (
             columns.map((col) => {
@@ -267,6 +329,13 @@ export function BoardPanel() {
       <AnimatePresence>
         {openTaskId && <TaskDetailDrawer taskId={openTaskId} onClose={() => setOpenTaskId(null)} />}
       </AnimatePresence>
+
+      <NewTaskDialog
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+        defaultTeamId={teamFilter !== 'all' ? teamFilter : undefined}
+        onCreated={handleCreated}
+      />
     </div>
   )
 }

--- a/apps/web/src/features/board/NewTaskDialog.tsx
+++ b/apps/web/src/features/board/NewTaskDialog.tsx
@@ -1,0 +1,255 @@
+// Manual "New task" composer — the human-driven counterpart to agent delegation.
+// A modal (mirrors ConfirmDialog's scrim + surface-overlay-tier card + spring)
+// that collects a title, optional description, team, and initial status, then
+// writes through boardClient.createTask. The board stays agent-first; this is the
+// escape hatch for a user who wants to drop work on it directly.
+//
+// The body lives in an inner component that mounts only while open, so
+// useFocusTrap can trap Tab within the dialog and restore focus to the trigger on
+// close — and so the form resets to a clean state on every open by construction.
+
+import { useEffect, useId, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Plus } from 'lucide-react'
+
+import { boardClient, type BoardTask } from '@/lib/boardClient'
+import { useTeamStore } from '@/stores/team'
+import { useToastStore } from '@/stores/toast'
+import { Button } from '@/features/shared/Button'
+import { Select } from '@/features/shared/Select'
+import { useFocusTrap } from '@/features/onboarding/useFocusTrap'
+
+import { STATUS_LABEL, type TaskStatus } from './boardStatus'
+
+// A manual task starts life in triage or ready-to-claim; the later lifecycle
+// states (in_progress … done) belong to an assignee doing the work, so we don't
+// offer them at creation time.
+const INITIAL_STATUSES = ['todo', 'backlog'] as const
+
+const FIELD_LABEL = 'mb-1.5 block text-[12px] font-medium text-foreground/60'
+const INPUT_CLASS =
+  'w-full rounded-lg border border-border bg-surface px-3 text-[13.5px] text-foreground ' +
+  'outline-none transition placeholder:text-foreground/35 ' +
+  'focus:border-primary focus:ring-4 focus:ring-primary/15 disabled:opacity-50'
+
+export interface NewTaskDialogProps {
+  open: boolean
+  onClose: () => void
+  /** Preselect this team (the board's active team filter), when one is active. */
+  defaultTeamId?: string
+  /** Called with the created task so the board can reflect it immediately. */
+  onCreated: (task: BoardTask) => void
+}
+
+export function NewTaskDialog({ open, onClose, defaultTeamId, onCreated }: NewTaskDialogProps) {
+  // Mount the body only while open so its state resets each time and useFocusTrap
+  // (inside) activates/restores with the dialog's lifecycle.
+  return (
+    <AnimatePresence>
+      {open && (
+        <NewTaskDialogBody
+          key="new-task"
+          onClose={onClose}
+          defaultTeamId={defaultTeamId}
+          onCreated={onCreated}
+        />
+      )}
+    </AnimatePresence>
+  )
+}
+
+type NewTaskDialogBodyProps = Omit<NewTaskDialogProps, 'open'>
+
+function NewTaskDialogBody({ onClose, defaultTeamId, onCreated }: NewTaskDialogBodyProps) {
+  const teams = useTeamStore((s) => s.teams)
+  const addToast = useToastStore((s) => s.addToast)
+
+  const titleId = useId()
+  const descId = useId()
+  const teamId = useId()
+  const statusId = useId()
+  const headingId = useId()
+
+  // The dialog element: useFocusTrap moves focus to its first focusable (the title
+  // input), traps Tab within it, and restores focus to the trigger on unmount.
+  const dialogRef = useRef<HTMLFormElement | null>(null)
+  useFocusTrap(dialogRef, 0)
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [team, setTeam] = useState(defaultTeamId ?? '')
+  const [status, setStatus] = useState<TaskStatus>('todo')
+  const [submitting, setSubmitting] = useState(false)
+
+  // Escape closes — unless a request is in flight (don't abandon a pending write).
+  // Bound to window in the BUBBLE phase (not document-capture): the Select popover
+  // stops Escape in the capture phase to close its own menu, so an open Team/Status
+  // dropdown swallows the key here and the dialog stays put. A document-capture
+  // listener would co-fire with Select's (stopPropagation doesn't suppress a
+  // same-node, same-phase sibling) and wrongly discard the whole form.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !submitting) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [submitting, onClose])
+
+  const trimmedTitle = title.trim()
+  const canSubmit = trimmedTitle.length > 0 && !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    const task = await boardClient.createTask({
+      title: trimmedTitle,
+      description: description.trim() || undefined,
+      teamId: team || undefined,
+      status,
+    })
+    if (task) {
+      addToast({ type: 'success', message: 'Task created' })
+      onCreated(task)
+      onClose()
+    } else {
+      addToast({ type: 'error', message: 'Couldn’t create the task. Please try again.' })
+      setSubmitting(false)
+    }
+  }
+
+  const activeTeams = teams.filter((t) => !t.isArchived)
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-[80] flex items-center justify-center p-4"
+      style={{ background: 'var(--overlay-scrim)' }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.15 }}
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !submitting) onClose()
+      }}
+    >
+      <motion.form
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        data-testid="new-task-dialog"
+        className="surface-overlay-tier w-full max-w-[440px] rounded-2xl p-5"
+        initial={{ opacity: 0, scale: 0.96, y: 8 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.97, y: 6 }}
+        transition={{ type: 'spring', stiffness: 320, damping: 26 }}
+        onSubmit={handleSubmit}
+      >
+        <h2
+          id={headingId}
+          className="text-[15px] font-semibold text-foreground"
+          style={{ letterSpacing: '-0.01em' }}
+        >
+          New task
+        </h2>
+        <p className="mt-1 text-[12.5px] leading-relaxed text-foreground/55">
+          Add work to the board manually. Agents can then claim and run it, just like a delegated
+          task.
+        </p>
+
+        <div className="mt-4 flex flex-col gap-3.5">
+          <div>
+            <label htmlFor={titleId} className={FIELD_LABEL}>
+              Title
+            </label>
+            <input
+              id={titleId}
+              className={`${INPUT_CLASS} h-9`}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="e.g. Draft the launch announcement"
+              maxLength={500}
+              disabled={submitting}
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor={descId} className={FIELD_LABEL}>
+              Description <span className="text-foreground/35">(optional)</span>
+            </label>
+            <textarea
+              id={descId}
+              className={`${INPUT_CLASS} resize-none py-2 leading-relaxed`}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Add any context an agent would need to pick this up."
+              rows={3}
+              maxLength={20_000}
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="flex gap-3">
+            <div className="min-w-0 flex-1">
+              <label htmlFor={teamId} className={FIELD_LABEL}>
+                Team
+              </label>
+              <Select
+                id={teamId}
+                aria-label="Team"
+                value={team}
+                onChange={setTeam}
+                disabled={submitting}
+                style={{ width: '100%' }}
+              >
+                <option value="">No team</option>
+                {activeTeams.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.icon} {t.name}
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className="min-w-0 flex-1">
+              <label htmlFor={statusId} className={FIELD_LABEL}>
+                Status
+              </label>
+              <Select
+                id={statusId}
+                aria-label="Initial status"
+                value={status}
+                onChange={(v) => setStatus(v as TaskStatus)}
+                disabled={submitting}
+                style={{ width: '100%' }}
+              >
+                {INITIAL_STATUSES.map((s) => (
+                  <option key={s} value={s}>
+                    {STATUS_LABEL[s]}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="secondary" size="sm" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            size="sm"
+            loading={submitting}
+            disabled={!canSubmit}
+          >
+            {!submitting && <Plus size={14} strokeWidth={2.2} />}
+            Create task
+          </Button>
+        </div>
+      </motion.form>
+    </motion.div>
+  )
+}

--- a/apps/web/src/features/board/StatusSelect.tsx
+++ b/apps/web/src/features/board/StatusSelect.tsx
@@ -1,0 +1,109 @@
+// Inline status editor for the task-detail drawer. Replaces the static status
+// text with a Select that writes through boardClient.updateStatus.
+//
+// It only offers the transitions the server will accept (statusOptions mirrors
+// the state machine), updates optimistically for a snappy feel, and rolls back +
+// toasts if the write is rejected (an illegal transition or a blocking
+// verification gate both surface as `false`). Terminal tasks (done / cancelled)
+// have no legal moves, so the control locks.
+//
+// Guard rail: the server clears the assignee on ANY transition to `todo` (the
+// agent-release path — see updateStatus in @clawboo/db). So moving a task that an
+// agent is actively working on back to "To do" would pull it out from under that
+// agent mid-run. When that's the case we confirm first, rather than silently
+// unassigning a live run.
+
+import { useEffect, useState } from 'react'
+
+import { boardClient } from '@/lib/boardClient'
+import { confirm } from '@/stores/confirm'
+import { useToastStore } from '@/stores/toast'
+import { Select } from '@/features/shared/Select'
+import { Spinner } from '@/features/shared/Spinner'
+
+import { STATUS_LABEL, isTerminalStatus, statusLabel, statusOptions } from './boardStatus'
+
+export interface StatusSelectProps {
+  taskId: string
+  status: string
+  /** The agent currently assigned to the task, if any. Present ⇒ moving the task
+   *  to `todo` would unassign a live run, so we confirm before doing so. */
+  assigneeAgentId?: string | null
+  /** Notifies the parent of a committed change so it can keep its copy in sync. */
+  onChange?: (next: string) => void
+}
+
+export function StatusSelect({ taskId, status, assigneeAgentId, onChange }: StatusSelectProps) {
+  const addToast = useToastStore((s) => s.addToast)
+  const [value, setValue] = useState(status)
+  const [saving, setSaving] = useState(false)
+
+  // A fresh task load (or an agent moving the card underneath us) reseeds the
+  // control — but never mid-write, so an in-flight optimistic value isn't clobbered.
+  useEffect(() => {
+    if (!saving) setValue(status)
+  }, [status, saving])
+
+  const options = statusOptions(value)
+
+  // Off-list status (nothing legal to offer) → read-only display, matching the
+  // board's catch-all "Other" handling rather than a broken, empty dropdown.
+  if (options.length === 0) {
+    return (
+      <span className="font-data text-[12.5px] text-foreground" data-testid="task-status-readonly">
+        {statusLabel(value)}
+      </span>
+    )
+  }
+
+  const locked = saving || isTerminalStatus(value)
+
+  async function handleChange(next: string) {
+    if (next === value) return
+    // Moving to `todo` releases the task for re-claim and clears its assignee. If
+    // an agent is on it, confirm before yanking the work out from under the run.
+    if (next === 'todo' && assigneeAgentId) {
+      const proceed = await confirm({
+        title: 'Unassign the agent?',
+        message:
+          'Moving this task back to “To do” releases it for re-claim — the agent assigned to it will be unassigned.',
+        confirmLabel: 'Move & unassign',
+        tone: 'danger',
+      })
+      if (!proceed) return // leave the Select on its current value; nothing sent
+    }
+    const prev = value
+    setValue(next) // optimistic
+    setSaving(true)
+    const ok = await boardClient.updateStatus(taskId, next)
+    setSaving(false)
+    if (ok) {
+      addToast({ type: 'success', message: `Status updated to ${statusLabel(next)}` })
+      onChange?.(next)
+    } else {
+      setValue(prev) // rollback
+      addToast({ type: 'error', message: `Couldn’t move this task to ${statusLabel(next)}.` })
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Select
+        size="sm"
+        aria-label="Task status"
+        data-testid="task-status-select"
+        value={value}
+        onChange={handleChange}
+        disabled={locked}
+        menuWidth={140}
+      >
+        {options.map((s) => (
+          <option key={s} value={s}>
+            {STATUS_LABEL[s]}
+          </option>
+        ))}
+      </Select>
+      {saving && <Spinner size={12} />}
+    </span>
+  )
+}

--- a/apps/web/src/features/board/TaskDetailDrawer.tsx
+++ b/apps/web/src/features/board/TaskDetailDrawer.tsx
@@ -26,6 +26,8 @@ import { Skeleton } from '@/features/shared/Skeleton'
 import { ActivityTerminal } from '@/features/obs/ActivityTerminal'
 import { ENTER_SPRING } from '@/lib/motion'
 
+import { StatusSelect } from './StatusSelect'
+
 const muted = (o: number) => `rgb(var(--foreground-rgb) / ${o})`
 const SECTION_LABEL =
   'font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/45'
@@ -104,6 +106,20 @@ function kv(label: string, value: string) {
       >
         {value}
       </span>
+    </div>
+  )
+}
+
+// Same label rhythm as `kv`, but the value is an interactive control (e.g. the
+// status editor) rather than plain text — so no font-data/word-break, and the
+// row is vertically centered on the control.
+function kvControl(label: string, control: React.ReactNode) {
+  return (
+    <div
+      style={{ display: 'flex', gap: 12, fontSize: 12.5, marginBottom: 6, alignItems: 'center' }}
+    >
+      <span style={{ color: muted(0.45), minWidth: 82 }}>{label}</span>
+      {control}
     </div>
   )
 }
@@ -249,7 +265,39 @@ export function TaskDetailDrawer({ taskId, onClose }: { taskId: string; onClose:
               )}
 
               <Section icon={<ListChecks size={13} />} title="Overview">
-                {kv('Status', task.status)}
+                {kvControl(
+                  'Status',
+                  <StatusSelect
+                    taskId={task.id}
+                    status={task.status}
+                    assigneeAgentId={task.assigneeAgentId}
+                    onChange={(next) =>
+                      setDetail((d) =>
+                        d
+                          ? {
+                              ...d,
+                              // Mirror the server: a →todo release clears the assignee,
+                              // runtime, and verification verdict (repository.ts, the
+                              // cross-runtime rebind boundary). Without this the Assignee
+                              // row reads stale, a prior verdict lingers, and the release
+                              // confirm would re-fire on the next move.
+                              task: {
+                                ...d.task,
+                                status: next,
+                                ...(next === 'todo'
+                                  ? {
+                                      assigneeAgentId: null,
+                                      assigneeRuntime: null,
+                                      verification: null,
+                                    }
+                                  : {}),
+                              },
+                            }
+                          : d,
+                      )
+                    }
+                  />,
+                )}
                 {kv('Assignee', String(task['assigneeAgentId'] ?? '—'))}
                 {kv('Runtime', String(task['assigneeRuntime'] ?? 'openclaw'))}
                 {kv('Cost', cost != null ? `$${cost.toFixed(4)}` : '—')}
@@ -370,7 +418,10 @@ export function TaskDetailDrawer({ taskId, onClose }: { taskId: string; onClose:
                       </span>{' '}
                       <span className="text-foreground/50">{ex.status}</span>
                       {typeof ex.costUsd === 'number' && (
-                        <span className="font-data text-foreground/50"> · ${ex.costUsd.toFixed(4)}</span>
+                        <span className="font-data text-foreground/50">
+                          {' '}
+                          · ${ex.costUsd.toFixed(4)}
+                        </span>
                       )}
                       {(ex.inputTokens != null || ex.outputTokens != null) && (
                         <span className="font-data text-foreground/40">

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -34,6 +34,110 @@ describe('BoardPanel', () => {
     ).toBeInTheDocument()
   })
 
+  it('explains the agent-driven model so the read-only board is self-explanatory', async () => {
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Wire the widget', status: 'todo' }] }),
+      ),
+    )
+    render(<BoardPanel />)
+    const hint = await screen.findByTestId('board-agent-hint')
+    expect(hint).toHaveTextContent(/AI agents continuously create and move work/i)
+    expect(hint).toHaveTextContent(/manage tasks manually/i)
+  })
+
+  it('offers a New task button in the header', async () => {
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Wire the widget', status: 'todo' }] }),
+      ),
+    )
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+    expect(screen.getByRole('button', { name: /New task/i })).toBeInTheDocument()
+  })
+
+  it('shows a branded empty state with a manual CTA when the board is empty', async () => {
+    server.use(http.get('/api/board', () => HttpResponse.json({ tasks: [] })))
+    render(<BoardPanel />)
+    const empty = await screen.findByTestId('board-empty')
+    expect(within(empty).getByText('No tasks yet')).toBeInTheDocument()
+    // The empty state offers the same manual escape hatch as the header.
+    expect(within(empty).getByRole('button', { name: /New task/i })).toBeInTheDocument()
+  })
+
+  it('creates a task through the composer and posts it to /api/board', async () => {
+    let createdBody: { title?: string; status?: string } | null = null
+    server.use(
+      // Populated board → only the header "New task" button renders (no empty-state CTA).
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Existing', status: 'todo' }] }),
+      ),
+      http.post('/api/board', async ({ request }) => {
+        createdBody = (await request.json()) as { title: string; status?: string }
+        return HttpResponse.json({
+          task: { id: 'new1', title: createdBody.title, status: createdBody.status ?? 'todo' },
+        })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    await user.click(screen.getByRole('button', { name: /New task/i }))
+    const dialog = await screen.findByTestId('new-task-dialog')
+    await user.type(within(dialog).getByLabelText('Title'), 'Draft the changelog')
+    await user.click(within(dialog).getByRole('button', { name: /Create task/i }))
+
+    await waitFor(() => expect(createdBody).not.toBeNull())
+    expect(createdBody).toMatchObject({ title: 'Draft the changelog', status: 'todo' })
+    // The dialog closes on success.
+    await waitFor(() => expect(screen.queryByTestId('new-task-dialog')).toBeNull())
+  })
+
+  it('moves focus into the composer (title field) when it opens', async () => {
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Existing', status: 'todo' }] }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    await user.click(screen.getByRole('button', { name: /New task/i }))
+    const dialog = await screen.findByTestId('new-task-dialog')
+    // useFocusTrap moves focus to the first focusable — the title input.
+    await waitFor(() => expect(within(dialog).getByLabelText('Title')).toHaveFocus())
+  })
+
+  it('Escape dismisses an open field dropdown without closing the composer', async () => {
+    // Regression: the dialog's Escape handler must not co-fire with the Select's,
+    // or dismissing a dropdown would tear down the whole form and lose typed input.
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Existing', status: 'todo' }] }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    await user.click(screen.getByRole('button', { name: /New task/i }))
+    const dialog = await screen.findByTestId('new-task-dialog')
+    await user.type(within(dialog).getByLabelText('Title'), 'Keep me')
+
+    // Open the Status dropdown, then press Escape to dismiss it.
+    await user.click(within(dialog).getByLabelText('Initial status'))
+    expect(await screen.findByRole('option', { name: 'Backlog' })).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+
+    // The menu closes, but the dialog — and the typed title — survive.
+    await waitFor(() => expect(screen.queryByRole('option', { name: 'Backlog' })).toBeNull())
+    expect(screen.getByTestId('new-task-dialog')).toBeInTheDocument()
+    expect(within(dialog).getByLabelText('Title')).toHaveValue('Keep me')
+  })
+
   it('shows a skeleton on first mount, before the board fetch resolves', () => {
     server.use(http.get('/api/board', () => HttpResponse.json({ tasks: [] })))
     render(<BoardPanel />)

--- a/apps/web/src/features/board/__tests__/TaskDetailDrawer.test.tsx
+++ b/apps/web/src/features/board/__tests__/TaskDetailDrawer.test.tsx
@@ -3,12 +3,13 @@
 // /executions, and /workspace/detail. The drawer is READ-ONLY — it displays
 // comments but has no compose box, so the user interaction is the Close button.
 
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { server } from '../../../__vitest__/mswServer'
+import { ConfirmDialog } from '../../shared/ConfirmDialog'
 import { TaskDetailDrawer } from '../TaskDetailDrawer'
 
 afterEach(() => cleanup())
@@ -30,6 +31,23 @@ function detailHandlers() {
   ]
 }
 
+// A task actively owned by an agent (in_progress + assignee) — moving it to `todo`
+// would unassign that agent, so the status editor must confirm first.
+function runningTaskHandlers() {
+  return [
+    http.get('/api/board/t1', () =>
+      HttpResponse.json({
+        task: { id: 't1', title: 'Ship it', status: 'in_progress', assigneeAgentId: 'agent-7' },
+        comments: [],
+        ancestors: [],
+      }),
+    ),
+    http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
+    http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
+    http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
+  ]
+}
+
 describe('TaskDetailDrawer', () => {
   it('loads + renders task detail', async () => {
     server.use(...detailHandlers())
@@ -37,11 +55,149 @@ describe('TaskDetailDrawer', () => {
 
     expect(await screen.findByTestId('task-detail-drawer')).toBeInTheDocument()
     expect(await screen.findByText('Ship it')).toBeInTheDocument()
-    expect(screen.getByText('in_review')).toBeInTheDocument()
+    // Status is now an editable Select showing the human label for `in_review`.
+    expect(screen.getByTestId('task-status-select')).toHaveTextContent('In review')
     expect(screen.getByText('looks good')).toBeInTheDocument()
     // The Activity section mounts (its ActivityTerminal backfills /api/obs/events,
     // which is mocked above — so onUnhandledRequest:'error' stays a real guarantee).
     expect(screen.getByText('Activity')).toBeInTheDocument()
+  })
+
+  it('changes status through the Select and PATCHes /api/board/:id', async () => {
+    let patched: { status?: string } | null = null
+    server.use(
+      ...detailHandlers(), // t1 is in_review → done is a legal transition
+      http.patch('/api/board/t1', async ({ request }) => {
+        patched = (await request.json()) as { status: string }
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: patched.status } })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<TaskDetailDrawer taskId="t1" onClose={() => {}} />)
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'Done' }))
+
+    await waitFor(() => expect(patched).toEqual({ status: 'done' }))
+  })
+
+  it('confirms before unassigning a running agent, then PATCHes on confirm', async () => {
+    let patched: { status?: string } | null = null
+    server.use(
+      ...runningTaskHandlers(),
+      http.patch('/api/board/t1', async ({ request }) => {
+        patched = (await request.json()) as { status: string }
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: patched.status } })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    expect(screen.getByText('agent-7')).toBeInTheDocument() // Assignee row, pre-move
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'To do' }))
+
+    // The confirm gate intercepts — nothing is sent until the user confirms.
+    const dialog = await screen.findByTestId('confirm-dialog')
+    expect(patched).toBeNull()
+    await user.click(within(dialog).getByTestId('confirm-ok'))
+    await waitFor(() => expect(patched).toEqual({ status: 'todo' }))
+    // The drawer mirrors the server's release: the assignee is cleared locally, so
+    // the Assignee row no longer shows a (now-detached) agent.
+    await waitFor(() => expect(screen.queryByText('agent-7')).toBeNull())
+  })
+
+  it('leaves a running task assigned when the unassign confirm is cancelled', async () => {
+    let patchCalls = 0
+    server.use(
+      ...runningTaskHandlers(),
+      http.patch('/api/board/t1', () => {
+        patchCalls++
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'To do' }))
+
+    const dialog = await screen.findByTestId('confirm-dialog')
+    await user.click(within(dialog).getByTestId('confirm-cancel'))
+
+    // No write fired, and the control stays on the original status.
+    await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).toBeNull())
+    expect(patchCalls).toBe(0)
+    expect(screen.getByTestId('task-status-select')).toHaveTextContent('In progress')
+  })
+
+  it('moves an UNassigned task to To do with no confirm prompt', async () => {
+    // The gate keys on a present assignee — an unassigned in_progress task releasing
+    // to `todo` clears nothing meaningful, so it must NOT prompt.
+    let patched: { status?: string } | null = null
+    server.use(
+      http.get('/api/board/t1', () =>
+        HttpResponse.json({
+          task: { id: 't1', title: 'Ship it', status: 'in_progress' }, // no assigneeAgentId
+          comments: [],
+          ancestors: [],
+        }),
+      ),
+      http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
+      http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
+      http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
+      http.patch('/api/board/t1', async ({ request }) => {
+        patched = (await request.json()) as { status: string }
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: patched.status } })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'To do' }))
+
+    await waitFor(() => expect(patched).toEqual({ status: 'todo' }))
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+  })
+
+  it('locks the status editor on a terminal (done) task', async () => {
+    server.use(
+      http.get('/api/board/t1', () =>
+        HttpResponse.json({
+          task: { id: 't1', title: 'Ship it', status: 'done' },
+          comments: [],
+          ancestors: [],
+        }),
+      ),
+      http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
+      http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
+      http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
+    )
+    render(<TaskDetailDrawer taskId="t1" onClose={() => {}} />)
+
+    await screen.findByText('Ship it')
+    // Terminal tasks have no legal moves → the control is disabled, not interactive.
+    expect(screen.getByTestId('task-status-select')).toBeDisabled()
   })
 
   it('calls onClose when the Close button is clicked', async () => {

--- a/apps/web/src/features/board/__tests__/boardStatus.parity.test.ts
+++ b/apps/web/src/features/board/__tests__/boardStatus.parity.test.ts
@@ -1,0 +1,54 @@
+// Parity guard: the board UI's boardStatus.ts hand-mirrors the server task state
+// machine (packages/db/src/board/state-machine.ts) so it can offer only the moves
+// the server accepts without dragging the db/sqlite graph into the browser bundle.
+// This test imports BOTH and fails when they drift — a new status, a changed
+// transition, or a terminal-state change on the server that the mirror missed.
+//
+// Node-project test (`*.test.ts`) so it can import @clawboo/db, exactly like the
+// server suites do. NOTE: `@clawboo/db` resolves to its built `dist/`, so the guard
+// compares against the LAST BUILD of the state machine. That's exactly what CI does
+// — `turbo test` has the test task `dependsOn: ["^build"]`, so @clawboo/db is rebuilt
+// first and drift is caught. A direct `vitest` run in apps/web without a prior
+// `pnpm build` would compare against a possibly-stale dist; run via `pnpm test`
+// (turbo) for the real guarantee.
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  TASK_STATUSES as DB_STATUSES,
+  canTransition as dbCanTransition,
+  isTerminal as dbIsTerminal,
+} from '@clawboo/db'
+
+import { TASK_STATUSES, isTerminalStatus, statusOptions } from '../boardStatus'
+
+// The client's notion of "can I move from → to", derived from what the editor
+// actually offers (statusOptions includes the current status + every legal target).
+function clientCanTransition(from: string, to: string): boolean {
+  if (from === to) return true // same-status is an idempotent no-op, like the server
+  return (statusOptions(from) as string[]).includes(to)
+}
+
+describe('boardStatus ↔ @clawboo/db state-machine parity', () => {
+  it('lists the same statuses in the same lifecycle order', () => {
+    expect([...TASK_STATUSES]).toEqual([...DB_STATUSES])
+  })
+
+  it('permits exactly the same transitions for every (from, to) pair', () => {
+    const mismatches: string[] = []
+    for (const from of DB_STATUSES) {
+      for (const to of DB_STATUSES) {
+        if (clientCanTransition(from, to) !== dbCanTransition(from, to)) {
+          mismatches.push(`${from} → ${to}`)
+        }
+      }
+    }
+    expect(mismatches).toEqual([])
+  })
+
+  it('agrees on which statuses are terminal', () => {
+    for (const s of DB_STATUSES) {
+      expect(isTerminalStatus(s)).toBe(dbIsTerminal(s))
+    }
+  })
+})

--- a/apps/web/src/features/board/boardStatus.ts
+++ b/apps/web/src/features/board/boardStatus.ts
@@ -1,0 +1,76 @@
+// Canonical board-status metadata for the web UI: the ordered status list, the
+// human labels the board renders, and the legal-transition table the manual
+// status editor offers.
+//
+// This is a deliberate BROWSER-SIDE MIRROR of the server state machine in
+// packages/db/src/board/state-machine.ts. The server remains the source of truth
+// (it re-checks every transition inside the write transaction and 409s an illegal
+// one), so this table is purely for ergonomics — it lets the UI offer only the
+// moves the server will accept instead of surfacing options that always fail.
+// Importing @clawboo/db here would drag the sqlite/server graph into the browser
+// bundle, so we mirror the 7 statuses locally (as BoardPanel already did for its
+// columns). KEEP THIS IN SYNC with state-machine.ts if the transitions change.
+
+/** The 7 task statuses, in lifecycle order (matches the board's column order). */
+export const TASK_STATUSES = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'in_review',
+  'blocked',
+  'done',
+  'cancelled',
+] as const
+
+export type TaskStatus = (typeof TASK_STATUSES)[number]
+
+/** Human labels for each status — the single source the columns and the status
+ *  editor both read, so a rename happens in one place. */
+export const STATUS_LABEL: Record<TaskStatus, string> = {
+  backlog: 'Backlog',
+  todo: 'To do',
+  in_progress: 'In progress',
+  in_review: 'In review',
+  blocked: 'Blocked',
+  done: 'Done',
+  cancelled: 'Cancelled',
+}
+
+// Legal forward transitions, mirroring state-machine.ts. `done` / `cancelled` are
+// terminal. Same-status is always an allowed no-op (handled by the helpers below).
+const LEGAL_TRANSITIONS: Record<TaskStatus, readonly TaskStatus[]> = {
+  backlog: ['todo', 'blocked', 'cancelled'],
+  todo: ['in_progress', 'blocked', 'backlog', 'cancelled'],
+  in_progress: ['in_review', 'done', 'blocked', 'todo', 'cancelled'],
+  in_review: ['done', 'in_progress', 'blocked', 'cancelled'],
+  blocked: ['todo', 'in_progress', 'backlog', 'cancelled'],
+  done: [],
+  cancelled: [],
+}
+
+export function isTaskStatus(value: unknown): value is TaskStatus {
+  return typeof value === 'string' && (TASK_STATUSES as readonly string[]).includes(value)
+}
+
+/** Terminal statuses have no outgoing transitions — the editor locks on them. */
+export function isTerminalStatus(status: string): boolean {
+  return status === 'done' || status === 'cancelled'
+}
+
+/** A human label for any status string (off-list statuses fall back to raw). */
+export function statusLabel(status: string): string {
+  return isTaskStatus(status) ? STATUS_LABEL[status] : status
+}
+
+/**
+ * The statuses the manual editor should offer for a task currently in `from`:
+ * the current status (so it renders as the selected value) plus every legal
+ * target, in canonical order. An unknown/off-list current status yields just
+ * itself, so the editor degrades to a locked, read-only display rather than
+ * offering moves the server would reject.
+ */
+export function statusOptions(from: string): TaskStatus[] {
+  if (!isTaskStatus(from)) return []
+  const reachable = new Set<TaskStatus>([from, ...LEGAL_TRANSITIONS[from]])
+  return TASK_STATUSES.filter((s) => reachable.has(s))
+}

--- a/docs/using/board.md
+++ b/docs/using/board.md
@@ -40,11 +40,19 @@ The board renders **seven columns**, one per task status, in lifecycle order:
 
 Each column shows its label and a live count of the tasks in it. The panel header shows a total task count (`{N} tasks`) and polls `GET /api/board` every five seconds, so status changes and new tasks appear without a manual refresh. A **Refresh** button forces an immediate re-fetch.
 
+Because the board is a live projection of agent activity — cards are created and moved by agents as they work — a one-line hint under the header (_"AI agents continuously create and move work. You can also manage tasks manually."_) sets that expectation up front, so the absence of drag-to-reorder reads as intentional rather than broken. The manual path is real, though: a **New task** button in the header opens a composer, and each task's status is editable from its [detail drawer](#the-task-detail-drawer).
+
 A task whose status falls outside the canonical seven is not silently dropped; an **Other** column is appended only when such a task exists, so off-list statuses stay visible and counted.
 
 <Note>
 Until the first fetch resolves, the board shows skeleton columns. If that first fetch fails, the board shows a "Couldn't load the board" error with a **Retry** link (distinct from a genuinely empty board). A *transient* poll failure after a good load keeps the last good snapshot rather than blanking an actively-watched board.
 </Note>
+
+A genuinely empty board (loaded fine, zero tasks) shows one **"No tasks yet"** empty state — explaining that agents populate the board automatically as work is delegated, with a **New task** button to add the first one manually — instead of seven identical empty columns.
+
+## Creating a task manually
+
+The header's **New task** button opens a small composer for adding work to the board by hand — the human counterpart to agent delegation. It collects a **title** (required), an optional **description**, a **team** (prefilled from the active team filter), and an initial **status** (**To do** by default, or **Backlog** for triage), then writes it through `POST /api/board`. On success the task appears on the board immediately (optimistically, then reconciled by the next poll) and a toast confirms it; a failed write keeps the composer open and toasts the error. Once on the board, a manually-created task is indistinguishable from a delegated one — an agent can claim and run it normally.
 
 ## Task cards
 
@@ -74,6 +82,8 @@ The drawer sections, top to bottom:
 ### Overview
 
 The task's core fields: **Status**, **Assignee** (`assigneeAgentId`), **Runtime** (`assigneeRuntime`, default `openclaw`), **Cost** (`costUsd` to four decimals), and **Parent** (a truncated `parentTaskId`, shown only for subtasks).
+
+**Status** is an inline editor, not just a label: a dropdown that offers only the transitions the [state machine](/concepts/the-board) permits from the current status (so it never lets you pick a move the server would reject), writes through `PATCH /api/board/:taskId`, and updates optimistically — rolling back and toasting if the write is refused (an illegal transition, or the `→done` verification gate). Terminal tasks (`done` / `cancelled`) have no legal moves, so the control locks.
 
 ### Verification
 

--- a/packages/team-orchestration/src/boardClient.ts
+++ b/packages/team-orchestration/src/boardClient.ts
@@ -6,9 +6,24 @@
 // failures resolve to a null/false result, never throw) and 409-aware: a claim
 // conflict means "someone else won" and MUST NOT be retried.
 
+// The 7 canonical task statuses. Declared locally (not imported from @clawboo/db)
+// so this host-agnostic interface package stays free of the server/db graph; it is
+// structurally identical to @clawboo/db's `TaskStatus`, so a host binding over the
+// direct-DB client still type-checks.
+export type TaskStatus =
+  | 'backlog'
+  | 'todo'
+  | 'in_progress'
+  | 'in_review'
+  | 'blocked'
+  | 'done'
+  | 'cancelled'
+
 export interface CreateTaskInput {
   title: string
   description?: string
+  /** Initial status; the server defaults to 'todo' when omitted. */
+  status?: TaskStatus
   teamId?: string
   assigneeRuntime?: string
   parentTaskId?: string


### PR DESCRIPTION
Closes #69

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- Makes the Board's agent-driven model explicit and gives humans a first-class manual path: an explanatory hint, a branded empty state, a **New task** composer (`createTask`), and inline **status editing** in the task drawer (`updateStatus`) — wiring existing REST methods that had no UI callers.
- Guards the agent-release path: moving an **assigned** task back to “To do” (which the server treats as unassigning the agent) now asks for confirmation first.
- Keeps the client status metadata honest with a parity test against the server state machine, traps focus in the New-task dialog (`useFocusTrap`), and defers drag-and-drop by design (documented).

## Type

<!-- Check one: -->

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

<!-- Required for user-facing changes to packages/* or apps/cli. -->
<!-- Run `pnpm changeset` and commit the generated file. -->

- [ ] Added changeset (or not needed: docs/CI/web-only change)

<!-- Not needed: this is an apps/web change (dashboard is not published, and @clawboo/web
     is in the changesets `ignore` list). The only non-web edit is a one-field addition to
     the private, non-published @clawboo/team-orchestration interface type — no user-facing
     package version to bump. -->

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

---

### Notes for reviewers

- **Release-transition gate:** `StatusSelect` still offers every server-legal transition, but because the server clears the assignee on any `→ todo` move, an `assigned` task moving to “To do” now routes through the shared `confirm()` dialog (“the agent assigned to it will be unassigned”) before the write. Unassigned tasks move without a prompt.
- **Focus trap:** the New-task dialog wires the existing `useFocusTrap` (focus into the title on open, Tab/Shift+Tab trapped, focus restored to the trigger on close).
- **Parity test:** `boardStatus.parity.test.ts` imports the real `@clawboo/db` state machine and fails if the browser-side mirror drifts (a changed transition, a new status, or a terminal-state change).
- **Drag-and-drop** remains intentionally out of scope (new dependency + interaction with the 5s reconciliation poll and the transition gate); the inline status editor covers moving work cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manual **New task** flow from the board (title, optional description, team, and initial status), including immediate optimistic appearance and a success/failure toast.
  - Added an **agent hint** banner and expanded header actions with a **refresh** button.
  - Reworked board empty view into a single board-level empty-state with a **“No tasks yet”** CTA, plus improved status labeling (including an **Other** bucket).
  - Enabled interactive status editing in the task drawer with permitted transitions, loading feedback, and terminal-state locking (plus confirmation when needed).
- **Bug Fixes**
  - Improved task empty-state messaging and refined cost value formatting in the execution ledger.
- **Documentation**
  - Updated board documentation for manual task creation and status-editing behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->