### PR TITLE
chore(cli): ship third-party notices with the bundled distribution

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,9 +8,13 @@ licenses verified for each.
 
 ## Bundled dependencies
 
-Code from these packages ships inside the published `clawboo` npm package (the bundled
-server and the dashboard). Full license texts are distributed with each package in
-`node_modules`.
+Code from these packages ships inside the published `clawboo` npm package. Most are
+bundled (inlined) at build time into the server bundle (`dist/server.js`) and the
+dashboard UI (`dist/ui/`), so they do **not** appear as separate entries in the
+installed package's `node_modules`. A few (`better-sqlite3`, `ws`, `pino`) are declared
+runtime dependencies and are installed normally, carrying their own license texts in
+`node_modules`. For the inlined packages, the copyright and license notices are
+aggregated in this file, which ships in the package (`dist/THIRD_PARTY_NOTICES.md`).
 
 | Package                     | License    |
 | --------------------------- | ---------- |

--- a/apps/web/server/lib/__tests__/thirdPartyNotices.test.ts
+++ b/apps/web/server/lib/__tests__/thirdPartyNotices.test.ts
@@ -1,6 +1,11 @@
 // elkjs (the EPL-2.0 graph-layout backend) is a bundled production dependency of
 // the dashboard, so it must be attributed in THIRD_PARTY_NOTICES.md. This guards
 // the notice against silent removal on a future dep bump.
+//
+// The bundled deps are inlined into dist/server.js and dist/ui/ at build time, so
+// their own license files never reach the user's node_modules — the aggregated
+// notices file is the only place those notices ship. These tests guard both the
+// content AND the wiring that puts the file into the published tarball.
 
 import { existsSync, readFileSync } from 'node:fs'
 import path from 'node:path'
@@ -24,5 +29,27 @@ describe('THIRD_PARTY_NOTICES.md attributes bundled non-MIT/Apache deps', () => 
     const notices = readFileSync(path.join(repoRoot(), 'THIRD_PARTY_NOTICES.md'), 'utf8')
     expect(notices).toContain('elkjs')
     expect(notices).toContain('EPL-2.0')
+  })
+})
+
+describe('THIRD_PARTY_NOTICES.md ships in the published CLI package', () => {
+  // The inlined deps' notices reach users only via this file. Guard the two links
+  // in the ship path so a future assemble/files change cannot silently drop it:
+  //   1. assemble-cli.sh copies it into the CLI dist dir, and
+  //   2. the CLI package publishes dist/.
+
+  it('is copied into the CLI dist by assemble-cli.sh', () => {
+    const assemble = readFileSync(path.join(repoRoot(), 'scripts/assemble-cli.sh'), 'utf8')
+    // A cp of THIRD_PARTY_NOTICES.md into the assembled CLI dist ($CLI_DIST).
+    expect(assemble).toMatch(
+      /cp\s+"\$ROOT\/THIRD_PARTY_NOTICES\.md"\s+"\$CLI_DIST\/THIRD_PARTY_NOTICES\.md"/,
+    )
+  })
+
+  it('publishes dist/ so the copied notices reach the tarball', () => {
+    const pkg = JSON.parse(
+      readFileSync(path.join(repoRoot(), 'apps/cli/package.json'), 'utf8'),
+    ) as { files?: string[] }
+    expect(pkg.files).toContain('dist')
   })
 })

--- a/docs/appendices/license-and-notices.md
+++ b/docs/appendices/license-and-notices.md
@@ -33,7 +33,7 @@ Every workspace library under `packages/` is named `@clawboo/*` and marked `priv
 
 ## Bundled third-party dependencies
 
-The code listed below ships inside the published `clawboo` package (the bundled server and the dashboard UI). Full license texts are distributed with each package in `node_modules`. The authoritative table lives in [`THIRD_PARTY_NOTICES.md`](https://github.com/clawboo/clawboo/blob/main/THIRD_PARTY_NOTICES.md); the summary here highlights the licenses you most need to know about.
+The code listed below ships inside the published `clawboo` package. Most of it is bundled (inlined) at build time into the server bundle (`dist/server.js`) and the dashboard UI (`dist/ui/`), so it does **not** appear as separate entries in the installed package's `node_modules`; a few packages (`better-sqlite3`, `ws`, `pino`) are declared runtime dependencies and carry their own license texts in `node_modules`. For the inlined packages, the aggregated notices ship in [`THIRD_PARTY_NOTICES.md`](https://github.com/clawboo/clawboo/blob/main/THIRD_PARTY_NOTICES.md) (included in the package as `dist/THIRD_PARTY_NOTICES.md`), which is also the authoritative table; the summary here highlights the licenses you most need to know about.
 
 | Package                     | License    | Role                                                                       |
 | --------------------------- | ---------- | -------------------------------------------------------------------------- |

--- a/scripts/assemble-cli.sh
+++ b/scripts/assemble-cli.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 # ── assemble-cli.sh ──────────────────────────────────────────────────────
-# Copies the bundled server.js and Vite UI output into apps/cli/dist/
-# so that `npx clawboo` has everything it needs.
+# Copies the bundled server.js, Vite UI output, MCP stdio bins, and the
+# third-party notices into apps/cli/dist/ so that `npx clawboo` has
+# everything it needs.
 #
 # Prerequisites: pnpm build must have completed successfully.
 # ─────────────────────────────────────────────────────────────────────────
@@ -63,10 +64,19 @@ cp "$WEB_DIST/mcp/memory.js" "$CLI_DIST/bin/memory.js"
 cp "$WEB_DIST/mcp/tools.js" "$CLI_DIST/bin/tools.js"
 cp "$WEB_DIST/mcp/teamchat.js" "$CLI_DIST/bin/teamchat.js"
 
+# ── Copy third-party notices ─────────────────────────────────────────────
+# The dependencies bundled into server.js / ui/ are inlined at build time,
+# so their own license files do NOT travel in the user's node_modules. Ship
+# the aggregated notices inside dist/ (which `files: ["dist"]` publishes) so
+# the bundled MIT / Apache-2.0 / EPL-2.0 notices reach every install.
+
+echo "Copying THIRD_PARTY_NOTICES.md → $CLI_DIST/"
+cp "$ROOT/THIRD_PARTY_NOTICES.md" "$CLI_DIST/THIRD_PARTY_NOTICES.md"
+
 # ── Verify ───────────────────────────────────────────────────────────────
 
 echo ""
 echo "Assembly complete:"
-ls -lh "$CLI_DIST/index.js" "$CLI_DIST/server.js" "$CLI_DIST/ui/index.html" "$CLI_DIST/bin/tasks.js"
+ls -lh "$CLI_DIST/index.js" "$CLI_DIST/server.js" "$CLI_DIST/ui/index.html" "$CLI_DIST/bin/tasks.js" "$CLI_DIST/THIRD_PARTY_NOTICES.md"
 echo ""
 echo "Test with: node $CLI_DIST/index.js"


### PR DESCRIPTION
## Summary

* Updates `THIRD_PARTY_NOTICES.md` to clarify how bundled and runtime dependencies are packaged and where their license texts are provided.
* Ensures `THIRD_PARTY_NOTICES.md` is copied into the CLI distribution and included in the published package tarball.
* Expands test coverage to verify the notices file ships correctly with the CLI release artifacts.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [x] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — packaging/compliance metadata only)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how third-party licenses and copyright notices are distributed in the published package.
  - Documented which dependencies are bundled and which retain individual license files.

- **Chores**
  - Included aggregated third-party notices in the CLI distribution and published package.
  - Updated packaging output to show the included notice file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->