### PR TITLE
fix(board): reject dependency cycles

### DIFF
--- a/.changeset/quiet-crabs-check.md
+++ b/.changeset/quiet-crabs-check.md
@@ -1,0 +1,5 @@
+---
+"clawboo": patch
+---
+
+Reject task dependency links that would introduce a direct or transitive cycle.

--- a/packages/db/src/board/__tests__/board.test.ts
+++ b/packages/db/src/board/__tests__/board.test.ts
@@ -24,6 +24,7 @@ import {
   listTasks,
   reconcileOrphans,
   reconcileStaleInProgress,
+  TaskDependencyCycleError,
   updateStatus,
   updateTaskFields,
 } from '../repository'
@@ -244,6 +245,25 @@ describe('state machine', () => {
 })
 
 describe('dependencies, lineage, comments, soft-delete', () => {
+  it('rejects a direct dependency cycle without changing readiness', () => {
+    const a = createTask(db, { title: 'A' })
+    const b = createTask(db, { title: 'B' })
+    linkDep(db, b.id, a.id)
+
+    expect(() => linkDep(db, a.id, b.id)).toThrow(TaskDependencyCycleError)
+    expect(getReadyTasks(db).map((task) => task.id)).toContain(a.id)
+  })
+
+  it('rejects a transitive dependency cycle', () => {
+    const a = createTask(db, { title: 'A' })
+    const b = createTask(db, { title: 'B' })
+    const c = createTask(db, { title: 'C' })
+    linkDep(db, b.id, a.id)
+    linkDep(db, c.id, b.id)
+
+    expect(() => linkDep(db, a.id, c.id)).toThrow(TaskDependencyCycleError)
+  })
+
   it('getReadyTasks excludes tasks with unsatisfied dependencies', () => {
     const a = createTask(db, { title: 'A' })
     const b = createTask(db, { title: 'B' })

--- a/packages/db/src/board/repository.ts
+++ b/packages/db/src/board/repository.ts
@@ -319,14 +319,40 @@ export function dropTask(db: ClawbooDb, taskId: string): void {
 
 // ─── Dependencies (Beads-style blocks / blocked-by) ──────────────────────────
 
+export class TaskDependencyCycleError extends Error {
+  readonly code = 'task_dependency_cycle'
+
+  constructor(taskId: string, dependsOnTaskId: string) {
+    super(`linking ${taskId} to ${dependsOnTaskId} would create a dependency cycle`)
+    this.name = 'TaskDependencyCycleError'
+  }
+}
+
 export function linkDep(db: ClawbooDb, taskId: string, dependsOnTaskId: string): void {
-  withWriteRetry(() =>
-    db
-      .insert(taskDeps)
+  immediateWrite(db, (tx) => {
+    if (taskId === dependsOnTaskId) {
+      throw new TaskDependencyCycleError(taskId, dependsOnTaskId)
+    }
+    const reachable = tx.all(
+      sql`
+        WITH RECURSIVE dependencies(id) AS (
+          SELECT depends_on_task_id FROM task_deps WHERE task_id = ${dependsOnTaskId}
+          UNION
+          SELECT td.depends_on_task_id
+          FROM task_deps td
+          JOIN dependencies dep ON td.task_id = dep.id
+        )
+        SELECT id FROM dependencies WHERE id = ${taskId} LIMIT 1
+      `,
+    ) as Array<{ id: string }>
+    if (reachable.length > 0) {
+      throw new TaskDependencyCycleError(taskId, dependsOnTaskId)
+    }
+    tx.insert(taskDeps)
       .values({ taskId, dependsOnTaskId, tenantId: null })
       .onConflictDoNothing()
-      .run(),
-  )
+      .run()
+  })
 }
 
 /**

--- a/packages/mcp/src/__tests__/contract.test.ts
+++ b/packages/mcp/src/__tests__/contract.test.ts
@@ -56,6 +56,29 @@ describe('Tasks MCP', () => {
     const list = await callText(client, 'list_tasks', { teamId: 't1' })
     expect((JSON.parse(list.text) as unknown[]).length).toBe(1)
   })
+
+  it('returns a tool error when a dependency link would create a cycle', async () => {
+    const client = await connectInMemory(createTasksServer(db))
+    const first = JSON.parse(
+      (await callText(client, 'create_task', { title: 'First' })).text,
+    ) as { id: string }
+    const second = JSON.parse(
+      (await callText(client, 'create_task', { title: 'Second' })).text,
+    ) as { id: string }
+
+    const linked = await callText(client, 'link_task', {
+      taskId: second.id,
+      dependsOnTaskId: first.id,
+    })
+    expect(linked.isError).toBe(false)
+
+    const cycle = await callText(client, 'link_task', {
+      taskId: first.id,
+      dependsOnTaskId: second.id,
+    })
+    expect(cycle.isError).toBe(true)
+    expect(cycle.text).toContain('dependency cycle')
+  })
 })
 
 describe('Memory MCP', () => {

--- a/packages/mcp/src/tasks/server.ts
+++ b/packages/mcp/src/tasks/server.ts
@@ -16,6 +16,7 @@ import {
   linkDep,
   listTasks,
   releaseTask,
+  TaskDependencyCycleError,
   unblockTask,
   updateStatus,
   type ClawbooDb,
@@ -201,7 +202,14 @@ export function createTasksServer(db: ClawbooDb): Server {
         'Make taskId depend on dependsOnTaskId (it stays unready until the dependency is done).',
       inputSchema: z.object({ taskId: z.string(), dependsOnTaskId: z.string() }),
       handler: (args) => {
-        linkDep(db, str(args['taskId']), str(args['dependsOnTaskId']))
+        try {
+          linkDep(db, str(args['taskId']), str(args['dependsOnTaskId']))
+        } catch (error) {
+          if (error instanceof TaskDependencyCycleError) {
+            return textResult(error.message, true)
+          }
+          throw error
+        }
         return textResult(
           `linked: ${str(args['taskId'])} depends on ${str(args['dependsOnTaskId'])}`,
         )


### PR DESCRIPTION
## Summary

- reject self-referential, direct, and transitive task dependency cycles
- make the reachability check and dependency insert one immediate transaction
- surface cycle failures as MCP tool errors
- add repository and MCP contract coverage plus a patch changeset

## Why

The task board currently accepts `A -> B -> ... -> A`, leaving tasks permanently unready. A recursive CTE can check whether the proposed dependency already reaches the task before the edge is inserted.

This is the cycle-detection slice of #79; fan-out and depth caps remain separate follow-up work.

## Validation

- dependency graph build (`pnpm --filter @clawboo/db... build`) ? passed
- `@clawboo/db` and `@clawboo/mcp` typechecks ? passed
- ESLint on the four changed TypeScript files ? passed
- focused Vitest collection was attempted, but the current Windows/Node 22 dependency graph fails during collection in `drizzle-orm` with a CJS/ESM cycle before any test executes

Part of #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task dependencies now reject direct and transitive cycles.
  * Clear error messages identify invalid dependency links.
  * Failed cycle attempts leave existing task readiness unchanged.

* **Bug Fixes**
  * The task-linking tool now reports dependency-cycle errors without suggesting a retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->