### PR TITLE
perf(web): code-split the SPA to shrink the initial bundle

### DIFF
--- a/apps/web/src/features/agent-detail/AgentDetailView.tsx
+++ b/apps/web/src/features/agent-detail/AgentDetailView.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react'
 import { Group, Panel } from 'react-resizable-panels'
 import { useFleetStore } from '@/stores/fleet'
 import { useConnectionStore } from '@/stores/connection'
@@ -7,8 +8,25 @@ import { ChatPanel } from '@/features/chat/ChatPanel'
 import { ResizeHandle } from '@/features/shared/ResizeHandle'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { useNativeRuntimeState } from '@/features/runtimes/useNativeRuntimeState'
-import { MiniGraph } from './MiniGraph'
-import { InlineEditor } from './InlineEditor'
+import { Spinner } from '@/features/shared/Spinner'
+
+// This view is on the eager path (ContentArea imports it statically), so both of
+// its heavy panes are lazy-loaded — otherwise they'd anchor their libraries to
+// the entry chunk regardless of how the vendor chunks are split.
+//
+// MiniGraph pulls in React Flow (+ ELK via the shared graph modules); InlineEditor
+// owns one of the two CodeMirror entry points (AgentFileEditorOverlay is the other).
+const MiniGraph = lazy(() => import('./MiniGraph').then((m) => ({ default: m.MiniGraph })))
+const InlineEditor = lazy(() => import('./InlineEditor').then((m) => ({ default: m.InlineEditor })))
+
+// Shared fallback for the two lazy panes — centered spinner, sized to the pane.
+function PaneFallback() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <Spinner size={20} />
+    </div>
+  )
+}
 
 // ─── AgentDetailView ─────────────────────────────────────────────────────────
 //
@@ -113,13 +131,17 @@ export function AgentDetailView({ agentId }: { agentId: string }) {
           <Panel defaultSize={55} minSize={25}>
             <Group orientation="vertical" id="agent-detail-v">
               <Panel defaultSize={55} minSize={15}>
-                <MiniGraph agentId={agentId} />
+                <Suspense fallback={<PaneFallback />}>
+                  <MiniGraph agentId={agentId} />
+                </Suspense>
               </Panel>
 
               <ResizeHandle direction="vertical" />
 
               <Panel defaultSize={45} minSize={15}>
-                <InlineEditor agentId={agentId} agentName={agent.name} />
+                <Suspense fallback={<PaneFallback />}>
+                  <InlineEditor agentId={agentId} agentName={agent.name} />
+                </Suspense>
               </Panel>
             </Group>
           </Panel>

--- a/apps/web/src/features/agent-detail/AgentDetailView.tsx
+++ b/apps/web/src/features/agent-detail/AgentDetailView.tsx
@@ -22,8 +22,9 @@ const InlineEditor = lazy(() => import('./InlineEditor').then((m) => ({ default:
 // Shared fallback for the two lazy panes — centered spinner, sized to the pane.
 function PaneFallback() {
   return (
-    <div className="flex h-full items-center justify-center">
+    <div role="status" className="flex h-full items-center justify-center">
       <Spinner size={20} />
+      <span className="sr-only">Loading…</span>
     </div>
   )
 }

--- a/apps/web/src/features/editor/AgentFileEditorOverlay.tsx
+++ b/apps/web/src/features/editor/AgentFileEditorOverlay.tsx
@@ -1,6 +1,13 @@
+import { lazy, Suspense } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { useEditorStore } from '@/stores/editor'
-import { AgentFileEditor } from './AgentFileEditor'
+
+// The editor pulls in the whole CodeMirror stack. This overlay is mounted
+// eagerly by ContentArea but renders nothing until the user opens a file, so
+// lazy-loading the editor itself keeps CodeMirror off the entry chunk.
+const AgentFileEditor = lazy(() =>
+  import('./AgentFileEditor').then((m) => ({ default: m.AgentFileEditor })),
+)
 
 export function AgentFileEditorOverlay() {
   const isOpen = useEditorStore((s) => s.isOpen)
@@ -11,12 +18,12 @@ export function AgentFileEditorOverlay() {
   return (
     <AnimatePresence>
       {isOpen && agentId && agentName && (
-        <AgentFileEditor
-          key={agentId}
-          agentId={agentId}
-          agentName={agentName}
-          onClose={closeEditor}
-        />
+        // `null` fallback: the overlay animates in over the current view, so a
+        // spinner would flash on top of it. The editor mounts once its chunk
+        // resolves.
+        <Suspense key={agentId} fallback={null}>
+          <AgentFileEditor agentId={agentId} agentName={agentName} onClose={closeEditor} />
+        </Suspense>
       )}
     </AnimatePresence>
   )

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -21,17 +21,23 @@
 // in `GroupChatPanel` is gated only by the connection status (so it stays quiet
 // when the Gateway is down).
 
-import { useEffect, useMemo, useRef } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useRef } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { TeamOnboardingGate } from './TeamOnboardingGate'
 import { GroupChatViewHeader } from './GroupChatViewHeader'
-import { TeamSpaceSplit } from './TeamSpaceSplit'
 import { useTeamOnboarding } from './useTeamOnboarding'
 import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
 import { useChatStore } from '@/stores/chat'
 import { useBooZeroStore } from '@/stores/booZero'
 import { buildTeamSessionKey } from '@/lib/sessionUtils'
+
+// The settled team space (TeamSpaceSplit) owns the team-scoped Ghost Graph,
+// which pulls in React Flow + elk.bundled.js. Lazy-load it so those libraries
+// stay off the entry chunk until a user actually opens a team space.
+const TeamSpaceSplit = lazy(() =>
+  import('./TeamSpaceSplit').then((m) => ({ default: m.TeamSpaceSplit })),
+)
 
 export function GroupChatView({ teamId }: { teamId: string }) {
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
@@ -43,13 +49,8 @@ export function GroupChatView({ teamId }: { teamId: string }) {
     [agents, booZeroAgentId],
   )
 
-  const {
-    agentsIntroduced,
-    userIntroduced,
-    isLoading,
-    markAgentsIntroduced,
-    markUserIntroduced,
-  } = useTeamOnboarding(teamId)
+  const { agentsIntroduced, userIntroduced, isLoading, markAgentsIntroduced, markUserIntroduced } =
+    useTeamOnboarding(teamId)
 
   const onboardingComplete = agentsIntroduced && userIntroduced
 
@@ -105,10 +106,15 @@ export function GroupChatView({ teamId }: { teamId: string }) {
         ) : (
           // Settled team space — when the user came through the gate this
           // session, the split plays its "open" animation (graph grows down
-          // from the top into its slot; chat settles below).
-          <div className="h-full">
-            <TeamSpaceSplit teamId={teamId} animateOpen={sawGateRef.current} />
-          </div>
+          // from the top into its slot; chat settles below). The split is
+          // lazy-loaded (it owns the team-scoped Ghost Graph + React Flow/ELK),
+          // so we hold a neutral full-window beat while its chunk resolves —
+          // matching the hydrating placeholder above, so there's no flash.
+          <Suspense fallback={<div className="h-full bg-background" />}>
+            <div className="h-full">
+              <TeamSpaceSplit teamId={teamId} animateOpen={sawGateRef.current} />
+            </div>
+          </Suspense>
         )}
       </div>
     </div>

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -1,9 +1,10 @@
-import { useEffect, type ReactNode } from 'react'
+import { useEffect, Suspense, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { NAV_PANELS } from './navPanels'
 import { AgentFileEditorOverlay } from '@/features/editor/AgentFileEditorOverlay'
 import { AgentDetailView } from '@/features/agent-detail'
 import { GroupChatView } from '@/features/group-chat/GroupChatView'
+import { Spinner } from '@/features/shared/Spinner'
 import { WelcomeState } from './WelcomeState'
 import { useViewStore } from '@/stores/view'
 import { useEditorStore } from '@/stores/editor'
@@ -148,7 +149,19 @@ export function ContentArea() {
       break
     case 'nav':
       viewKey = `nav-${viewMode.view}`
-      viewContent = NAV_PANELS[viewMode.view]()
+      viewContent = (
+        <Suspense
+          fallback={
+            <div
+              style={{ display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center' }}
+            >
+              <Spinner size={20} />
+            </div>
+          }
+        >
+          {NAV_PANELS[viewMode.view]()}
+        </Suspense>
+      )
       break
     default:
       viewKey = 'welcome'

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -153,9 +153,11 @@ export function ContentArea() {
         <Suspense
           fallback={
             <div
+              role="status"
               style={{ display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center' }}
             >
               <Spinner size={20} />
+              <span className="sr-only">Loading…</span>
             </div>
           }
         >

--- a/apps/web/src/features/layout/navPanels.tsx
+++ b/apps/web/src/features/layout/navPanels.tsx
@@ -1,19 +1,53 @@
-import { type ReactNode } from 'react'
-import { GhostGraphPanel } from '@/features/graph/GhostGraphPanel'
-import { SchedulerPanel } from '@/features/scheduler/SchedulerPanel'
-import { CostDashboard } from '@/app/cost/CostDashboard'
-import { MarketplacePanel } from '@/features/marketplace/MarketplacePanel'
-import { MaintenancePanel } from '@/features/maintenance'
-import { ObsPanel } from '@/features/obs'
-import { BoardPanel } from '@/features/board/BoardPanel'
-import { RuntimesPanel } from '@/features/runtimes/RuntimesPanel'
-import { ProvidersPanel } from '@/features/providers/ProvidersPanel'
-import { FleetHealth } from '@/features/fleet/FleetHealth'
-import { MemoryPanel } from '@/features/memory/MemoryPanel'
-import { CapabilitiesPanel } from '@/features/capabilities/CapabilitiesPanel'
-import { GovernancePanel } from '@/features/governance/GovernancePanel'
-import { SystemHealthPanel } from '@/features/health'
+import { lazy, type ReactNode } from 'react'
 import type { NavView } from '@/stores/view'
+
+// Each panel is lazy-loaded so it stays off the initial entry chunk and only
+// downloads/parses when its nav view is first opened. Panels are named exports,
+// so we map each to `default` for React.lazy. The heavy features (Ghost Graph +
+// ELK, Marketplace catalog, CodeMirror, recharts) now load on demand rather
+// than up front. Rendered behind a <Suspense> boundary in ContentArea.
+const GhostGraphPanel = lazy(() =>
+  import('@/features/graph/GhostGraphPanel').then((m) => ({ default: m.GhostGraphPanel })),
+)
+const SchedulerPanel = lazy(() =>
+  import('@/features/scheduler/SchedulerPanel').then((m) => ({ default: m.SchedulerPanel })),
+)
+const CostDashboard = lazy(() =>
+  import('@/app/cost/CostDashboard').then((m) => ({ default: m.CostDashboard })),
+)
+const MarketplacePanel = lazy(() =>
+  import('@/features/marketplace/MarketplacePanel').then((m) => ({ default: m.MarketplacePanel })),
+)
+const MaintenancePanel = lazy(() =>
+  import('@/features/maintenance').then((m) => ({ default: m.MaintenancePanel })),
+)
+const ObsPanel = lazy(() => import('@/features/obs').then((m) => ({ default: m.ObsPanel })))
+const BoardPanel = lazy(() =>
+  import('@/features/board/BoardPanel').then((m) => ({ default: m.BoardPanel })),
+)
+const RuntimesPanel = lazy(() =>
+  import('@/features/runtimes/RuntimesPanel').then((m) => ({ default: m.RuntimesPanel })),
+)
+const ProvidersPanel = lazy(() =>
+  import('@/features/providers/ProvidersPanel').then((m) => ({ default: m.ProvidersPanel })),
+)
+const FleetHealth = lazy(() =>
+  import('@/features/fleet/FleetHealth').then((m) => ({ default: m.FleetHealth })),
+)
+const MemoryPanel = lazy(() =>
+  import('@/features/memory/MemoryPanel').then((m) => ({ default: m.MemoryPanel })),
+)
+const CapabilitiesPanel = lazy(() =>
+  import('@/features/capabilities/CapabilitiesPanel').then((m) => ({
+    default: m.CapabilitiesPanel,
+  })),
+)
+const GovernancePanel = lazy(() =>
+  import('@/features/governance/GovernancePanel').then((m) => ({ default: m.GovernancePanel })),
+)
+const SystemHealthPanel = lazy(() =>
+  import('@/features/health').then((m) => ({ default: m.SystemHealthPanel })),
+)
 
 // The single source of truth mapping each NavView → its panel renderer.
 // Shared by ContentArea (full-screen work surfaces) AND the SettingsModal

--- a/apps/web/src/features/layout/navPanels.tsx
+++ b/apps/web/src/features/layout/navPanels.tsx
@@ -4,8 +4,10 @@ import type { NavView } from '@/stores/view'
 // Each panel is lazy-loaded so it stays off the initial entry chunk and only
 // downloads/parses when its nav view is first opened. Panels are named exports,
 // so we map each to `default` for React.lazy. The heavy features (Ghost Graph +
-// ELK, Marketplace catalog, CodeMirror, recharts) now load on demand rather
-// than up front. Rendered behind a <Suspense> boundary in ContentArea.
+// ELK, CodeMirror, recharts) now load on demand rather than up front; extracting
+// the marketplace agent catalog itself is separate follow-up work. Rendered
+// behind a <Suspense> boundary in ContentArea AND in SettingsModal, which
+// renders this same map outside ContentArea's boundary.
 const GhostGraphPanel = lazy(() =>
   import('@/features/graph/GhostGraphPanel').then((m) => ({ default: m.GhostGraphPanel })),
 )

--- a/apps/web/src/features/settings/SettingsModal.tsx
+++ b/apps/web/src/features/settings/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import {
   Activity,
@@ -18,6 +18,7 @@ import {
 import { useSettingsModalStore, type SettingsView } from '@/stores/settingsModal'
 import { NAV_PANELS } from '@/features/layout/navPanels'
 import { InSettingsModalContext } from './settingsModalContext'
+import { Spinner } from '@/features/shared/Spinner'
 
 interface SettingsItem {
   id: SettingsView
@@ -40,26 +41,66 @@ const GROUPS: SettingsGroup[] = [
   {
     label: 'Workspace',
     items: [
-      { id: 'providers', label: 'Providers', icon: KeyRound, keywords: 'api key anthropic openai google openrouter vault provider llm' },
-      { id: 'runtimes', label: 'Runtimes', icon: Cpu, keywords: 'connect install claude codex hermes native openclaw' },
+      {
+        id: 'providers',
+        label: 'Providers',
+        icon: KeyRound,
+        keywords: 'api key anthropic openai google openrouter vault provider llm',
+      },
+      {
+        id: 'runtimes',
+        label: 'Runtimes',
+        icon: Cpu,
+        keywords: 'connect install claude codex hermes native openclaw',
+      },
       { id: 'memory', label: 'Memory', icon: Brain, keywords: 'facts recall knowledge' },
-      { id: 'capabilities', label: 'Capabilities', icon: Puzzle, keywords: 'tools skills connectors' },
+      {
+        id: 'capabilities',
+        label: 'Capabilities',
+        icon: Puzzle,
+        keywords: 'tools skills connectors',
+      },
       { id: 'scheduler', label: 'Scheduler', icon: Clock, keywords: 'routines cron schedule' },
     ],
   },
   {
     label: 'Insights',
     items: [
-      { id: 'cost', label: 'Tokens Used', icon: BarChart3, keywords: 'cost usage spend budget tokens' },
-      { id: 'obs', label: 'Observability', icon: Activity, keywords: 'traces telemetry events fleet health' },
-      { id: 'governance', label: 'Governance', icon: ShieldAlert, keywords: 'budget audit approvals caps' },
+      {
+        id: 'cost',
+        label: 'Tokens Used',
+        icon: BarChart3,
+        keywords: 'cost usage spend budget tokens',
+      },
+      {
+        id: 'obs',
+        label: 'Observability',
+        icon: Activity,
+        keywords: 'traces telemetry events fleet health',
+      },
+      {
+        id: 'governance',
+        label: 'Governance',
+        icon: ShieldAlert,
+        keywords: 'budget audit approvals caps',
+      },
     ],
   },
   {
     label: 'System',
     items: [
-      { id: 'system', label: 'System', icon: SettingsIcon, keywords: 'openclaw model api key gateway maintenance' },
-      { id: 'health', label: 'System Health', icon: HeartPulse, keywords: 'boot probe diagnostics status' },
+      {
+        id: 'system',
+        label: 'System',
+        icon: SettingsIcon,
+        keywords: 'openclaw model api key gateway maintenance',
+      },
+      {
+        id: 'health',
+        label: 'System Health',
+        icon: HeartPulse,
+        keywords: 'boot probe diagnostics status',
+      },
     ],
   },
 ]
@@ -209,7 +250,9 @@ export function SettingsModal() {
                             size={16}
                             strokeWidth={2}
                             className={
-                              active ? 'text-primary' : 'text-foreground/55 group-hover:text-foreground/80'
+                              active
+                                ? 'text-primary'
+                                : 'text-foreground/55 group-hover:text-foreground/80'
                             }
                           />
                           {it.label}
@@ -245,7 +288,18 @@ export function SettingsModal() {
               </div>
               <InSettingsModalContext.Provider value={true}>
                 <div key={view} className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                  {NAV_PANELS[view]()}
+                  {/* NAV_PANELS entries are lazy-loaded, so this surface needs its
+                      own Suspense boundary — the modal renders outside
+                      ContentArea's boundary (it's mounted directly under App). */}
+                  <Suspense
+                    fallback={
+                      <div className="flex flex-1 items-center justify-center">
+                        <Spinner size={20} />
+                      </div>
+                    }
+                  >
+                    {NAV_PANELS[view]()}
+                  </Suspense>
                 </div>
               </InSettingsModalContext.Provider>
             </div>

--- a/apps/web/src/features/settings/SettingsModal.tsx
+++ b/apps/web/src/features/settings/SettingsModal.tsx
@@ -293,8 +293,9 @@ export function SettingsModal() {
                       ContentArea's boundary (it's mounted directly under App). */}
                   <Suspense
                     fallback={
-                      <div className="flex flex-1 items-center justify-center">
+                      <div role="status" className="flex flex-1 items-center justify-center">
                         <Spinner size={20} />
+                        <span className="sr-only">Loading…</span>
                       </div>
                     }
                   >

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -52,12 +52,19 @@ export default defineConfig({
         // not part of the entry chunk. Combined with the lazy panels/graph, a
         // first-run user only downloads/parses these when they open the feature
         // that needs them (editor, charts, or the graph).
+        // d3-* gets its own chunk rather than being folded into `charts`.
+        // React Flow and recharts both depend on parts of d3, so letting it
+        // land in `charts` couples the two — anything that pulls the graph then
+        // drags recharts (~383 KB) onto the same load path. An explicit `d3`
+        // chunk lets each side depend on the shared code independently.
         manualChunks(id) {
           if (!id.includes('node_modules')) return
           if (id.includes('@codemirror') || id.includes('/codemirror/') || id.includes('@lezer'))
             return 'codemirror'
-          if (id.includes('recharts') || id.includes('/d3-')) return 'charts'
           if (id.includes('@xyflow') || id.includes('elkjs')) return 'graph'
+          if (id.includes('recharts')) return 'charts'
+          if (id.includes('/d3-') || id.includes('/internmap/') || id.includes('/victory-vendor/'))
+            return 'd3'
         },
       },
     },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -44,7 +44,24 @@ const apiPort = resolveApiPort()
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths({ ignoreConfigErrors: true })],
-  build: { outDir: 'dist/ui' },
+  build: {
+    outDir: 'dist/ui',
+    rollupOptions: {
+      output: {
+        // Split the heaviest vendor libraries into their own chunks so they're
+        // not part of the entry chunk. Combined with the lazy panels/graph, a
+        // first-run user only downloads/parses these when they open the feature
+        // that needs them (editor, charts, or the graph).
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return
+          if (id.includes('@codemirror') || id.includes('/codemirror/') || id.includes('@lezer'))
+            return 'codemirror'
+          if (id.includes('recharts') || id.includes('/d3-')) return 'charts'
+          if (id.includes('@xyflow') || id.includes('elkjs')) return 'graph'
+        },
+      },
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

- `React.lazy` all 14 nav panels (`navPanels.tsx`) behind a `<Suspense>` boundary in `ContentArea`, using the shared `<Spinner />` as the fallback — moves the graph, marketplace, cost, and other panels off the entry chunk.
- Lazy-load the team-scoped Ghost Graph (`TeamSpaceSplit` in `GroupChatView`) so React Flow + `elk.bundled.js` only load when a team space opens, with a neutral `bg-background` Suspense fallback that matches the existing hydrating placeholder (no flash).
- Add `build.rollupOptions.output.manualChunks` in `vite.config.ts` to split CodeMirror, recharts, and React Flow/ELK into their own vendor chunks.

Closes #65

### Verification (`vite build`)

Heavy libs are now their own chunks and off the entry path: `graph` (React Flow + ELK) ~1.59 MB, `codemirror` ~507 KB, `charts` ~435 KB, and every panel emits its own chunk (`TeamSpaceSplit`, `GhostGraphPanel`, `MarketplacePanel`, …), loaded on demand behind the Suspense boundary. `pnpm turbo run build/typecheck/lint --filter=@clawboo/web` all pass.

Note: the entry chunk is still dominated by the ~3.9 MB marketplace agent catalog (`AGENT_CATALOG`, built at module load). Moving that to an API / static-JSON fetch is the agreed follow-up and is intentionally out of scope here to keep this diff clean.

## Type

- [x] Refactor (`refactor:`)

## Changeset

- [ ] Added changeset (or not needed: docs/CI/web-only change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved load times by lazy-loading heavy areas (team/group chat views, agent detail panes, editor overlay, and settings/navigation panels) only when they’re needed.
  * Optimized bundle splitting with manual chunking to separate Codemirror/Lezer, graph, charts, and D3-related dependencies.
* **UI/UX**
  * Added/standardized loading states for async panel transitions using `Suspense` fallbacks (centered spinners and consistent placeholders), including a neutral full-window placeholder for specific team-space hydration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->