### PR TITLE
Enable npm provenance on the release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,3 +77,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Add `id-token: write` to the publish job permissions.
- Enable npm provenance by setting `NPM_CONFIG_PROVENANCE: true` for the publish step.
- This is a localized change to `.github/workflows/publish.yml` matching the acceptance criteria for #84.

Closes #84.

## Type

- [ ] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [x] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

- [ ] Added changeset (or not needed: docs/CI/web-only change)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled provenance metadata for published packages.
  * Updated the publishing workflow to support secure token-based publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->