### PR TITLE
board: drag-and-drop to move tasks between columns

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,8 @@
     "@codemirror/state": "^6.5.4",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.39.16",
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/utilities": "3.2.2",
     "@lezer/highlight": "^1.2.3",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,7 +52,6 @@
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.39.16",
     "@dnd-kit/core": "6.3.1",
-    "@dnd-kit/utilities": "3.2.2",
     "@lezer/highlight": "^1.2.3",
     "@opentelemetry/exporter-trace-otlp-http": "^0.218.0",
     "@opentelemetry/sdk-node": "^0.218.0",

--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -1,6 +1,29 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Bot, CornerDownRight, KanbanSquare, Plus, RefreshCw, Sparkles } from 'lucide-react'
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  rectIntersection,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type CollisionDetection,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  Bot,
+  CornerDownRight,
+  GripVertical,
+  KanbanSquare,
+  Plus,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react'
 
 import { useTeamStore } from '@/stores/team'
 import { fetchBoardResult, type BoardTask } from '@/lib/boardClient'
@@ -18,7 +41,9 @@ import { ENTER_SPRING, listDelay } from '@/lib/motion'
 import { TaskDetailDrawer } from './TaskDetailDrawer'
 import { ApprovalsColumn } from './ApprovalsColumn'
 import { NewTaskDialog } from './NewTaskDialog'
-import { STATUS_LABEL, TASK_STATUSES } from './boardStatus'
+import { STATUS_LABEL, TASK_STATUSES, canTransition, statusOptions } from './boardStatus'
+import { useStatusMutation } from './useStatusMutation'
+import { resolveDrop } from './resolveDrop'
 
 const SECTION_LABEL =
   'font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/45'
@@ -103,6 +128,103 @@ function TaskCard({ task, onClick }: { task: BoardTask; onClick: () => void }) {
   )
 }
 
+// Columns are large targets, so pointer position is the most predictable hit test;
+// fall back to rect intersection for keyboard drags (which have no pointer coords).
+const boardCollision: CollisionDetection = (args) => {
+  const hits = pointerWithin(args)
+  return hits.length ? hits : rectIntersection(args)
+}
+
+// A card wrapped for drag-and-drop. The card body keeps its click-to-open behavior;
+// a dedicated grip handle is the drag activator (so dragging never competes with the
+// open-drawer click, and keyboard pickup — Space/arrows/Space — has a clear, labelled
+// target). Terminal / off-list cards pass `disabled` and render no handle.
+function DraggableCard({
+  task,
+  disabled,
+  onOpen,
+}: {
+  task: BoardTask
+  disabled: boolean
+  onOpen: () => void
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: task.id,
+    data: { fromStatus: task.status },
+    disabled,
+  })
+  return (
+    <div ref={setNodeRef} className="group/card relative" style={{ opacity: isDragging ? 0.4 : 1 }}>
+      <TaskCard task={task} onClick={onOpen} />
+      {!disabled && (
+        <button
+          type="button"
+          aria-label={`Drag to move “${task.title ?? 'task'}” to another column`}
+          className="absolute right-1.5 top-1.5 flex h-6 w-6 cursor-grab items-center justify-center rounded-md text-foreground/30 opacity-0 transition hover:bg-foreground/[0.08] hover:text-foreground/60 focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 active:cursor-grabbing group-hover/card:opacity-100"
+          style={{ touchAction: 'none' }}
+          {...listeners}
+          {...attributes}
+        >
+          <GripVertical size={14} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  )
+}
+
+// A status column that is also a drop target. `dropDisabled` turns off the column
+// mid-drag when the active card can't legally move here, so illegal targets don't
+// highlight or accept a drop (the server-legal transitions come from boardStatus).
+function BoardColumn({
+  col,
+  items,
+  dropDisabled,
+  cardDisabled,
+  onCardOpen,
+}: {
+  col: { id: string; label: string }
+  items: BoardTask[]
+  dropDisabled: boolean
+  cardDisabled: (task: BoardTask) => boolean
+  onCardOpen: (id: string) => void
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: col.id, disabled: dropDisabled })
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={`board-column-${col.id}`}
+      className={[
+        'flex w-[264px] shrink-0 flex-col gap-2.5 rounded-2xl border p-3 transition-colors',
+        isOver && !dropDisabled
+          ? 'border-primary bg-primary/[0.05]'
+          : 'border-border bg-foreground/[0.02]',
+      ].join(' ')}
+    >
+      <div className="flex items-center justify-between px-1">
+        <span className={SECTION_LABEL}>{col.label}</span>
+        <span className="font-data rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-semibold text-foreground/50">
+          {items.length}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {items.map((t, i) => (
+          <motion.div
+            key={t.id}
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ ...ENTER_SPRING, delay: listDelay(i) }}
+          >
+            <DraggableCard task={t} disabled={cardDisabled(t)} onOpen={() => onCardOpen(t.id)} />
+          </motion.div>
+        ))}
+        {items.length === 0 && (
+          <div className="py-3.5 text-center text-[11px] text-foreground/30">No tasks</div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function BoardPanel() {
   const teams = useTeamStore((s) => s.teams)
   const selectedTeamId = useTeamStore((s) => s.selectedTeamId)
@@ -117,6 +239,23 @@ export function BoardPanel() {
   // Mirrors `loaded` for the refresh closure so `refresh` stays dep-stable
   // (`[teamFilter]`) and the 5s poll doesn't re-create the interval each load.
   const loadedRef = useRef(false)
+
+  // Optimistic drag moves: taskId → target status, laid on top of `tasks` so the card
+  // sits in its new column while the PATCH is in flight. Short-lived — cleared the
+  // moment the mutation resolves (committed into `tasks` on success, or rolled back).
+  const [overrides, setOverrides] = useState<Record<string, string>>({})
+  const [activeTask, setActiveTask] = useState<BoardTask | null>(null)
+  const mutate = useStatusMutation()
+  const sensors = useSensors(
+    // Grip-handle drags only. distance:5 → a stationary press on the handle doesn't
+    // start a drag, and the card body's click-to-open is never intercepted (the handle
+    // is a separate element, so click vs. drag don't compete).
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    // Keyboard DnD: focus a handle, Space to pick up, arrows to move, Space to drop,
+    // Esc to cancel. Uses the default coordinate getter (25px/arrow, resolved via the
+    // rectIntersection fallback); crisp column-to-column snapping is a follow-up.
+    useSensor(KeyboardSensor),
+  )
 
   const refresh = useCallback(async () => {
     setRefreshing(true)
@@ -161,23 +300,92 @@ export function BoardPanel() {
     [teamFilter, refresh],
   )
 
+  // Tasks with any in-flight optimistic drag move applied, so the board (and the 5s
+  // poll) keep the moved card in its target column until the server confirms.
+  const effectiveTasks = useMemo(
+    () =>
+      Object.keys(overrides).length === 0
+        ? tasks
+        : tasks.map((t) => (overrides[t.id] ? { ...t, status: overrides[t.id]! } : t)),
+    [tasks, overrides],
+  )
+
   const byStatus = useMemo(() => {
     const map: Record<string, BoardTask[]> = {}
     for (const col of COLUMNS) map[col.id] = []
     const other: BoardTask[] = []
-    for (const t of tasks) {
+    for (const t of effectiveTasks) {
       if (COLUMN_IDS.has(t.status)) (map[t.status] ??= []).push(t)
       else other.push(t)
     }
     if (other.length) map[OTHER_COLUMN.id] = other
     return map
-  }, [tasks])
+  }, [effectiveTasks])
 
   // Append the catch-all "Other" column only when an off-list status appears.
   const columns = useMemo(
     () => (byStatus[OTHER_COLUMN.id]?.length ? [...COLUMNS, OTHER_COLUMN] : COLUMNS),
     [byStatus],
   )
+
+  const onDragStart = useCallback(
+    ({ active }: DragStartEvent) => {
+      setActiveTask(effectiveTasks.find((t) => t.id === active.id) ?? null)
+    },
+    [effectiveTasks],
+  )
+
+  // Resolve the drop to a status move and commit it through the SAME shared mutation
+  // the drawer editor uses (legal-transition guard + agent-release confirm + rollback
+  // + toast). The override only bridges the in-flight PATCH; on success the move is
+  // committed into `tasks` and the override dropped, so the poll stays authoritative
+  // (if the server later advances the task further, the next poll simply shows that).
+  const clearOverride = useCallback(
+    (taskId: string) =>
+      setOverrides((o) => {
+        if (!(taskId in o)) return o
+        const n = { ...o }
+        delete n[taskId]
+        return n
+      }),
+    [],
+  )
+
+  const onDragEnd = useCallback(
+    async ({ active, over }: DragEndEvent) => {
+      setActiveTask(null)
+      const move = resolveDrop(String(active.id), over ? String(over.id) : null, effectiveTasks)
+      if (!move) return
+      const task = effectiveTasks.find((t) => t.id === move.taskId)
+      const ok = await mutate({
+        taskId: move.taskId,
+        from: move.from,
+        to: move.to,
+        assigneeAgentId: (task?.assigneeAgentId as string | null | undefined) ?? null,
+        applyOptimistic: () => setOverrides((o) => ({ ...o, [move.taskId]: move.to })),
+        rollback: () => clearOverride(move.taskId),
+      })
+      if (ok) {
+        setTasks((prev) => prev.map((t) => (t.id === move.taskId ? { ...t, status: move.to } : t)))
+        clearOverride(move.taskId)
+      }
+    },
+    [effectiveTasks, mutate, clearOverride],
+  )
+
+  // Mid-drag, a card may only land on a column it can legally transition to; all other
+  // columns are disabled as drop targets (so they neither highlight nor accept a drop).
+  const columnDropDisabled = useCallback(
+    (columnId: string) =>
+      activeTask != null &&
+      activeTask.status !== columnId &&
+      !canTransition(activeTask.status, columnId),
+    [activeTask],
+  )
+
+  // Draggable only when the card has at least one legal target — so terminal
+  // (done/cancelled) and off-list "Other" cards can't be dragged into illegal states.
+  const cardDisabled = useCallback((task: BoardTask) => statusOptions(task.status).length <= 1, [])
 
   return (
     <div className="flex h-full flex-col">
@@ -237,101 +445,94 @@ export function BoardPanel() {
       </div>
 
       <div className="flex-1 overflow-auto px-6 py-5">
-        <div className="flex min-h-full items-start gap-4">
-          {/* Approvals are decoupled from the board-task fetch (an exec store + a
+        <DndContext
+          sensors={sensors}
+          collisionDetection={boardCollision}
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          onDragCancel={() => setActiveTask(null)}
+        >
+          <div className="flex min-h-full items-start gap-4">
+            {/* Approvals are decoupled from the board-task fetch (an exec store + a
               /api/tools/approvals poll), so this column ALWAYS renders as the first
               column — a /api/board outage never hides a pending, time-sensitive gate.
               Scoped to the team filter; a rail when empty, auto-expands on a new gate. */}
-          <ApprovalsColumn teamFilter={teamFilter} />
-          {!loaded ? (
-            // Skeleton columns until the first fetch resolves (mirrors the
-            // RuntimesPanel `!loaded` pattern — empty columns shouldn't flash first).
-            <div
-              data-testid="board-skeleton"
-              style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}
-            >
-              {COLUMNS.map((col) => (
-                <div
-                  key={col.id}
-                  style={{ flex: '0 0 264px', display: 'flex', flexDirection: 'column', gap: 10 }}
-                >
-                  <Skeleton width="50%" height={11} />
-                  <Skeleton height={72} radius={16} />
-                  <Skeleton height={72} radius={16} />
-                </div>
-              ))}
-            </div>
-          ) : !fetchOk ? (
-            // The fetch FAILED — distinct from a genuinely empty board (which would
-            // otherwise show "No tasks" in every column with no hint of an error).
-            <div data-testid="board-fetch-error" className="max-w-[460px]">
-              <FormattedAlert tone="error">
-                <span className="flex items-center gap-2">
-                  Couldn’t load the board.
-                  <Button variant="ghost" size="sm" onClick={() => void refresh()}>
-                    Retry
-                  </Button>
-                </span>
-              </FormattedAlert>
-            </div>
-          ) : tasks.length === 0 ? (
-            // A genuinely empty board (fetch OK, zero tasks) → one board-level
-            // empty state with a manual CTA, rather than seven identical "No
-            // tasks" columns. Reinforces the agent-driven model and offers the
-            // manual escape hatch in the same place a first-time user looks.
-            <div
-              data-testid="board-empty"
-              className="flex flex-1 items-center justify-center py-16"
-            >
-              <EmptyState
-                icon={Sparkles}
-                tone="primary"
-                title="No tasks yet"
-                helper="Agents populate this board automatically as work is delegated in chat. You can also add the first task yourself."
-                action={
-                  <Button variant="primary" size="sm" onClick={() => setComposerOpen(true)}>
-                    <Plus size={14} strokeWidth={2.4} /> New task
-                  </Button>
-                }
-              />
-            </div>
-          ) : (
-            columns.map((col) => {
-              const items = byStatus[col.id] ?? []
-              return (
-                <div
-                  key={col.id}
-                  data-testid={`board-column-${col.id}`}
-                  className="flex w-[264px] shrink-0 flex-col gap-2.5 rounded-2xl border border-border bg-foreground/[0.02] p-3"
-                >
-                  <div className="flex items-center justify-between px-1">
-                    <span className={SECTION_LABEL}>{col.label}</span>
-                    <span className="font-data rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-semibold text-foreground/50">
-                      {items.length}
-                    </span>
+            <ApprovalsColumn teamFilter={teamFilter} />
+            {!loaded ? (
+              // Skeleton columns until the first fetch resolves (mirrors the
+              // RuntimesPanel `!loaded` pattern — empty columns shouldn't flash first).
+              <div
+                data-testid="board-skeleton"
+                style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}
+              >
+                {COLUMNS.map((col) => (
+                  <div
+                    key={col.id}
+                    style={{ flex: '0 0 264px', display: 'flex', flexDirection: 'column', gap: 10 }}
+                  >
+                    <Skeleton width="50%" height={11} />
+                    <Skeleton height={72} radius={16} />
+                    <Skeleton height={72} radius={16} />
                   </div>
-                  <div className="flex flex-col gap-2.5">
-                    {items.map((t, i) => (
-                      <motion.div
-                        key={t.id}
-                        initial={{ opacity: 0, y: 4 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ ...ENTER_SPRING, delay: listDelay(i) }}
-                      >
-                        <TaskCard task={t} onClick={() => setOpenTaskId(t.id)} />
-                      </motion.div>
-                    ))}
-                    {items.length === 0 && (
-                      <div className="py-3.5 text-center text-[11px] text-foreground/30">
-                        No tasks
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )
-            })
-          )}
-        </div>
+                ))}
+              </div>
+            ) : !fetchOk ? (
+              // The fetch FAILED — distinct from a genuinely empty board (which would
+              // otherwise show "No tasks" in every column with no hint of an error).
+              <div data-testid="board-fetch-error" className="max-w-[460px]">
+                <FormattedAlert tone="error">
+                  <span className="flex items-center gap-2">
+                    Couldn’t load the board.
+                    <Button variant="ghost" size="sm" onClick={() => void refresh()}>
+                      Retry
+                    </Button>
+                  </span>
+                </FormattedAlert>
+              </div>
+            ) : tasks.length === 0 ? (
+              // A genuinely empty board (fetch OK, zero tasks) → one board-level
+              // empty state with a manual CTA, rather than seven identical "No
+              // tasks" columns. Reinforces the agent-driven model and offers the
+              // manual escape hatch in the same place a first-time user looks.
+              <div
+                data-testid="board-empty"
+                className="flex flex-1 items-center justify-center py-16"
+              >
+                <EmptyState
+                  icon={Sparkles}
+                  tone="primary"
+                  title="No tasks yet"
+                  helper="Agents populate this board automatically as work is delegated in chat. You can also add the first task yourself."
+                  action={
+                    <Button variant="primary" size="sm" onClick={() => setComposerOpen(true)}>
+                      <Plus size={14} strokeWidth={2.4} /> New task
+                    </Button>
+                  }
+                />
+              </div>
+            ) : (
+              columns.map((col) => (
+                <BoardColumn
+                  key={col.id}
+                  col={col}
+                  items={byStatus[col.id] ?? []}
+                  dropDisabled={columnDropDisabled(col.id)}
+                  cardDisabled={cardDisabled}
+                  onCardOpen={setOpenTaskId}
+                />
+              ))
+            )}
+          </div>
+          {/* Rendered in an overlay so the moving card isn't clipped by column
+              overflow, and follows the pointer/keyboard cursor across columns. */}
+          <DragOverlay>
+            {activeTask ? (
+              <div className="w-[240px] cursor-grabbing">
+                <TaskCard task={activeTask} onClick={() => {}} />
+              </div>
+            ) : null}
+          </DragOverlay>
+        </DndContext>
       </div>
 
       <AnimatePresence>

--- a/apps/web/src/features/board/StatusSelect.tsx
+++ b/apps/web/src/features/board/StatusSelect.tsx
@@ -1,27 +1,20 @@
 // Inline status editor for the task-detail drawer. Replaces the static status
-// text with a Select that writes through boardClient.updateStatus.
+// text with a Select that writes through the shared `useStatusMutation` (the same
+// path the board's drag-and-drop uses, so the two stay in lock-step).
 //
 // It only offers the transitions the server will accept (statusOptions mirrors
 // the state machine), updates optimistically for a snappy feel, and rolls back +
-// toasts if the write is rejected (an illegal transition or a blocking
-// verification gate both surface as `false`). Terminal tasks (done / cancelled)
-// have no legal moves, so the control locks.
-//
-// Guard rail: the server clears the assignee on ANY transition to `todo` (the
-// agent-release path — see updateStatus in @clawboo/db). So moving a task that an
-// agent is actively working on back to "To do" would pull it out from under that
-// agent mid-run. When that's the case we confirm first, rather than silently
-// unassigning a live run.
+// toasts if the write is rejected. Terminal tasks (done / cancelled) have no legal
+// moves, so the control locks. The agent-release (`→ todo`) confirm gate lives in
+// `useStatusMutation`.
 
 import { useEffect, useState } from 'react'
 
-import { boardClient } from '@/lib/boardClient'
-import { confirm } from '@/stores/confirm'
-import { useToastStore } from '@/stores/toast'
 import { Select } from '@/features/shared/Select'
 import { Spinner } from '@/features/shared/Spinner'
 
 import { STATUS_LABEL, isTerminalStatus, statusLabel, statusOptions } from './boardStatus'
+import { useStatusMutation } from './useStatusMutation'
 
 export interface StatusSelectProps {
   taskId: string
@@ -34,7 +27,7 @@ export interface StatusSelectProps {
 }
 
 export function StatusSelect({ taskId, status, assigneeAgentId, onChange }: StatusSelectProps) {
-  const addToast = useToastStore((s) => s.addToast)
+  const mutate = useStatusMutation()
   const [value, setValue] = useState(status)
   const [saving, setSaving] = useState(false)
 
@@ -60,30 +53,24 @@ export function StatusSelect({ taskId, status, assigneeAgentId, onChange }: Stat
 
   async function handleChange(next: string) {
     if (next === value) return
-    // Moving to `todo` releases the task for re-claim and clears its assignee. If
-    // an agent is on it, confirm before yanking the work out from under the run.
-    if (next === 'todo' && assigneeAgentId) {
-      const proceed = await confirm({
-        title: 'Unassign the agent?',
-        message:
-          'Moving this task back to “To do” releases it for re-claim — the agent assigned to it will be unassigned.',
-        confirmLabel: 'Move & unassign',
-        tone: 'danger',
-      })
-      if (!proceed) return // leave the Select on its current value; nothing sent
-    }
     const prev = value
-    setValue(next) // optimistic
-    setSaving(true)
-    const ok = await boardClient.updateStatus(taskId, next)
+    // The confirm gate, illegal-transition guard, PATCH, and toasts all live in the
+    // shared hook; StatusSelect only owns its own optimistic value + spinner. `saving`
+    // flips on inside applyOptimistic (after the confirm gate passes and the write
+    // begins), so the spinner/disabled-select never show during the confirm wait.
+    const ok = await mutate({
+      taskId,
+      from: value,
+      to: next,
+      assigneeAgentId,
+      applyOptimistic: () => {
+        setValue(next)
+        setSaving(true)
+      },
+      rollback: () => setValue(prev),
+    })
     setSaving(false)
-    if (ok) {
-      addToast({ type: 'success', message: `Status updated to ${statusLabel(next)}` })
-      onChange?.(next)
-    } else {
-      setValue(prev) // rollback
-      addToast({ type: 'error', message: `Couldn’t move this task to ${statusLabel(next)}.` })
-    }
+    if (ok) onChange?.(next)
   }
 
   return (

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -261,6 +261,41 @@ describe('BoardPanel', () => {
     ).toBeInTheDocument()
   })
 
+  it('rolls back an optimistic drag when the server rejects the move (500)', async () => {
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'in_progress' }] }),
+      ),
+      // A legal move (in_progress → done) that the server refuses.
+      http.patch('/api/board/t1', () => new HttpResponse(null, { status: 500 })),
+    )
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+    // Sanity: it starts in the In progress column.
+    expect(
+      within(screen.getByTestId('board-column-in_progress')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } })
+    })
+
+    // The optimistic override is rolled back: the card returns to In progress and is
+    // NOT left stuck in Done (no lingering override).
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('board-column-in_progress')).queryByTestId('board-card'),
+      ).not.toBeNull(),
+    )
+    expect(within(screen.getByTestId('board-column-done')).queryByTestId('board-card')).toBeNull()
+    // A subsequent poll doesn't resurrect the move either (override truly cleared).
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    expect(
+      within(screen.getByTestId('board-column-in_progress')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+  })
+
   it('rejects an illegal drag client-side without a PATCH', async () => {
     let patchCalled = false
     server.use(

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -2,19 +2,37 @@
 // re-fetch. msw's onUnhandledRequest:'error' keeps the test honest about which
 // endpoints are hit.
 
-import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useTeamStore } from '@/stores/team'
+import { useToastStore } from '@/stores/toast'
 
 import { server } from '../../../__vitest__/mswServer'
+import { ConfirmDialog } from '../../shared/ConfirmDialog'
 import { BoardPanel } from '../BoardPanel'
+
+// dnd-kit's real pointer drag can't run in jsdom (no layout/rects), so we capture
+// the REAL onDragEnd handler by passing through DndContext (keeping the real provider
+// so useDraggable/useDroppable still work) and invoke it with synthetic drag events.
+const dnd = vi.hoisted(() => ({ onDragEnd: undefined as undefined | ((e: unknown) => void) }))
+vi.mock('@dnd-kit/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@dnd-kit/core')>()
+  return {
+    ...actual,
+    DndContext: (props: React.ComponentProps<typeof actual.DndContext>) => {
+      dnd.onDragEnd = props.onDragEnd as (e: unknown) => void
+      return <actual.DndContext {...props} />
+    },
+  }
+})
 
 beforeEach(() => {
   // teamFilter init = selectedTeamId ?? 'all' → keep it 'all' so the fetch has no ?teamId.
   useTeamStore.setState({ teams: [], selectedTeamId: null })
+  useToastStore.setState({ toasts: [] }) // isolate toast assertions across tests
 })
 afterEach(() => cleanup())
 
@@ -215,5 +233,136 @@ describe('BoardPanel', () => {
 
     expect(await screen.findByText('Second')).toBeInTheDocument()
     expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('drag-moves a card to a legal column and PATCHes the status', async () => {
+    let patched: { status?: string } | null = null
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'in_progress' }] }),
+      ),
+      http.patch('/api/board/t1', async ({ request }) => {
+        patched = (await request.json()) as { status: string }
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: patched.status } })
+      }),
+    )
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    // Simulate dropping the in_progress card onto the Done column (a legal move).
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } })
+    })
+
+    await waitFor(() => expect(patched).toEqual({ status: 'done' }))
+    // Optimistic move: the card now sits in the Done column.
+    expect(
+      within(screen.getByTestId('board-column-done')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+  })
+
+  it('rejects an illegal drag client-side without a PATCH', async () => {
+    let patchCalled = false
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'todo' }] }),
+      ),
+      http.patch('/api/board/t1', () => {
+        patchCalled = true
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    // todo → done is not a legal transition; the shared mutation must reject it
+    // client-side (no wasted PATCH), matching the drawer editor.
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } })
+    })
+
+    expect(patchCalled).toBe(false)
+    // The card stays in the To do column.
+    expect(
+      within(screen.getByTestId('board-column-todo')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+    // And the rejection actually ran (not a silent no-op): an error toast was raised.
+    await waitFor(() =>
+      expect(
+        useToastStore
+          .getState()
+          .toasts.some((t) => t.type === 'error' && /can’t move/i.test(t.message)),
+      ).toBe(true),
+    )
+  })
+
+  it('does not stay pinned when the server advances the task past the drag target', async () => {
+    // Regression: a committed drag must not leave the card stuck in its target column
+    // when a concurrent agent moves it further before the next poll (drag → To do, then
+    // an agent re-claims it → In progress). The move commits, then the poll wins.
+    let board = [{ id: 't1', title: 'Ship it', status: 'in_progress' }]
+    server.use(
+      http.get('/api/board', () => HttpResponse.json({ tasks: board })),
+      http.patch('/api/board/t1', () =>
+        HttpResponse.json({ ok: true, task: { id: 't1', status: 'done' } }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } }) // in_progress → done (legal)
+    })
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('board-column-done')).queryByTestId('board-card'),
+      ).not.toBeNull(),
+    )
+
+    // A poll now reports the task advanced past 'done' to 'cancelled'.
+    board = [{ id: 't1', title: 'Ship it', status: 'cancelled' }]
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+
+    // The card follows the server to Cancelled — it is NOT stuck in Done.
+    expect(
+      await within(screen.getByTestId('board-column-cancelled')).findByTestId('board-card'),
+    ).toBeInTheDocument()
+    expect(within(screen.getByTestId('board-column-done')).queryByTestId('board-card')).toBeNull()
+  })
+
+  it('confirms before a drag that unassigns a running agent (→ To do)', async () => {
+    let patched: { status?: string } | null = null
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({
+          tasks: [
+            { id: 't1', title: 'Ship it', status: 'in_progress', assigneeAgentId: 'agent-7' },
+          ],
+        }),
+      ),
+      http.patch('/api/board/t1', async ({ request }) => {
+        patched = (await request.json()) as { status: string }
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: patched.status } })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <BoardPanel />
+        <ConfirmDialog />
+      </>,
+    )
+    await screen.findByTestId('board-card')
+
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'todo' } }) // in_progress → todo (release)
+    })
+
+    // The shared confirm gate intercepts the drag — nothing is sent until confirmed.
+    const dialog = await screen.findByTestId('confirm-dialog')
+    expect(patched).toBeNull()
+    await user.click(within(dialog).getByTestId('confirm-ok'))
+    await waitFor(() => expect(patched).toEqual({ status: 'todo' }))
   })
 })

--- a/apps/web/src/features/board/__tests__/resolveDrop.test.ts
+++ b/apps/web/src/features/board/__tests__/resolveDrop.test.ts
@@ -1,0 +1,59 @@
+// Pure drag-resolution logic — the primary DnD coverage, since dnd-kit's real
+// pointer drag can't run in jsdom (no layout/rects). Exercises the (activeId,
+// overId, tasks) → move | null contract exhaustively.
+
+import { describe, expect, it } from 'vitest'
+
+import type { BoardTask } from '@/lib/boardClient'
+
+import { resolveDrop } from '../resolveDrop'
+
+const tasks: BoardTask[] = [
+  { id: 't1', status: 'todo', title: 'A' },
+  { id: 't2', status: 'in_progress', title: 'B' },
+  { id: 't3', status: 'done', title: 'C' },
+]
+
+describe('resolveDrop', () => {
+  it('resolves a drop onto a different column to a from→to move', () => {
+    expect(resolveDrop('t1', 'in_progress', tasks)).toEqual({
+      taskId: 't1',
+      from: 'todo',
+      to: 'in_progress',
+    })
+  })
+
+  it('is a no-op when dropped back on the card’s own column', () => {
+    expect(resolveDrop('t1', 'todo', tasks)).toBeNull()
+  })
+
+  it('is a no-op when dropped outside any column (over = null)', () => {
+    expect(resolveDrop('t1', null, tasks)).toBeNull()
+  })
+
+  it('is a no-op for an unknown task id', () => {
+    expect(resolveDrop('ghost', 'done', tasks)).toBeNull()
+  })
+
+  it('returns the target column verbatim (legality is enforced downstream)', () => {
+    // todo→done is illegal per the state machine, but resolveDrop is purely
+    // geometric — it reports the intent; useStatusMutation rejects the illegal move.
+    expect(resolveDrop('t1', 'done', tasks)).toEqual({ taskId: 't1', from: 'todo', to: 'done' })
+    // Same for the catch-all "Other" column id.
+    expect(resolveDrop('t1', '__other__', tasks)).toEqual({
+      taskId: 't1',
+      from: 'todo',
+      to: '__other__',
+    })
+  })
+
+  it('resolves against the passed statuses (so optimistic overrides are respected)', () => {
+    // A card already optimistically moved to in_review resolves its next move from there.
+    const moved: BoardTask[] = [{ id: 't1', status: 'in_review', title: 'A' }]
+    expect(resolveDrop('t1', 'done', moved)).toEqual({
+      taskId: 't1',
+      from: 'in_review',
+      to: 'done',
+    })
+  })
+})

--- a/apps/web/src/features/board/boardStatus.ts
+++ b/apps/web/src/features/board/boardStatus.ts
@@ -52,6 +52,19 @@ export function isTaskStatus(value: unknown): value is TaskStatus {
   return typeof value === 'string' && (TASK_STATUSES as readonly string[]).includes(value)
 }
 
+/**
+ * Whether the server would accept a `from → to` status change. Same-status is an
+ * idempotent no-op (allowed), matching the server's `canTransition`. Off-list
+ * statuses have no legal moves. Used by the drag-and-drop handler to reject an
+ * illegal move client-side (no wasted PATCH), exactly as the drawer's status
+ * editor only offers legal targets.
+ */
+export function canTransition(from: string, to: string): boolean {
+  if (!isTaskStatus(from) || !isTaskStatus(to)) return false
+  if (from === to) return true
+  return LEGAL_TRANSITIONS[from].includes(to)
+}
+
 /** Terminal statuses have no outgoing transitions — the editor locks on them. */
 export function isTerminalStatus(status: string): boolean {
   return status === 'done' || status === 'cancelled'

--- a/apps/web/src/features/board/resolveDrop.ts
+++ b/apps/web/src/features/board/resolveDrop.ts
@@ -1,0 +1,36 @@
+// Pure drag-resolution logic for the board, extracted so it's exhaustively
+// unit-testable without a DOM (dnd-kit's real drag needs layout/pointer events
+// that jsdom doesn't implement). Given the dragged card's task id and the
+// droppable it was released over, decide the intended status move — or `null`
+// for a no-op. Legality of the move (state machine) and the agent-release gate
+// are enforced downstream in `useStatusMutation`, exactly as the drawer editor.
+
+import type { BoardTask } from '@/lib/boardClient'
+
+export interface DropResolution {
+  taskId: string
+  from: string
+  to: string
+}
+
+/**
+ * @param activeId  the dragged card's task id (the `useDraggable` id).
+ * @param overId    the droppable released over, or `null` if dropped in dead space.
+ *                  Board column droppable ids ARE the status strings (e.g. `todo`),
+ *                  so `overId` is the target status directly.
+ * @param tasks     the current tasks (statuses should already reflect any optimistic
+ *                  overrides, so a second drag mid-flight resolves from the live column).
+ * @returns the intended move, or `null` for: dropped outside a column, an unknown
+ *          task, or a drop back onto the card's own column (no change).
+ */
+export function resolveDrop(
+  activeId: string,
+  overId: string | null,
+  tasks: BoardTask[],
+): DropResolution | null {
+  if (!overId) return null
+  const task = tasks.find((t) => t.id === activeId)
+  if (!task) return null
+  if (overId === task.status) return null
+  return { taskId: activeId, from: task.status, to: overId }
+}

--- a/apps/web/src/features/board/useStatusMutation.ts
+++ b/apps/web/src/features/board/useStatusMutation.ts
@@ -1,0 +1,78 @@
+// The one place a manual status change is committed, shared by the drawer's
+// status editor (StatusSelect) and the board's drag-and-drop. Centralizing it
+// guarantees both paths behave identically: they reject an illegal transition
+// client-side (no wasted PATCH), confirm before the agent-release (`→ todo`)
+// move, update optimistically via caller-supplied callbacks, roll back on a
+// server rejection, and toast either way.
+
+import { useCallback } from 'react'
+
+import { boardClient } from '@/lib/boardClient'
+import { confirm } from '@/stores/confirm'
+import { useToastStore } from '@/stores/toast'
+
+import { canTransition, statusLabel } from './boardStatus'
+
+export interface StatusMutationInput {
+  taskId: string
+  from: string
+  to: string
+  /** The agent currently assigned; present ⇒ a `→ todo` move unassigns a live run. */
+  assigneeAgentId?: string | null
+  /** Applied only after the confirm gate passes, immediately before the write. */
+  applyOptimistic?: () => void
+  /** Undo the optimistic change when the server rejects the move. */
+  rollback?: () => void
+}
+
+/** Returns a stable `mutate` fn; resolves `true` when the status change committed. */
+export function useStatusMutation(): (input: StatusMutationInput) => Promise<boolean> {
+  const addToast = useToastStore((s) => s.addToast)
+
+  return useCallback(
+    async ({
+      taskId,
+      from,
+      to,
+      assigneeAgentId,
+      applyOptimistic,
+      rollback,
+    }: StatusMutationInput) => {
+      if (from === to) return false
+
+      // Illegal transition → reject client-side; the drawer editor never offers one,
+      // and a drag onto an illegal column shouldn't burn a doomed PATCH.
+      if (!canTransition(from, to)) {
+        addToast({
+          type: 'error',
+          message: `Can’t move ${statusLabel(from)} → ${statusLabel(to)}.`,
+        })
+        return false
+      }
+
+      // Agent-release guard: any `→ todo` clears the assignee server-side, pulling an
+      // actively-worked task out from under its agent. Confirm before doing so.
+      if (to === 'todo' && assigneeAgentId) {
+        const proceed = await confirm({
+          title: 'Unassign the agent?',
+          message:
+            'Moving this task back to “To do” releases it for re-claim — the agent assigned to it will be unassigned.',
+          confirmLabel: 'Move & unassign',
+          tone: 'danger',
+        })
+        if (!proceed) return false
+      }
+
+      applyOptimistic?.()
+      const ok = await boardClient.updateStatus(taskId, to)
+      if (ok) {
+        addToast({ type: 'success', message: `Status updated to ${statusLabel(to)}` })
+      } else {
+        rollback?.()
+        addToast({ type: 'error', message: `Couldn’t move this task to ${statusLabel(to)}.` })
+      }
+      return ok
+    },
+    [addToast],
+  )
+}

--- a/docs/using/board.md
+++ b/docs/using/board.md
@@ -42,7 +42,7 @@ The board renders **seven columns**, one per task status, in lifecycle order:
 
 Each column shows its label and a live count of the tasks in it. The panel header shows a total task count (`{N} tasks`) and polls `GET /api/board` every five seconds, so status changes and new tasks appear without a manual refresh. A **Refresh** button forces an immediate re-fetch.
 
-Because the board is a live projection of agent activity — cards are created and moved by agents as they work — a one-line hint under the header (_"AI agents continuously create and move work. You can also manage tasks manually."_) sets that expectation up front, so the absence of drag-to-reorder reads as intentional rather than broken. The manual path is real, though: a **New task** button in the header opens a composer, and each task's status is editable from its [detail drawer](#the-task-detail-drawer).
+Because the board is a live projection of agent activity — cards are created and moved by agents as they work — a one-line hint under the header (_"AI agents continuously create and move work. You can also manage tasks manually."_) sets that expectation up front. The manual path is real, though, and there are three ways to drive the board by hand: a **New task** button in the header opens a composer, each task's status is editable from its [detail drawer](#the-task-detail-drawer), and you can **drag a card between columns** (see below).
 
 A task whose status falls outside the canonical seven is not silently dropped; an **Other** column is appended only when such a task exists, so off-list statuses stay visible and counted.
 
@@ -55,6 +55,17 @@ A genuinely empty board (loaded fine, zero tasks) shows one **"No tasks yet"** e
 ## Creating a task manually
 
 The header's **New task** button opens a small composer for adding work to the board by hand — the human counterpart to agent delegation. It collects a **title** (required), an optional **description**, a **team** (prefilled from the active team filter), and an initial **status** (**To do** by default, or **Backlog** for triage), then writes it through `POST /api/board`. On success the task appears on the board immediately (optimistically, then reconciled by the next poll) and a toast confirms it; a failed write keeps the composer open and toasts the error. Once on the board, a manually-created task is indistinguishable from a delegated one — an agent can claim and run it normally.
+
+## Moving a task by drag-and-drop
+
+Each card has a **grip handle** (top-right, visible on hover or keyboard focus). Dragging a card to another column is a status change: it writes through the same `PATCH /api/board/:taskId` path as the drawer's status editor, so the server stays authoritative and the same rules apply.
+
+- **Only legal moves are offered.** Mid-drag, columns the card can't legally transition to (per the [state machine](/concepts/the-board)) are dimmed and won't accept a drop; terminal cards (`done` / `cancelled`) and off-list **Other** cards aren't draggable at all.
+- **The agent-release guard still applies.** Dragging an _assigned_ task to **To do** — which unassigns its agent — asks for confirmation first, exactly as the drawer editor does.
+- **Optimistic + poll-safe.** The card moves instantly and is reconciled against the server; a rejected move (e.g. a `→ done` verification gate) rolls back with a toast, and an in-flight move isn't reverted by the five-second poll.
+- **Keyboard and touch.** Focus a card's handle and press **Space** to pick it up, **arrow keys** to choose a column, **Space** to drop, **Escape** to cancel; touch drag is supported too.
+
+Clicking a card (rather than its handle) still opens the detail drawer — a click and a drag don't conflict.
 
 ## Task cards
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
       '@dnd-kit/core':
         specifier: 6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@dnd-kit/utilities':
-        specifier: 3.2.2
-        version: 3.2.2(react@19.2.4)
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,12 @@ importers:
       '@codemirror/view':
         specifier: ^6.39.16
         version: 6.39.16
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.2.4)
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1211,6 +1217,22 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -6266,6 +6288,24 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 


### PR DESCRIPTION
Closes #96

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- Adds **drag-and-drop** to move a task between board columns — a second, native-feeling way to change status alongside the drawer's editor. Dragging a card to a column writes through the **same** `boardClient.updateStatus` path (server stays authoritative), reusing a shared `useStatusMutation` hook so drag and drawer can't drift.
- Respects every board invariant: only **legal transitions** are droppable (illegal columns are disabled mid-drag; terminal `done`/`cancelled` and off-list "Other" cards aren't draggable), the **agent-release confirm** fires when dragging an assigned task to "To do", and moves are **optimistic + poll-safe** (committed on success, rolled back on a 409, never reverted by the 5s poll).
- **Keyboard + touch accessible** via `@dnd-kit` PointerSensor/KeyboardSensor and a labelled grip handle; a `DragOverlay` keeps the dragged card from clipping. Crisp keyboard column-snapping is intentionally deferred (noted in code).

## Type

<!-- Check one: -->

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

<!-- Required for user-facing changes to packages/* or apps/cli. -->
<!-- Run `pnpm changeset` and commit the generated file. -->

- [x] Not needed: `apps/web`-only change (plus docs) — the dashboard is not published to npm (`@clawboo/web` is `private` and in the changesets `ignore` list), so there's no package version to bump.

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

---

### Notes for reviewers

- **New dependency:** `@dnd-kit/core` + `@dnd-kit/utilities` (~14 KB gzip, the app's first DnD lib). `@dnd-kit/core` alone covers cross-column moves — no `@dnd-kit/sortable` (no intra-column reordering).
- **Shared mutation:** the drawer's `StatusSelect` was refactored onto the new `useStatusMutation` hook (legal-transition guard + agent-release confirm + optimistic + rollback + toast), so drag-and-drop matches the drawer by construction. Drop resolution is a pure, unit-tested `resolveDrop`.
- **Tests:** `resolveDrop` unit coverage + DnD wiring (legal move → PATCH, illegal drag rejected client-side with a toast, a committed move that the server later advances past isn't left stuck, and drag-to-"To do" of an assigned task confirms first). dnd-kit's real pointer gesture can't run in jsdom, so those go to a browser/e2e follow-up — the standard dnd-kit testing posture.
- Follow-up to the manual board work in #91.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled drag-and-drop to move tasks between board columns with client-side move validation.
  * Added optimistic UI updates with automatic rollback if the server rejects the move.
  * Kept “assigned task → To do” moves behind a confirmation prompt.
* **Bug Fixes**
  * Board now shows a single empty-state when there are no tasks, while preserving card click-to-open details.
* **Documentation**
  * Expanded the board guide with drag-and-drop behavior, supported interactions, move restrictions, and confirmation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->