### PR TITLE
board: "Complete anyway" override when the verification gate blocks a manual → done

### DIFF
--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -400,4 +400,46 @@ describe('BoardPanel', () => {
     await user.click(within(dialog).getByTestId('confirm-ok'))
     await waitFor(() => expect(patched).toEqual({ status: 'todo' }))
   })
+
+  it('offers "Complete anyway" when a drag to Done hits the verification gate', async () => {
+    // The shared useStatusMutation means the override the drawer got in #97 also
+    // works from the drag path — a drag to Done blocked by the gate offers the override.
+    const bodies: Array<{ status?: string; humanOverride?: boolean }> = []
+    server.use(
+      http.get('/api/board', () =>
+        HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'in_progress' }] }),
+      ),
+      http.patch('/api/board/t1', async ({ request }) => {
+        const body = (await request.json()) as { status: string; humanOverride?: boolean }
+        bodies.push(body)
+        if (body.humanOverride) {
+          return HttpResponse.json({ ok: true, task: { id: 't1', status: 'done' } })
+        }
+        return HttpResponse.json({ ok: false, error: 'verification_required' }, { status: 409 })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <BoardPanel />
+        <ConfirmDialog />
+      </>,
+    )
+    await screen.findByTestId('board-card')
+
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } }) // in_progress → done (gated)
+    })
+
+    const dialog = await screen.findByTestId('confirm-dialog')
+    await user.click(within(dialog).getByTestId('confirm-ok'))
+
+    // The gated attempt, then the audited override retry — same flow as the drawer.
+    await waitFor(() =>
+      expect(bodies).toEqual([{ status: 'done' }, { status: 'done', humanOverride: true }]),
+    )
+    expect(
+      within(screen.getByTestId('board-column-done')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+  })
 })

--- a/apps/web/src/features/board/__tests__/TaskDetailDrawer.test.tsx
+++ b/apps/web/src/features/board/__tests__/TaskDetailDrawer.test.tsx
@@ -8,6 +8,8 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { useToastStore } from '@/stores/toast'
+
 import { server } from '../../../__vitest__/mswServer'
 import { ConfirmDialog } from '../../shared/ConfirmDialog'
 import { TaskDetailDrawer } from '../TaskDetailDrawer'
@@ -80,6 +82,110 @@ describe('TaskDetailDrawer', () => {
     await user.click(await screen.findByRole('option', { name: 'Done' }))
 
     await waitFor(() => expect(patched).toEqual({ status: 'done' }))
+  })
+
+  it('offers "Complete anyway" when the verification gate blocks → done, then overrides', async () => {
+    const bodies: Array<{ status?: string; humanOverride?: boolean }> = []
+    server.use(
+      ...detailHandlers(), // t1 is in_review; → done is legal but the gate refuses it
+      http.patch('/api/board/t1', async ({ request }) => {
+        const body = (await request.json()) as { status: string; humanOverride?: boolean }
+        bodies.push(body)
+        // The server gates → done unless the human override is set (audited path).
+        if (body.humanOverride) {
+          return HttpResponse.json({ ok: true, task: { id: 't1', status: 'done' } })
+        }
+        return HttpResponse.json({ ok: false, error: 'verification_required' }, { status: 409 })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'Done' }))
+
+    // The gated attempt is refused → a "Complete anyway?" override confirm appears.
+    const dialog = await screen.findByTestId('confirm-dialog')
+    expect(within(dialog).getByText(/passed verification/i)).toBeInTheDocument()
+    await user.click(within(dialog).getByTestId('confirm-ok'))
+
+    // Exactly two writes: the gated attempt, then the audited override retry.
+    await waitFor(() =>
+      expect(bodies).toEqual([{ status: 'done' }, { status: 'done', humanOverride: true }]),
+    )
+  })
+
+  it('leaves the task unchanged when "Complete anyway" is declined', async () => {
+    const bodies: Array<{ status?: string; humanOverride?: boolean }> = []
+    server.use(
+      ...detailHandlers(),
+      http.patch('/api/board/t1', async ({ request }) => {
+        bodies.push((await request.json()) as { status: string; humanOverride?: boolean })
+        return HttpResponse.json({ ok: false, error: 'verification_required' }, { status: 409 })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'Done' }))
+
+    const dialog = await screen.findByTestId('confirm-dialog')
+    await user.click(within(dialog).getByTestId('confirm-cancel'))
+
+    // No override sent (only the initial gated attempt), and the editor rolled back —
+    // a deliberate decline, so no error toast either.
+    await waitFor(() => expect(screen.queryByTestId('confirm-dialog')).toBeNull())
+    expect(bodies).toEqual([{ status: 'done' }])
+    expect(screen.getByTestId('task-status-select')).toHaveTextContent('In review')
+  })
+
+  it('rolls back and reports failure when the override retry is still refused', async () => {
+    useToastStore.setState({ toasts: [] })
+    const bodies: Array<{ status?: string; humanOverride?: boolean }> = []
+    server.use(
+      ...detailHandlers(),
+      // Refuse both the gated attempt AND the human-override retry.
+      http.patch('/api/board/t1', async ({ request }) => {
+        bodies.push((await request.json()) as { status: string; humanOverride?: boolean })
+        return HttpResponse.json({ ok: false, error: 'verification_required' }, { status: 409 })
+      }),
+    )
+    const user = userEvent.setup()
+    render(
+      <>
+        <TaskDetailDrawer taskId="t1" onClose={() => {}} />
+        <ConfirmDialog />
+      </>,
+    )
+
+    await screen.findByText('Ship it')
+    await user.click(screen.getByTestId('task-status-select'))
+    await user.click(await screen.findByRole('option', { name: 'Done' }))
+    await user.click(within(await screen.findByTestId('confirm-dialog')).getByTestId('confirm-ok'))
+
+    // Both writes attempted (gated, then override), then a clean rollback + error toast.
+    await waitFor(() =>
+      expect(bodies).toEqual([{ status: 'done' }, { status: 'done', humanOverride: true }]),
+    )
+    expect(screen.getByTestId('task-status-select')).toHaveTextContent('In review')
+    expect(
+      useToastStore
+        .getState()
+        .toasts.some((t) => t.type === 'error' && /verification/i.test(t.message)),
+    ).toBe(true)
   })
 
   it('confirms before unassigning a running agent, then PATCHes on confirm', async () => {

--- a/apps/web/src/features/board/useStatusMutation.ts
+++ b/apps/web/src/features/board/useStatusMutation.ts
@@ -2,16 +2,35 @@
 // status editor (StatusSelect) and the board's drag-and-drop. Centralizing it
 // guarantees both paths behave identically: they reject an illegal transition
 // client-side (no wasted PATCH), confirm before the agent-release (`→ todo`)
-// move, update optimistically via caller-supplied callbacks, roll back on a
-// server rejection, and toast either way.
+// move, offer the audited "Complete anyway" override when the verification gate
+// blocks a `→ done`, update optimistically via caller-supplied callbacks, roll
+// back on a server rejection, and toast a cause-specific message.
 
 import { useCallback } from 'react'
 
-import { boardClient } from '@/lib/boardClient'
+import { updateStatusResult, type StatusChangeReason } from '@/lib/boardClient'
 import { confirm } from '@/stores/confirm'
 import { useToastStore } from '@/stores/toast'
 
 import { canTransition, statusLabel } from './boardStatus'
+
+/** A refusal message that names the actual cause, so the user isn't left guessing. */
+function statusErrorMessage(
+  reason: StatusChangeReason | undefined,
+  from: string,
+  to: string,
+): string {
+  switch (reason) {
+    case 'verification_required':
+      return 'Verification hasn’t passed — this task can’t be completed.'
+    case 'illegal_transition':
+      return `Can’t move ${statusLabel(from)} → ${statusLabel(to)}.`
+    case 'not_found':
+      return 'This task no longer exists on the board.'
+    default:
+      return `Couldn’t move this task to ${statusLabel(to)}.`
+  }
+}
 
 export interface StatusMutationInput {
   taskId: string
@@ -64,14 +83,33 @@ export function useStatusMutation(): (input: StatusMutationInput) => Promise<boo
       }
 
       applyOptimistic?.()
-      const ok = await boardClient.updateStatus(taskId, to)
-      if (ok) {
-        addToast({ type: 'success', message: `Status updated to ${statusLabel(to)}` })
-      } else {
-        rollback?.()
-        addToast({ type: 'error', message: `Couldn’t move this task to ${statusLabel(to)}.` })
+      let res = await updateStatusResult(taskId, to)
+
+      // The verification gate refused a manual → done. Not a dead-end: offer the
+      // server's audited human override (a person shipping despite a non-promotable
+      // verdict, recorded in the audit log) instead of just rolling back.
+      if (!res.ok && res.reason === 'verification_required' && to === 'done') {
+        const proceed = await confirm({
+          title: 'Complete anyway?',
+          message:
+            'This task hasn’t passed verification. Completing it is a manual override and will be recorded in the audit log.',
+          confirmLabel: 'Complete anyway',
+          tone: 'danger',
+        })
+        if (!proceed) {
+          rollback?.() // a deliberate decline — roll back quietly, no error toast
+          return false
+        }
+        res = await updateStatusResult(taskId, to, { humanOverride: true })
       }
-      return ok
+
+      if (res.ok) {
+        addToast({ type: 'success', message: `Status updated to ${statusLabel(to)}` })
+        return true
+      }
+      rollback?.()
+      addToast({ type: 'error', message: statusErrorMessage(res.reason, from, to) })
+      return false
     },
     [addToast],
   )

--- a/apps/web/src/lib/boardClient.ts
+++ b/apps/web/src/lib/boardClient.ts
@@ -56,16 +56,11 @@ export const boardClient: BoardClient = {
   },
 
   async updateStatus(taskId, status) {
-    try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}`, {
-        method: 'PATCH',
-        headers: JSON_HEADERS,
-        body: JSON.stringify({ status }),
-      })
-      return r.ok
-    } catch {
-      return false
-    }
+    // Delegate to `updateStatusResult` (below) so a single implementation owns the
+    // status PATCH. This interface method stays boolean, so the server/orchestrator
+    // bindings that consume `BoardClient` are unaffected; the dashboard UI calls
+    // `updateStatusResult` directly when it needs the failure reason / human override.
+    return (await updateStatusResult(taskId, status)).ok
   },
 
   async addComment(taskId, body, authorType = 'system', authorAgentId) {
@@ -193,6 +188,49 @@ export async function fetchBoardResult(teamId?: string): Promise<BoardFetchResul
 /** All non-dropped tasks, optionally scoped to a team (omit teamId = all teams). */
 export async function fetchBoardTasks(teamId?: string): Promise<BoardTask[]> {
   return (await fetchBoardResult(teamId)).tasks
+}
+
+/** Why a status change was refused, surfaced from the PATCH 409/404 body so the UI
+ *  can react to it (e.g. offer the human override for a blocking verification gate)
+ *  instead of collapsing every failure into a bare boolean. */
+export type StatusChangeReason =
+  | 'illegal_transition'
+  | 'verification_required'
+  | 'not_found'
+  | 'error'
+
+export interface StatusChangeResult {
+  ok: boolean
+  /** Present only on failure. */
+  reason?: StatusChangeReason
+}
+
+/**
+ * The status-PATCH the dashboard UI uses: like `boardClient.updateStatus` (which
+ * now delegates here), but it returns the failure REASON (from the server's
+ * `{ ok:false, error }` 409/404 body) rather than a bare boolean, and allows the
+ * audited `humanOverride` (a human shipping to `done` despite a non-promotable
+ * verification verdict — recorded server-side). Keeping the reason out of the
+ * `BoardClient` interface leaves `updateStatus` boolean, so the orchestrator/server
+ * bindings that share that interface are unaffected.
+ */
+export async function updateStatusResult(
+  taskId: string,
+  status: string,
+  opts: { humanOverride?: boolean } = {},
+): Promise<StatusChangeResult> {
+  try {
+    const r = await fetch(`/api/board/${encodeURIComponent(taskId)}`, {
+      method: 'PATCH',
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ status, ...(opts.humanOverride ? { humanOverride: true } : {}) }),
+    })
+    if (r.ok) return { ok: true }
+    const body = (await r.json().catch(() => null)) as { error?: string } | null
+    return { ok: false, reason: (body?.error as StatusChangeReason) ?? 'error' }
+  } catch {
+    return { ok: false, reason: 'error' }
+  }
 }
 
 export interface BoardExecution {

--- a/docs/using/board.md
+++ b/docs/using/board.md
@@ -98,7 +98,9 @@ The drawer sections, top to bottom:
 
 The task's core fields: **Status**, **Assignee** (`assigneeAgentId`), **Runtime** (`assigneeRuntime`, default `openclaw`), **Cost** (`costUsd` to four decimals), and **Parent** (a truncated `parentTaskId`, shown only for subtasks).
 
-**Status** is an inline editor, not just a label: a dropdown that offers only the transitions the [state machine](/concepts/the-board) permits from the current status (so it never lets you pick a move the server would reject), writes through `PATCH /api/board/:taskId`, and updates optimistically — rolling back and toasting if the write is refused (an illegal transition, or the `→done` verification gate). Terminal tasks (`done` / `cancelled`) have no legal moves, so the control locks.
+**Status** is an inline editor, not just a label: a dropdown that offers only the transitions the [state machine](/concepts/the-board) permits from the current status (so it never lets you pick a move the server would reject), writes through `PATCH /api/board/:taskId`, and updates optimistically — rolling back and toasting if the write is refused, with the message naming the cause (an illegal transition vs. the verification gate). Terminal tasks (`done` / `cancelled`) have no legal moves, so the control locks.
+
+When a `→ done` is refused **specifically by the [verification](/concepts/verification) gate** (the task carries a non-promotable verdict), the editor doesn't dead-end: it offers a **"Complete anyway"** confirmation that re-submits with the server's `humanOverride`. That's the supported path for a human shipping despite a non-promotable verdict — and, like on the server, the override is **recorded in the audit log**. An _illegal_ transition can't be overridden this way (the override only bypasses the verification gate, not the state machine). This lives in the shared status-mutation path, so it works the same whether you change status from this drawer or by [dragging a card](#moving-a-task-by-drag-and-drop) to the Done column.
 
 ### Verification
 


### PR DESCRIPTION
Closes #97

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- When a manual **→ Done** is refused *specifically by the verification gate* (a non-promotable verdict), the status editor no longer dead-ends: it offers a **"Complete anyway?"** confirm that re-submits with the server's audited `humanOverride`. Illegal transitions can't be overridden this way (the override bypasses only the verification gate, not the state machine).
- Refusal toasts now **name the cause** (verification gate vs. illegal transition vs. not-found), so the user isn't left guessing.
- Implemented in the shared `useStatusMutation` hook, so it works identically from **both** the drawer's status editor and **drag-and-drop** — no changes needed in `StatusSelect` or `BoardPanel`.

## Type

<!-- Check one: -->

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

<!-- Required for user-facing changes to packages/* or apps/cli. -->
<!-- Run `pnpm changeset` and commit the generated file. -->

- [x] Not needed: `apps/web`-only change (plus docs) — the dashboard is not published to npm (`@clawboo/web` is `private` and in the changesets `ignore` list), so there's no package version to bump.

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

---

### Notes for reviewers

- **Server support already existed** — `updateTaskBody.humanOverride` (`schemas.ts`) + the audit-log entry in `apps/web/server/api/board.ts`. This PR only exposes that capability in the UI; it does **not** weaken the gate, and the override stays **audit-logged** server-side.
- **New client helper:** `updateStatusResult` surfaces the 409/404 `reason` (and accepts `humanOverride`). To avoid a second copy of the status PATCH, `BoardClient.updateStatus` now **delegates** to it (`return (await updateStatusResult(...)).ok`); it stays boolean, so the shared `BoardClient` interface — and the orchestrator/server bindings that implement it — are unaffected.
- **Declining** the override rolls back quietly (no error toast — it's a deliberate choice, matching the `→ todo` unassign gate).
- **Tests:** drawer (offer→override, decline, override-retry-still-refused) + a drag-path test proving the same override flow.
- Follow-up to #91 / #102.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Complete anyway” confirmation when moving a task to **Done** is blocked by verification.
  - Confirming retries the update and records the override; declining restores the previous status.
  - Added clear error messages and notifications when status changes fail.

- **Documentation**
  - Clarified verification-gated completion, override behavior, audit logging, and non-overridable invalid transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->