### PR TITLE
refactor(data): introduce read sequencing for concurrent state updates

### DIFF
--- a/apps/web/src/features/approvals/__tests__/useToolApprovals.test.tsx
+++ b/apps/web/src/features/approvals/__tests__/useToolApprovals.test.tsx
@@ -1,0 +1,90 @@
+// The tool-approval poll and `resolveTool`'s optimistic removal write the same list, so
+// the poll is sequenced last-write-wins. Driven through the hook rather than a panel: the
+// interesting case is a read that was already in flight when a decision was sent, which is
+// far easier to stage deterministically here than through a rendered queue.
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { server } from '../../../__vitest__/mswServer'
+import { useToolApprovals } from '../usePendingApprovals'
+
+function approval(id: string) {
+  return {
+    id,
+    toolName: 'write_file',
+    agentId: 'agent-1',
+    argsSummary: null,
+    reason: null,
+    createdAt: 0,
+    expiresAt: 0,
+  }
+}
+
+afterEach(() => server.resetHandlers())
+
+describe('useToolApprovals', () => {
+  it('does not resurrect a resolved approval when an in-flight poll lands late', async () => {
+    // Without sequencing, the parked read below lands after the optimistic removal and
+    // re-adds the card — a reappearing gate on a time-sensitive prompt, which invites a
+    // second click on a decision already sent.
+    let calls = 0
+    let releaseStale: (() => void) | undefined
+    let staleAnswered = false
+    let resolveHits = 0
+    server.use(
+      http.get('/api/tools/approvals', async () => {
+        calls += 1
+        // Read 2 is parked and still lists the approval; read 3 (resolveTool's own
+        // reconcile) sees it gone.
+        if (calls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseStale = resolve
+          })
+          staleAnswered = true
+          return HttpResponse.json({ approvals: [approval('ap-1')] })
+        }
+        return HttpResponse.json({ approvals: calls >= 3 ? [] : [approval('ap-1')] })
+      }),
+      http.post('/api/tools/approvals/ap-1/resolve', () => {
+        resolveHits += 1
+        return HttpResponse.json({ ok: true })
+      }),
+    )
+
+    const { result } = renderHook(() => useToolApprovals())
+    await waitFor(() => expect(result.current.tool).toHaveLength(1))
+
+    // Start a read and leave it in flight, then send the decision underneath it.
+    void result.current.refetch()
+    await waitFor(() => expect(calls).toBe(2))
+    await result.current.resolveTool('ap-1', 'deny')
+    await waitFor(() => expect(result.current.tool).toHaveLength(0)) // optimistic removal
+
+    // The stale read now answers, still listing the approval.
+    releaseStale?.()
+    await waitFor(() => expect(staleAnswered).toBe(true))
+    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(3))
+
+    expect(result.current.tool).toHaveLength(0) // stays resolved
+    expect(resolveHits).toBe(1) // and the decision was sent exactly once
+  })
+
+  it('applies a fresh poll that arrives after the resolve reconciled', async () => {
+    // The guard must not wedge the list: a read issued after the commit still applies, so
+    // a NEW approval showing up later is not swallowed.
+    let calls = 0
+    server.use(
+      http.get('/api/tools/approvals', () => {
+        calls += 1
+        return HttpResponse.json({ approvals: calls === 1 ? [] : [approval('ap-2')] })
+      }),
+    )
+    const { result } = renderHook(() => useToolApprovals())
+    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(1))
+
+    await result.current.refetch()
+    await waitFor(() => expect(result.current.tool.map((a) => a.id)).toEqual(['ap-2']))
+  })
+})

--- a/apps/web/src/features/approvals/__tests__/useToolApprovals.test.tsx
+++ b/apps/web/src/features/approvals/__tests__/useToolApprovals.test.tsx
@@ -3,7 +3,7 @@
 // interesting case is a read that was already in flight when a decision was sent, which is
 // far easier to stage deterministically here than through a rendered queue.
 
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { http, HttpResponse } from 'msw'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -65,25 +65,37 @@ describe('useToolApprovals', () => {
     // The stale read now answers, still listing the approval.
     releaseStale?.()
     await waitFor(() => expect(staleAnswered).toBe(true))
-    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(3))
+    // `staleAnswered` only proves the SERVER replied. Flush a macrotask so the client's
+    // fetch → json → setTool chain actually runs — otherwise a regressed guard would apply
+    // its resurrection AFTER the assertion below and the test would pass anyway.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
 
     expect(result.current.tool).toHaveLength(0) // stays resolved
     expect(resolveHits).toBe(1) // and the decision was sent exactly once
   })
 
   it('applies a fresh poll that arrives after the resolve reconciled', async () => {
-    // The guard must not wedge the list: a read issued after the commit still applies, so
-    // a NEW approval showing up later is not swallowed.
+    // The guard must not WEDGE the list. A resolve advances the write sequence, so if that
+    // bump were mishandled every later read would be judged stale forever and a new approval
+    // would never appear again. The resolve here is load-bearing: without it `writeSeqRef`
+    // stays 0 and this passes even if `isCurrent()` ignored the write sequence entirely.
     let calls = 0
     server.use(
       http.get('/api/tools/approvals', () => {
         calls += 1
-        return HttpResponse.json({ approvals: calls === 1 ? [] : [approval('ap-2')] })
+        return HttpResponse.json({
+          approvals: calls === 1 ? [approval('ap-1')] : [approval('ap-2')],
+        })
       }),
+      http.post('/api/tools/approvals/ap-1/resolve', () => HttpResponse.json({ ok: true })),
     )
     const { result } = renderHook(() => useToolApprovals())
-    await waitFor(() => expect(calls).toBeGreaterThanOrEqual(1))
+    await waitFor(() => expect(result.current.tool).toHaveLength(1))
 
+    // Commit a local write (advances writeSeq), then read AFTER it.
+    await result.current.resolveTool('ap-1', 'allow_once')
     await result.current.refetch()
     await waitFor(() => expect(result.current.tool.map((a) => a.id)).toEqual(['ap-2']))
   })

--- a/apps/web/src/features/approvals/usePendingApprovals.ts
+++ b/apps/web/src/features/approvals/usePendingApprovals.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useApprovalsStore, type ApprovalRequest } from '@/stores/approvals'
 import { useBooZeroStore } from '@/stores/booZero'
 import { useFleetStore } from '@/stores/fleet'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 
 // A pending MCP tool-call / delegation approval (from GET /api/tools/approvals).
 // Distinct from the OpenClaw exec `ApprovalRequest` — different fields + a different
@@ -43,16 +44,24 @@ export function useToolApprovals(): {
   refetch: () => Promise<void>
 } {
   const [tool, setTool] = useState<ToolApproval[]>([])
+  // The 3s poll and `resolveTool`'s optimistic removal write the same list, so reads are
+  // sequenced last-write-wins. Without it, a poll already in flight when a decision is
+  // made lands afterwards and RESURRECTS the card that was just resolved — a reappearing
+  // gate on a time-sensitive prompt, which invites a second click on a decision already
+  // sent. See useReadSequencer.
+  const reads = useReadSequencer()
 
   const refetch = useCallback(async () => {
+    const read = reads.beginRead()
     try {
       const r = await fetch('/api/tools/approvals?status=pending')
       const body = r.ok ? ((await r.json()) as { approvals?: ToolApproval[] }) : { approvals: [] }
+      if (!read.isCurrent()) return // predates a resolve, or superseded by a newer read
       setTool(body.approvals ?? [])
     } catch {
       /* best-effort — the next poll reconciles */
     }
-  }, [])
+  }, [reads])
 
   useEffect(() => {
     void refetch()
@@ -62,6 +71,7 @@ export function useToolApprovals(): {
 
   const resolveTool = useCallback(
     async (id: string, decision: ToolDecision) => {
+      reads.commitLocalWrite() // any read already in flight still lists this approval
       setTool((prev) => prev.filter((a) => a.id !== id)) // optimistic removal
       try {
         await fetch(`/api/tools/approvals/${id}/resolve`, {
@@ -74,7 +84,7 @@ export function useToolApprovals(): {
       }
       void refetch()
     },
-    [refetch],
+    [refetch, reads],
   )
 
   return { tool, resolveTool, refetch }

--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -27,6 +27,7 @@ import {
 
 import { useTeamStore } from '@/stores/team'
 import { fetchBoardResult, type BoardTask } from '@/lib/boardClient'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { PanelHeader } from '@/features/shared/PanelHeader'
 import { Button } from '@/features/shared/Button'
@@ -239,6 +240,11 @@ export function BoardPanel() {
   // Mirrors `loaded` for the refresh closure so `refresh` stays dep-stable
   // (`[teamFilter]`) and the 5s poll doesn't re-create the interval each load.
   const loadedRef = useRef(false)
+  // Reads overlap by design here (the 5s poll, Refresh/Retry, the post-create reconcile)
+  // and a local commit can land between a GET being issued and its response arriving, so
+  // the board snapshot is sequenced last-write-wins. See useReadSequencer for the two
+  // staleness rules; the drag path is exactly why a plain generation counter isn't enough.
+  const reads = useReadSequencer()
 
   // Optimistic drag moves: taskId → target status, laid on top of `tasks` so the card
   // sits in its new column while the PATCH is in flight. Short-lived — cleared the
@@ -258,9 +264,16 @@ export function BoardPanel() {
   )
 
   const refresh = useCallback(async () => {
+    // Claimed synchronously, before the await — so `handleCreated`'s optimistic
+    // prepend and its reconcile read invalidate any in-flight read in the same tick.
+    const read = reads.beginRead()
     setRefreshing(true)
     try {
       const res = await fetchBoardResult(teamFilter === 'all' ? undefined : teamFilter)
+      // Superseded by a newer read, or by a local commit made after this read was
+      // issued → a stale snapshot. Drop it rather than reverting newer state; the
+      // next poll (≤5s) reconciles against a response that saw the commit.
+      if (!read.isCurrent()) return
       if (res.ok) {
         setTasks(res.tasks)
         setFetchOk(true)
@@ -272,11 +285,19 @@ export function BoardPanel() {
       // A transient poll failure AFTER a good load keeps the last good snapshot —
       // don't blank a populated, actively-watched board to the error screen.
     } finally {
-      setRefreshing(false)
-      setLoaded(true)
-      loadedRef.current = true
+      // A `return` above still runs this, so the loading chrome needs its own guard:
+      // an older read must neither clear the spinner while a newer read is still
+      // running, nor dismiss the skeleton on a team-filter switch (which would flash
+      // the previous team's tasks). `isNewestRead` (not `isCurrent`) on purpose — see
+      // useReadSequencer. The newest read always resolves (`fetchBoardResult` never
+      // throws), so `loaded` can't get stuck.
+      if (read.isNewestRead()) {
+        setRefreshing(false)
+        setLoaded(true)
+        loadedRef.current = true
+      }
     }
-  }, [teamFilter])
+  }, [teamFilter, reads])
 
   useEffect(() => {
     setLoaded(false) // a team-filter change re-enters the loading state
@@ -293,11 +314,12 @@ export function BoardPanel() {
     (task: BoardTask) => {
       const matchesFilter = teamFilter === 'all' || task.teamId === teamFilter
       if (matchesFilter) {
+        reads.commitLocalWrite() // a read already in flight predates this prepend
         setTasks((prev) => (prev.some((t) => t.id === task.id) ? prev : [task, ...prev]))
       }
       void refresh()
     },
-    [teamFilter, refresh],
+    [teamFilter, refresh, reads],
   )
 
   // Tasks with any in-flight optimistic drag move applied, so the board (and the 5s
@@ -366,11 +388,16 @@ export function BoardPanel() {
         rollback: () => clearOverride(move.taskId),
       })
       if (ok) {
+        // The override bridged the in-flight PATCH (it layers over `tasks`, so no read
+        // could clobber it). Clearing it hands authority back to `tasks`, so the commit
+        // must also fence off any read issued before this point — otherwise that read
+        // lands with the pre-drag status and snaps the card back to its old column.
+        reads.commitLocalWrite()
         setTasks((prev) => prev.map((t) => (t.id === move.taskId ? { ...t, status: move.to } : t)))
         clearOverride(move.taskId)
       }
     },
-    [effectiveTasks, mutate, clearOverride],
+    [effectiveTasks, mutate, clearOverride, reads],
   )
 
   // Mid-drag, a card may only land on a column it can legally transition to; all other

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -366,6 +366,185 @@ describe('BoardPanel', () => {
     expect(within(screen.getByTestId('board-column-done')).queryByTestId('board-card')).toBeNull()
   })
 
+  it('ignores a board response that was already in flight when a drag committed', async () => {
+    // Regression (#105): reads overlap by design (the 5s poll, Refresh/Retry, the
+    // post-create reconcile), so a GET issued BEFORE a drag commits can resolve
+    // AFTER it, carrying the PRE-drag status. Applied unconditionally it snapped the
+    // card back to its old column until the next poll healed it. `refresh()` is
+    // sequenced against local commits, so the stale snapshot is dropped instead.
+    let calls = 0
+    let releaseStale: (() => void) | undefined
+    let staleAnswered = false
+    server.use(
+      http.get('/api/board', async () => {
+        calls += 1
+        // Hold the 2nd read open until the test releases it. Every read answers with
+        // the pre-drag snapshot, so the released one is genuinely stale.
+        if (calls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseStale = resolve
+          })
+          staleAnswered = true
+        }
+        return HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'in_progress' }] })
+      }),
+      http.patch('/api/board/t1', () =>
+        HttpResponse.json({ ok: true, task: { id: 't1', status: 'done' } }),
+      ),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    // Start the slow read, then commit the drag while it is still in flight.
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(calls).toBe(2))
+    await act(async () => {
+      dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'done' } }) // in_progress → done (legal)
+    })
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('board-column-done')).queryByTestId('board-card'),
+      ).not.toBeNull(),
+    )
+
+    // The stale read now lands, reporting the task still In progress.
+    releaseStale?.()
+    await waitFor(() => expect(staleAnswered).toBe(true))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0)) // flush fetch → json → setState
+    })
+
+    // The committed move survives — no snap-back to In progress.
+    expect(
+      within(screen.getByTestId('board-column-done')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('board-column-in_progress')).queryByTestId('board-card'),
+    ).toBeNull()
+  })
+
+  it('ignores a board response that was already in flight when a task was created', async () => {
+    // Regression (#105), the create half: the composer prepends the new task
+    // optimistically and kicks a reconcile read. A read issued BEFORE the POST
+    // landed answers WITHOUT the new task, so applying it blanked the just-created
+    // card until the next poll. Only the newest read may write to the board.
+    const EXISTING = [{ id: 't1', title: 'Existing', status: 'todo' }]
+    let calls = 0
+    let releaseStale: (() => void) | undefined
+    let staleAnswered = false
+    let created = false
+    server.use(
+      http.get('/api/board', async () => {
+        calls += 1
+        // Read 2 is held open and answers with the pre-create snapshot; read 3 is
+        // handleCreated's reconcile, which sees the new task.
+        if (calls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseStale = resolve
+          })
+          staleAnswered = true
+          return HttpResponse.json({ tasks: EXISTING })
+        }
+        return HttpResponse.json({
+          tasks: created
+            ? [...EXISTING, { id: 'new1', title: 'Draft the changelog', status: 'todo' }]
+            : EXISTING,
+        })
+      }),
+      http.post('/api/board', async ({ request }) => {
+        const body = (await request.json()) as { title: string; status?: string }
+        created = true
+        return HttpResponse.json({
+          task: { id: 'new1', title: body.title, status: body.status ?? 'todo' },
+        })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    await screen.findByTestId('board-card')
+
+    // Start the slow read, then create a task while it is still in flight.
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(calls).toBe(2))
+
+    await user.click(screen.getByRole('button', { name: /New task/i }))
+    const dialog = await screen.findByTestId('new-task-dialog')
+    await user.type(within(dialog).getByLabelText('Title'), 'Draft the changelog')
+    await user.click(within(dialog).getByRole('button', { name: /Create task/i }))
+    expect(await screen.findByText('Draft the changelog')).toBeInTheDocument()
+
+    // The stale read now lands, reporting a board without the new task.
+    releaseStale?.()
+    await waitFor(() => expect(staleAnswered).toBe(true))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0)) // flush fetch → json → setState
+    })
+
+    // The created card survives — it isn't blanked by the pre-create snapshot.
+    expect(screen.getByText('Draft the changelog')).toBeInTheDocument()
+  })
+
+  it('discards an in-flight response for the previous team filter', async () => {
+    // Same ordering hazard on the filter path: switching teams re-enters the loading
+    // state, but a read for the PREVIOUS filter can still resolve afterwards. Applied
+    // it would both write the wrong team's tasks and dismiss the skeleton over them.
+    useTeamStore.setState({
+      teams: [
+        {
+          id: 'team-1',
+          name: 'Alpha',
+          icon: '🐙',
+          color: '#e94560',
+          colorCollectionId: null,
+          templateId: null,
+          agentCount: 1,
+          leaderAgentId: null,
+          isArchived: false,
+          serverOrchestrated: false,
+        },
+      ],
+      selectedTeamId: null, // teamFilter starts at 'all' → the first read has no ?teamId
+    })
+    let releaseStale: (() => void) | undefined
+    let staleAnswered = false
+    server.use(
+      http.get('/api/board', async ({ request }) => {
+        const teamId = new URL(request.url).searchParams.get('teamId')
+        if (teamId === null) {
+          // The all-teams read from mount, held open past the filter switch.
+          await new Promise<void>((resolve) => {
+            releaseStale = resolve
+          })
+          staleAnswered = true
+          return HttpResponse.json({
+            tasks: [{ id: 'a1', title: 'All-teams task', status: 'todo' }],
+          })
+        }
+        return HttpResponse.json({ tasks: [{ id: 'b1', title: 'Alpha task', status: 'todo' }] })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+    // The first read hasn't resolved, so the board is still skeletons.
+    expect(screen.getByTestId('board-skeleton')).toBeInTheDocument()
+
+    // Switch to the team filter; its read resolves normally.
+    await user.click(screen.getByLabelText('Filter by team'))
+    await user.click(await screen.findByRole('option', { name: /Alpha/ }))
+    expect(await screen.findByText('Alpha task')).toBeInTheDocument()
+
+    // The all-teams read now lands, after the filter already moved on.
+    releaseStale?.()
+    await waitFor(() => expect(staleAnswered).toBe(true))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0)) // flush fetch → json → setState
+    })
+
+    expect(screen.getByText('Alpha task')).toBeInTheDocument()
+    expect(screen.queryByText('All-teams task')).toBeNull()
+  })
+
   it('confirms before a drag that unassigns a running agent (→ To do)', async () => {
     let patched: { status?: string } | null = null
     server.use(

--- a/apps/web/src/features/fleet/FleetHealth.tsx
+++ b/apps/web/src/features/fleet/FleetHealth.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/features/shared/Button'
 import { EmptyState } from '@/features/shared/EmptyState'
 import { PanelHeader } from '@/features/shared/PanelHeader'
 import { formatRelative } from '@/lib/formatRelative'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 import {
   fetchFleetSummary,
   fetchRecentIssues,
@@ -52,13 +53,10 @@ function MetricCard({ label, value, sub }: { label: string; value: string; sub?:
 }
 
 function HealthDot({ ok }: { ok: boolean | null }) {
-  const color = ok === null ? 'rgb(var(--foreground-rgb) / 0.3)' : ok ? 'var(--mint)' : 'var(--primary)'
+  const color =
+    ok === null ? 'rgb(var(--foreground-rgb) / 0.3)' : ok ? 'var(--mint)' : 'var(--primary)'
   return (
-    <span
-      aria-hidden
-      className="h-2 w-2 shrink-0 rounded-full"
-      style={{ background: color }}
-    />
+    <span aria-hidden className="h-2 w-2 shrink-0 rounded-full" style={{ background: color }} />
   )
 }
 
@@ -115,12 +113,19 @@ export function FleetHealth() {
   const [issues, setIssues] = useState<FleetIssue[]>([])
   const [loaded, setLoaded] = useState(false)
 
+  const reads = useReadSequencer()
+
   const refresh = useCallback(async () => {
+    // The Refresh button races the 8s poll; sequenced so an older read can't land last and
+    // replace what the user just pulled with staler numbers.
+    const read = reads.beginRead()
     const [s, i] = await Promise.all([fetchFleetSummary(), fetchRecentIssues()])
-    setSummary(s)
-    setIssues(i)
-    setLoaded(true)
-  }, [])
+    if (read.isCurrent()) {
+      setSummary(s)
+      setIssues(i)
+    }
+    if (read.isNewestRead()) setLoaded(true)
+  }, [reads])
 
   useEffect(() => {
     void refresh()
@@ -154,7 +159,10 @@ export function FleetHealth() {
       <div className="flex-1 overflow-y-auto px-6 py-5">
         <div className="mx-auto flex max-w-[880px] flex-col gap-6">
           {/* Metric strip */}
-          <div className="grid gap-3" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}>
+          <div
+            className="grid gap-3"
+            style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))' }}
+          >
             <MetricCard
               label="Agents"
               value={String(summary?.totalAgents ?? 0)}
@@ -237,7 +245,10 @@ export function FleetHealth() {
                       {e.runtime ? (
                         <span className="text-foreground/45"> · {runtimeName(e.runtime)}</span>
                       ) : null}
-                      <span className="text-foreground/40"> · {e.ts ? formatRelative(e.ts) : ''}</span>
+                      <span className="text-foreground/40">
+                        {' '}
+                        · {e.ts ? formatRelative(e.ts) : ''}
+                      </span>
                       {e.message ? (
                         <div className="mt-0.5 text-foreground/60">{e.message}</div>
                       ) : null}

--- a/apps/web/src/features/governance/GovernancePanel.tsx
+++ b/apps/web/src/features/governance/GovernancePanel.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react'
 
 import { ToolApprovalQueue } from '@/features/approvals/ToolApprovalQueue'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 import { useToastStore } from '@/stores/toast'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { Button } from '@/features/shared/Button'
@@ -89,9 +90,7 @@ const STATUS_PILL: Record<Budget['status'], StatusTone> = {
 const SECTION_LABEL = 'font-mono text-[11px] font-semibold uppercase tracking-[0.14em]'
 
 function SectionKicker({ children }: { children: ReactNode }) {
-  return (
-    <div className={`${SECTION_LABEL} text-foreground/45`}>{children}</div>
-  )
+  return <div className={`${SECTION_LABEL} text-foreground/45`}>{children}</div>
 }
 
 // Card shell — the shared premium surface (rounded-2xl, hairline border, raised
@@ -130,16 +129,11 @@ function BudgetRow({ b, onChanged }: { b: Budget; onChanged: () => void }) {
           <span className="font-data rounded-full bg-foreground/[0.06] px-2 py-0.5 text-[10px] font-bold uppercase tracking-[0.04em] text-foreground/60">
             {b.scope}
           </span>
-          <span
-            className="font-data truncate text-[13px] text-foreground"
-            title={b.scopeId}
-          >
+          <span className="font-data truncate text-[13px] text-foreground" title={b.scopeId}>
             {b.scopeId}
           </span>
           {b.tenantId && (
-            <span className="font-data text-[11px] text-foreground/40">
-              · tenant {b.tenantId}
-            </span>
+            <span className="font-data text-[11px] text-foreground/40">· tenant {b.tenantId}</span>
           )}
         </span>
         <span className="flex items-center gap-1.5">
@@ -180,14 +174,9 @@ function BudgetRow({ b, onChanged }: { b: Budget; onChanged: () => void }) {
             / {dollars(b.limitUsdCents)}
           </span>
         </span>
-        <span className="font-data text-[12px] text-foreground/50">
-          {pct.toFixed(0)}%
-        </span>
+        <span className="font-data text-[12px] text-foreground/50">{pct.toFixed(0)}%</span>
       </div>
-      <div
-        className="overflow-hidden rounded-full bg-foreground/[0.08]"
-        style={{ height: 6 }}
-      >
+      <div className="overflow-hidden rounded-full bg-foreground/[0.08]" style={{ height: 6 }}>
         <div style={{ width: `${pct}%`, height: '100%', background: STATUS_TONE[b.status] }} />
       </div>
 
@@ -284,30 +273,45 @@ export function GovernancePanel() {
   // Default posture is track-and-warn (a hard cap is the explicit opt-in).
   const [newMode, setNewMode] = useState<BudgetMode>('warn')
 
+  // Budgets and the audit log are independent polls over independent state, so each gets
+  // its own sequencer — a budget write must not invalidate an in-flight audit read.
+  const budgetReads = useReadSequencer()
+  const auditReads = useReadSequencer()
+
   const refreshBudgets = useCallback(async () => {
+    const read = budgetReads.beginRead()
     const r = await listBudgets()
-    if (r.ok) {
-      setBudgets(r.budgets)
-      setBudgetsOk(true)
-    } else if (!budgetsLoadedRef.current) {
-      // Initial-load failure → error/retry. A transient poll failure after a
-      // good load keeps the last good snapshot (no blank-to-error flicker).
-      setBudgets([])
-      setBudgetsOk(false)
+    // Every budget write (create, raise cap, resume) reconciles through this read. A poll
+    // already in flight when one lands answers with the PRE-write rows, so applying it
+    // would show the old cap for up to 5s right after a success toast.
+    if (read.isCurrent()) {
+      if (r.ok) {
+        setBudgets(r.budgets)
+        setBudgetsOk(true)
+      } else if (!budgetsLoadedRef.current) {
+        // Initial-load failure → error/retry. A transient poll failure after a
+        // good load keeps the last good snapshot (no blank-to-error flicker).
+        setBudgets([])
+        setBudgetsOk(false)
+      }
     }
-    budgetsLoadedRef.current = true
-  }, [])
+    if (read.isNewestRead()) budgetsLoadedRef.current = true
+  }, [budgetReads])
 
   const refreshAudit = useCallback(async () => {
-    setAudit(
-      await listAudit({
-        agentId: auditAgent.trim() || undefined,
-        eventType: auditType || undefined,
-        since: auditSince ? Date.now() - auditSince : undefined,
-        limit: 200,
-      }),
-    )
-  }, [auditAgent, auditType, auditSince])
+    const read = auditReads.beginRead()
+    const rows = await listAudit({
+      agentId: auditAgent.trim() || undefined,
+      eventType: auditType || undefined,
+      since: auditSince ? Date.now() - auditSince : undefined,
+      limit: 200,
+    })
+    // The agent filter is an undebounced text input, so every keystroke fires a read.
+    // Applied by arrival order, the response for an earlier prefix can land last and
+    // leave the table showing rows that contradict the filter box.
+    if (!read.isCurrent()) return
+    setAudit(rows)
+  }, [auditAgent, auditType, auditSince, auditReads])
 
   useEffect(() => {
     void refreshBudgets()
@@ -371,10 +375,7 @@ export function GovernancePanel() {
                 </FormattedAlert>
               </div>
             ) : budgets.length === 0 ? (
-              <div
-                className="rounded-2xl border border-border bg-surface"
-                style={cardStyle}
-              >
+              <div className="rounded-2xl border border-border bg-surface" style={cardStyle}>
                 <EmptyState
                   icon={Wallet}
                   title="No budgets yet"
@@ -477,10 +478,7 @@ export function GovernancePanel() {
           {/* Approval queue (shared with the Approvals panel) */}
           <section className="flex flex-col gap-3">
             <SectionKicker>Approval queue</SectionKicker>
-            <div
-              className="rounded-2xl border border-border bg-surface p-2"
-              style={cardStyle}
-            >
+            <div className="rounded-2xl border border-border bg-surface p-2" style={cardStyle}>
               <ToolApprovalQueue showEmpty />
             </div>
           </section>
@@ -557,9 +555,7 @@ export function GovernancePanel() {
                         {a.agentId.slice(0, 10)}
                       </span>
                     )}
-                    <span className="truncate text-foreground/60">
-                      {summarize(a.summary)}
-                    </span>
+                    <span className="truncate text-foreground/60">{summarize(a.summary)}</span>
                     {a.tenantId && (
                       <span className="font-data whitespace-nowrap text-foreground/35">
                         · {a.tenantId}

--- a/apps/web/src/features/governance/__tests__/GovernancePanel.test.tsx
+++ b/apps/web/src/features/governance/__tests__/GovernancePanel.test.tsx
@@ -3,7 +3,7 @@
 // embedded <ToolApprovalQueue/> now always polls /api/tools/approvals, so every
 // test stubs that endpoint (msw onUnhandledRequest:'error' would fail otherwise).
 
-import { cleanup, render, screen, within } from '@testing-library/react'
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -62,6 +62,58 @@ describe('GovernancePanel', () => {
     expect(await screen.findByTestId('audit-row')).toBeInTheDocument()
     // A healthy under-limit budget shows no "will re-pause" badge.
     expect(screen.queryByTestId('budget-will-repause')).toBeNull()
+  })
+
+  it('ignores an audit response for an earlier filter prefix that lands late', async () => {
+    // The agent-id filter is an undebounced input, so every keystroke fires its own
+    // /api/governance/audit read. Applied by arrival order, the response for the shorter
+    // prefix can land last and leave the table showing rows the filter excludes.
+    let releaseShortPrefix: (() => void) | undefined
+    let shortPrefixAnswered = false
+    server.use(
+      http.get('/api/governance/budgets', () => HttpResponse.json({ budgets: [] })),
+      http.get('/api/governance/audit', async ({ request }) => {
+        const agentId = new URL(request.url).searchParams.get('agentId')
+        const row = (id: string, summary: string) => ({
+          id,
+          eventType: 'budget',
+          agentId,
+          taskId: null,
+          teamId: null,
+          tenantId: null,
+          summary,
+          createdAt: 0,
+        })
+        // Hold the one-character prefix open so it resolves AFTER the full filter's read.
+        if (agentId === 'a') {
+          await new Promise<void>((resolve) => {
+            releaseShortPrefix = resolve
+          })
+          shortPrefixAnswered = true
+          return HttpResponse.json({ audit: [row('stale', '{"prefix":"a"}')] })
+        }
+        return HttpResponse.json({ audit: [row('fresh', '{"prefix":"ab"}')] })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<GovernancePanel />)
+    await screen.findByTestId('governance-panel')
+
+    // Two keystrokes → a read for 'a' (parked) and a read for 'ab' (resolves).
+    await user.type(screen.getByPlaceholderText('agent id'), 'ab')
+    await waitFor(() => expect(screen.getByTestId('audit-row')).toHaveTextContent('prefix'))
+    await waitFor(() => expect(screen.getByTestId('audit-row')).toHaveTextContent('ab'))
+
+    // The earlier prefix's response now lands.
+    releaseShortPrefix?.()
+    await waitFor(() => expect(shortPrefixAnswered).toBe(true))
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0)) // flush fetch → json → setState
+    })
+
+    // The table still matches what is in the filter box.
+    expect(screen.getByTestId('audit-row')).toHaveTextContent('ab')
+    expect(screen.getByPlaceholderText('agent id')).toHaveValue('ab')
   })
 
   it('shows a "will re-pause" badge for a cap budget resumed while over its limit', async () => {

--- a/apps/web/src/features/health/SystemHealthPanel.tsx
+++ b/apps/web/src/features/health/SystemHealthPanel.tsx
@@ -15,6 +15,7 @@ import { StatusPill, type StatusTone } from '@/features/shared/StatusPill'
 import { FormattedAlert } from '@/features/shared/FormattedAlert'
 import { Spinner } from '@/features/shared/Spinner'
 import { ENTER_SPRING, listDelay } from '@/lib/motion'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 
 import { fetchHealth, recheckHealth, type BootCheck, type BootReport } from './healthClient'
 
@@ -63,10 +64,7 @@ function SectionCard({ title, children }: { title: string; children: ReactNode }
   return (
     <section className="mb-6">
       <div className={`${SECTION_LABEL} mb-2.5 text-foreground/45`}>{title}</div>
-      <div
-        className="rounded-2xl border border-border bg-surface px-4"
-        style={cardStyle}
-      >
+      <div className="rounded-2xl border border-border bg-surface px-4" style={cardStyle}>
         {children}
       </div>
     </section>
@@ -88,18 +86,30 @@ export function SystemHealthPanel() {
   const [error, setError] = useState<string | null>(null)
   const mountedRef = useRef(true)
 
-  const load = useCallback(async (recheck: boolean) => {
-    setLoading(true)
-    setError(null)
-    try {
-      const r = recheck ? await recheckHealth() : await fetchHealth()
-      if (mountedRef.current) setReport(r)
-    } catch (err) {
-      if (mountedRef.current) setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      if (mountedRef.current) setLoading(false)
-    }
-  }, [])
+  // The 30s poll and the manual Recheck share this one loader, so reads are sequenced
+  // last-write-wins: a poll already in flight when Recheck resolves would otherwise land
+  // afterwards with the PRE-recheck report and silently undo what the user just asked for.
+  const reads = useReadSequencer()
+
+  const load = useCallback(
+    async (recheck: boolean) => {
+      const read = reads.beginRead()
+      setLoading(true)
+      setError(null)
+      try {
+        const r = recheck ? await recheckHealth() : await fetchHealth()
+        if (mountedRef.current && read.isCurrent()) setReport(r)
+      } catch (err) {
+        if (mountedRef.current && read.isCurrent())
+          setError(err instanceof Error ? err.message : String(err))
+      } finally {
+        // Chrome, not data: only the newest read may clear the spinner, or an older one
+        // finishing first would drop it while the newer read is still running.
+        if (mountedRef.current && read.isNewestRead()) setLoading(false)
+      }
+    },
+    [reads],
+  )
 
   useEffect(() => {
     mountedRef.current = true
@@ -170,9 +180,8 @@ export function SystemHealthPanel() {
               {fatalCount > 0 ? (
                 <>
                   <strong>The install has a fatal problem.</strong> clawboo has no upgrade/repair
-                  path — reset{' '}
-                  <code className="font-data text-[11px]">~/.clawboo</code>{' '}
-                  and re-run onboarding to start clean.
+                  path — reset <code className="font-data text-[11px]">~/.clawboo</code> and re-run
+                  onboarding to start clean.
                 </>
               ) : (
                 <>
@@ -195,10 +204,7 @@ export function SystemHealthPanel() {
               <Spinner size={13} /> Running boot probe…
             </div>
           ) : (
-            <div
-              className="rounded-2xl border border-border bg-surface px-4"
-              style={cardStyle}
-            >
+            <div className="rounded-2xl border border-border bg-surface px-4" style={cardStyle}>
               {report?.checks.map((check, i) => {
                 const tone = toneFor(report, check)
                 const meta = TONE_META[tone]

--- a/apps/web/src/features/obs/ObsPanel.tsx
+++ b/apps/web/src/features/obs/ObsPanel.tsx
@@ -23,6 +23,7 @@ import { EmptyState } from '@/features/shared/EmptyState'
 import { PanelHeader } from '@/features/shared/PanelHeader'
 import { StatusPill, type StatusTone } from '@/features/shared/StatusPill'
 import { ENTER_SPRING, listDelay } from '@/lib/motion'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 
 import { EvalScorecard } from './EvalScorecard'
 
@@ -143,14 +144,20 @@ export function ObsPanel() {
   const [selectedTrace, setSelectedTrace] = useState<string | null>(null)
   const selRef = useRef<string | null>(null)
   selRef.current = selectedTrace
+  const reads = useReadSequencer()
 
   const refresh = useCallback(async () => {
+    // Four parallel reads plus a fifth sequential one on a 5s interval, raced by the
+    // Refresh button — so refreshes overlap and are sequenced last-write-wins, or an older
+    // one lands last and flaps every tile back to a staler snapshot.
+    const read = reads.beginRead()
     const [h, ev, er, g] = await Promise.all([
       getJson<{ agents: FleetAgent[] }>('/api/obs/health'),
       getJson<{ events: ObsEvent[] }>('/api/obs/events?order=desc&limit=300'),
       getJson<{ errors: ObsError[]; harnessBugCount: number }>('/api/obs/errors'),
       getJson<ProjectedGraph>('/api/obs/graph'),
     ])
+    if (!read.isCurrent()) return
     if (h) setHealth(h.agents)
     if (ev) setRecent(ev.events)
     if (er) {
@@ -161,9 +168,11 @@ export function ObsPanel() {
     const sel = selRef.current
     if (sel) {
       const t = await getJson<TraceResult>(`/api/obs/traces/${sel}`)
-      if (t) setTrace(t)
+      // Also re-check the SELECTION: picking another trace mid-flight must not be
+      // overwritten by the previous one's response arriving late.
+      if (t && read.isCurrent() && selRef.current === sel) setTrace(t)
     }
-  }, [])
+  }, [reads])
 
   useEffect(() => {
     void refresh()
@@ -197,8 +206,11 @@ export function ObsPanel() {
 
   const openTrace = useCallback(async (traceId: string) => {
     setSelectedTrace(traceId)
+    selRef.current = traceId // eagerly, so the check below sees this click, not the last render
     const t = await getJson<TraceResult>(`/api/obs/traces/${traceId}`)
-    setTrace(t)
+    // Clicking a second trace before this one resolved must win: the later selection is
+    // what the user is looking at, so an earlier trace arriving late is dropped.
+    if (selRef.current === traceId) setTrace(t)
   }, [])
 
   const depths = useMemo(
@@ -220,9 +232,7 @@ export function ObsPanel() {
         actions={
           <>
             <span className="font-data rounded-full bg-foreground/[0.06] px-2.5 py-0.5 text-[11px] font-semibold text-foreground/55">
-              {graph
-                ? `${graph.tasks.length} tasks · ${graph.agents.length} agents`
-                : 'event log'}
+              {graph ? `${graph.tasks.length} tasks · ${graph.agents.length} agents` : 'event log'}
             </span>
             <Button
               variant="secondary"
@@ -330,7 +340,10 @@ export function ObsPanel() {
             </div>
           </Section>
 
-          <Section title={`Traces (${traces.length})`} icon={<GitBranch size={13} strokeWidth={2} />}>
+          <Section
+            title={`Traces (${traces.length})`}
+            icon={<GitBranch size={13} strokeWidth={2} />}
+          >
             <div data-testid="obs-traces-list">
               {traces.length === 0 ? (
                 <EmptyState
@@ -391,9 +404,7 @@ export function ObsPanel() {
                 style={{ boxShadow: 'var(--shadow-raised)' }}
               >
                 <div className="mb-3 flex items-baseline gap-2 text-[12px] font-semibold">
-                  <span className="font-data text-foreground/70">
-                    {trace.traceId.slice(0, 24)}
-                  </span>
+                  <span className="font-data text-foreground/70">{trace.traceId.slice(0, 24)}</span>
                   <span className="font-data text-[11px] font-normal text-foreground/45">
                     {trace.events.length} events
                   </span>

--- a/apps/web/src/features/runtimes/OpenClawGatewaySection.tsx
+++ b/apps/web/src/features/runtimes/OpenClawGatewaySection.tsx
@@ -15,6 +15,7 @@ import { consumeApiSSE } from '@clawboo/control-client'
 import { Button } from '@/features/shared/Button'
 import { StatusPill } from '@/features/shared/StatusPill'
 import { useToastStore } from '@/stores/toast'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 
 const muted = (o: number) => `rgb(var(--foreground-rgb) / ${o})`
 
@@ -45,16 +46,21 @@ export function OpenClawGatewaySection({
   const [busy, setBusy] = useState<null | 'start' | 'restart'>(null)
   const sseRef = useRef<AbortController | null>(null)
 
+  const reads = useReadSequencer()
+
   const refresh = useCallback(async () => {
+    // Start / restart reconcile through this read, so it must not be overwritten by a 10s
+    // poll that was already in flight and still reports the pre-action gateway state.
+    const read = reads.beginRead()
     try {
       const data = (await fetch('/api/system/status').then((r) => r.json())) as {
         gateway?: GatewayState
       }
-      if (data.gateway) setGw(data.gateway)
+      if (data.gateway && read.isCurrent()) setGw(data.gateway)
     } catch {
       // non-fatal — the row's own status chip is the primary signal
     }
-  }, [])
+  }, [reads])
 
   useEffect(() => {
     void refresh()

--- a/apps/web/src/features/runtimes/RuntimesPanel.tsx
+++ b/apps/web/src/features/runtimes/RuntimesPanel.tsx
@@ -4,6 +4,7 @@ import { Cpu, RefreshCw, ChevronDown } from 'lucide-react'
 
 import { useConnectionStore } from '@/stores/connection'
 import { useSettingsModalStore } from '@/stores/settingsModal'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { Button } from '@/features/shared/Button'
 import { PanelHeader } from '@/features/shared/PanelHeader'
@@ -157,6 +158,7 @@ export function RuntimesPanel() {
   // The standalone OpenClaw setup flow (detect → install → configure → start),
   // launched from the OpenClaw tab's "Set up OpenClaw" CTA when not connected.
   const [setupOpen, setSetupOpen] = useState(false)
+  const reads = useReadSequencer()
 
   // A one-shot intent from elsewhere (a disabled OpenClaw option in CreateTeamModal)
   // lands the user here directly in the OpenClaw Gateway setup flow.
@@ -175,7 +177,13 @@ export function RuntimesPanel() {
   // Each 8s poll appends a sample to the per-runtime probe ring buffer so the
   // diagnostics drawer can render a "last N checks" timeline (no server store).
   const refresh = useCallback(async () => {
+    // Three sequential round trips on an 8s interval, so refreshes genuinely overlap —
+    // and the drawer's Recheck merges a single runtime straight into `statuses`. Sequenced
+    // last-write-wins so an older refresh can neither flap the connection badges back nor
+    // overwrite a just-rechecked runtime with its pre-recheck health.
+    const read = reads.beginRead()
     const next = await fetchRuntimes()
+    if (!read.isCurrent()) return
     setStatuses(next)
     setLoaded(true)
     const record = useRuntimeProbeStore.getState().record
@@ -185,6 +193,7 @@ export function RuntimesPanel() {
     // The server's OpenClaw operator connection — the thin-client signal (no
     // browser Gateway WS needed). Defensive: disconnected on any error.
     const health = await fetchRegistryHealth()
+    if (!read.isCurrent()) return // re-checked per hop: each await is its own staleness window
     const srvConn = health.connection === 'connected'
     setServerOpenclawConnected(srvConn)
     // OpenClaw's own ChatGPT-subscription oauth profile (defensive: false on any
@@ -193,6 +202,7 @@ export function RuntimesPanel() {
     const cfg = (await fetch('/api/system/openclaw-config')
       .then((r) => (r.ok ? r.json() : null))
       .catch(() => null)) as { config?: unknown; codexAuth?: { profile?: boolean } } | null
+    if (!read.isCurrent()) return
     setOpenclawSubConnected(!!cfg?.codexAuth?.profile)
     // `config` is the parsed openclaw.json (null when never set up) — the "was
     // configured" signal, independent of whether the gateway is currently up.
@@ -204,7 +214,7 @@ export function RuntimesPanel() {
       ok: ocOk,
       message: ocOk ? 'connected' : conn.status === 'connected' ? 'not connected' : conn.status,
     })
-  }, [])
+  }, [reads])
 
   useEffect(() => {
     void refresh()
@@ -280,6 +290,7 @@ export function RuntimesPanel() {
     if (!diagId) return
     const s = await recheckRuntime(diagId as RuntimeId)
     if (s) {
+      reads.commitLocalWrite() // a refresh already in flight carries this runtime's OLD health
       setStatuses((prev) => prev.map((x) => (x.id === s.id ? s : x)))
       useRuntimeProbeStore
         .getState()

--- a/apps/web/src/features/runtimes/RuntimesPanel.tsx
+++ b/apps/web/src/features/runtimes/RuntimesPanel.tsx
@@ -288,9 +288,14 @@ export function RuntimesPanel() {
       return
     }
     if (!diagId) return
+    // `recheckRuntime` reads the SAME GET /api/runtimes as `refresh`, narrowed to one id
+    // client-side — it is not a stronger forced probe. So it takes a read token like any
+    // other read: if a refresh (or a later recheck) has since applied a newer answer from
+    // that endpoint, this one is older and merging it would revert the fresher value.
+    const read = reads.beginRead()
     const s = await recheckRuntime(diagId as RuntimeId)
-    if (s) {
-      reads.commitLocalWrite() // a refresh already in flight carries this runtime's OLD health
+    if (s && read.isCurrent()) {
+      reads.commitLocalWrite() // upholds the invariant: every local write to `statuses` fences
       setStatuses((prev) => prev.map((x) => (x.id === s.id ? s : x)))
       useRuntimeProbeStore
         .getState()

--- a/apps/web/src/features/runtimes/__tests__/RuntimesPanel.test.tsx
+++ b/apps/web/src/features/runtimes/__tests__/RuntimesPanel.test.tsx
@@ -177,6 +177,64 @@ describe('RuntimesPanel', () => {
     expect(await screen.findByTestId('runtime-clawboo-native-details')).toBeInTheDocument()
   })
 
+  it('drops a drawer recheck whose answer is older than an applied refresh', async () => {
+    // `recheckRuntime` narrows the SAME GET /api/runtimes the 8s poll reads, so the two
+    // overlap and the later-issued answer must win. Here the recheck is issued first but
+    // resolves last: merging it would revert the runtime to the pre-refresh state that the
+    // user is staring at in the diagnostics drawer.
+    let calls = 0
+    let releaseRecheck: (() => void) | undefined
+    let recheckAnswered = false
+    const runtime = (connectionState: string) => ({
+      runtimes: [{ id: 'clawboo-native', connectionState, capabilities: {}, health: { ok: true } }],
+      available: [],
+    })
+    server.use(
+      http.get('/api/runtimes', async () => {
+        calls += 1
+        // Call 2 is the drawer recheck: parked, and answers with the PRE-refresh state.
+        if (calls === 2) {
+          await new Promise<void>((resolve) => {
+            releaseRecheck = resolve
+          })
+          recheckAnswered = true
+          return HttpResponse.json(runtime('ready'))
+        }
+        // Call 1 is the mount refresh; call 3+ is the header Refresh, which has newer news.
+        return HttpResponse.json(runtime(calls === 1 ? 'ready' : 'needs-login'))
+      }),
+    )
+    const user = userEvent.setup()
+    render(<RuntimesPanel />)
+
+    await user.click(await screen.findByTestId('runtime-clawboo-native-details'))
+    const drawer = await screen.findByTestId('runtime-diagnostics-drawer')
+    expect(drawer).toHaveTextContent('Connected')
+
+    // Start the recheck (parks), then let a refresh land with the newer state.
+    await user.click(screen.getByTestId('runtime-diagnostics-recheck'))
+    await waitFor(() => expect(calls).toBe(2))
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-diagnostics-drawer')).toHaveTextContent('Needs login'),
+    )
+
+    // The stale recheck now answers 'ready'.
+    releaseRecheck?.()
+    await waitFor(() => expect(recheckAnswered).toBe(true))
+    // `recheckAnswered` only proves the SERVER replied — asserting here could run before the
+    // client finished the fetch → json → setStatuses chain, so a regressed guard would slip
+    // through. The drawer re-enables Re-check only after `await onRecheck()` returns, which
+    // is causally downstream of that whole chain: wait for that instead of a fixed delay.
+    await waitFor(() => expect(screen.getByTestId('runtime-diagnostics-recheck')).toBeEnabled(), {
+      timeout: 3000,
+    })
+
+    // It is discarded — the drawer keeps the fresher state.
+    expect(screen.getByTestId('runtime-diagnostics-drawer')).toHaveTextContent('Needs login')
+    expect(screen.getByTestId('runtime-diagnostics-drawer')).not.toHaveTextContent('Connected')
+  })
+
   it('the disconnected OpenClaw row carries Set up + the MCP attach config', async () => {
     useConnectionStore.setState({ status: 'disconnected', client: null })
     server.use(http.get('/api/runtimes', () => HttpResponse.json({ runtimes: [], available: [] })))

--- a/apps/web/src/features/scheduler/SchedulerPanel.tsx
+++ b/apps/web/src/features/scheduler/SchedulerPanel.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/lib/schedulesClient'
 import { useToastStore } from '@/stores/toast'
 import { confirm } from '@/stores/confirm'
+import { useReadSequencer } from '@/lib/useReadSequencer'
 
 import { canScheduleOwnLife, formatScheduleLabel } from './scheduleHelpers'
 import { RuntimeGlyph } from '../runtimes/runtimeDepth'
@@ -186,7 +187,9 @@ function ScheduleRow({ rec, onChanged }: { rec: ScheduleRecord; onChanged: () =>
               void (async () => {
                 if (
                   !(await confirm({
-                    title: ownLife ? 'Delete this Gateway cron job?' : 'Delete this scheduled routine?',
+                    title: ownLife
+                      ? 'Delete this Gateway cron job?'
+                      : 'Delete this scheduled routine?',
                     message: ownLife
                       ? "It removes the agent's own scheduled wake on the OpenClaw Gateway."
                       : 'It is removed permanently.',
@@ -427,12 +430,7 @@ function ScheduleDialog({ onClose, onCreated }: { onClose: () => void; onCreated
         <Field label="Runs">
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
             {CRON_PRESETS.map((p) => (
-              <Chip
-                key={p.cron}
-                active={cron === p.cron}
-                onClick={() => setCron(p.cron)}
-                size="sm"
-              >
+              <Chip key={p.cron} active={cron === p.cron} onClick={() => setCron(p.cron)} size="sm">
                 {p.label}
               </Chip>
             ))}
@@ -493,12 +491,20 @@ export function SchedulerPanel() {
   const [loaded, setLoaded] = useState(false)
   const [showDialog, setShowDialog] = useState(false)
 
+  const reads = useReadSequencer()
+
   const refresh = useCallback(async () => {
+    // Every row action (pause / resume / run-now) and the create dialog reconcile through
+    // this read, and the Refresh button races the 8s poll. Sequenced last-write-wins so a
+    // read issued before a toggle can't land after it and show the pre-toggle state.
+    const read = reads.beginRead()
     const view = await fetchSchedules()
-    setSchedules(view.schedules)
-    setSources(view.sources)
-    setLoaded(true)
-  }, [])
+    if (read.isCurrent()) {
+      setSchedules(view.schedules)
+      setSources(view.sources)
+    }
+    if (read.isNewestRead()) setLoaded(true)
+  }, [reads])
 
   useEffect(() => {
     void refresh()

--- a/apps/web/src/lib/__tests__/useReadSequencer.test.tsx
+++ b/apps/web/src/lib/__tests__/useReadSequencer.test.tsx
@@ -1,0 +1,78 @@
+// The two-counter staleness contract every polling panel depends on. Exercised here
+// directly (rather than only through a panel) because the interesting cases are orderings
+// that are awkward to stage through a UI: a local commit that starts no new read, and the
+// deliberate split between gating DATA and gating LOADING CHROME.
+
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useReadSequencer } from '../useReadSequencer'
+
+describe('useReadSequencer', () => {
+  it('lets a lone read write', () => {
+    const { result } = renderHook(() => useReadSequencer())
+    const read = result.current.beginRead()
+    expect(read.isNewestRead()).toBe(true)
+    expect(read.isCurrent()).toBe(true)
+  })
+
+  it('supersedes an older read as soon as a newer one begins', () => {
+    const { result } = renderHook(() => useReadSequencer())
+    const first = result.current.beginRead()
+    const second = result.current.beginRead()
+
+    // The older read may write nothing — not the data, not the loading chrome.
+    expect(first.isCurrent()).toBe(false)
+    expect(first.isNewestRead()).toBe(false)
+    // Whichever order they RESOLVE in, only the newest may write.
+    expect(second.isCurrent()).toBe(true)
+    expect(second.isNewestRead()).toBe(true)
+  })
+
+  it('fences an in-flight read on a local commit that starts no new read', () => {
+    // The case a plain generation counter misses: a drag that PATCHes and commits, or an
+    // optimistic list removal. No newer read exists, so the in-flight read is still the
+    // newest — only writeSeq can tell that its snapshot predates the commit.
+    const { result } = renderHook(() => useReadSequencer())
+    const read = result.current.beginRead()
+
+    result.current.commitLocalWrite()
+
+    expect(read.isCurrent()).toBe(false) // data: stale, must be dropped
+    expect(read.isNewestRead()).toBe(true) // chrome: still the newest read, so it settles
+  })
+
+  it('does not fence a read issued AFTER the local commit', () => {
+    const { result } = renderHook(() => useReadSequencer())
+    result.current.commitLocalWrite()
+    const read = result.current.beginRead()
+    expect(read.isCurrent()).toBe(true)
+  })
+
+  it('keeps consecutive local commits from resurrecting an intervening read', () => {
+    // Two commits in a row (e.g. two quick drags) with a read issued between them: the
+    // read predates the second commit, so it stays stale rather than reverting it.
+    const { result } = renderHook(() => useReadSequencer())
+    result.current.commitLocalWrite()
+    const read = result.current.beginRead()
+    result.current.commitLocalWrite()
+    expect(read.isCurrent()).toBe(false)
+  })
+
+  it('is referentially stable across re-renders so it never re-creates a poll', () => {
+    const { result, rerender } = renderHook(() => useReadSequencer())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it('keeps counters per hook instance', () => {
+    const a = renderHook(() => useReadSequencer())
+    const b = renderHook(() => useReadSequencer())
+    const readA = a.result.current.beginRead()
+    b.result.current.beginRead()
+    b.result.current.commitLocalWrite()
+    // One panel's activity must not invalidate another panel's in-flight read.
+    expect(readA.isCurrent()).toBe(true)
+  })
+})

--- a/apps/web/src/lib/useReadSequencer.ts
+++ b/apps/web/src/lib/useReadSequencer.ts
@@ -1,0 +1,99 @@
+// Last-write-wins sequencing for a poll that overlaps itself.
+//
+// Every polling panel in the dashboard has more than one read in the air routinely:
+// the interval fires again before the previous response landed, a Refresh button races
+// the tick, and a mutation kicks a reconcile read. Applying each response as it arrives
+// makes the view last-ARRIVAL-wins instead of last-REQUEST-wins, so an older snapshot
+// can land last and revert newer state. Observed symptoms: a just-created card blanked,
+// a committed drag snapped back to its old column, an optimistically-removed approval
+// resurrected, a manual "Recheck" result reverted, and search-as-you-type results that
+// contradict the filter box.
+//
+// TWO counters, because a read goes stale in two independent ways:
+//
+//   readId    A NEWER READ began. The older one must not write anything — not the data,
+//             and not the loading chrome (clearing a spinner while a newer read is still
+//             running, or dismissing a skeleton over the previous scope's data).
+//
+//   writeSeq  A LOCAL COMMIT landed after the read was issued, so the response predates
+//             it and cannot possibly reflect it. This is NOT redundant with readId: a
+//             local commit often starts no new read at all (a drag that PATCHes then
+//             commits, an optimistic list removal), which leaves the in-flight read
+//             still the newest and therefore invisible to readId alone.
+//
+// Usage — claim the token BEFORE the first await, so a commit made in the same tick as
+// the call is already fenced off:
+//
+//   const reads = useReadSequencer()
+//
+//   const refresh = useCallback(async () => {
+//     const read = reads.beginRead()
+//     const data = await fetchThing()
+//     if (!read.isCurrent()) return            // stale snapshot → drop it
+//     setThing(data)
+//     if (read.isNewestRead()) setLoaded(true) // loading chrome: newest read only
+//   }, [reads])
+//
+//   // ...and at EVERY local write of the polled state:
+//   reads.commitLocalWrite()
+//   setThing((prev) => …)
+//
+// Dropping a stale response is safe: the poll re-reads within its interval, so the view
+// converges on the next tick instead of flickering backwards on this one.
+//
+// `reads` is referentially stable, so adding it to a `useCallback`/`useEffect` dep array
+// never re-creates a poll interval.
+
+import { useMemo, useRef } from 'react'
+
+/** A single read's claim on the right to write state. Obtained from `beginRead()`. */
+export interface ReadToken {
+  /**
+   * No newer read has begun since this one. Gates the LOADING CHROME (spinner,
+   * skeleton) — deliberately ignores local commits, because a commit does not mean a
+   * newer read is coming, and gating chrome on it would strand a spinner until the
+   * next poll tick.
+   */
+  isNewestRead(): boolean
+  /**
+   * No newer read began AND no local commit landed since this read was issued. Gates
+   * the DATA. False ⇒ this response is a stale snapshot; return without writing.
+   */
+  isCurrent(): boolean
+}
+
+export interface ReadSequencer {
+  /** Claim the next read id. Call synchronously, before the first `await`. */
+  beginRead(): ReadToken
+  /**
+   * Fence off every read currently in flight, because state just changed locally
+   * (an optimistic update, or a mutation committed into the polled state). Call it
+   * immediately before the local `setState`.
+   */
+  commitLocalWrite(): void
+}
+
+export function useReadSequencer(): ReadSequencer {
+  const readIdRef = useRef(0)
+  const writeSeqRef = useRef(0)
+
+  // Stable for the component's lifetime — refs are mutable, so nothing here needs to
+  // change identity, and a stable object keeps callers' dep arrays honest and cheap.
+  return useMemo(
+    () => ({
+      beginRead(): ReadToken {
+        const readId = ++readIdRef.current
+        const writeSeq = writeSeqRef.current
+        const isNewestRead = (): boolean => readId === readIdRef.current
+        return {
+          isNewestRead,
+          isCurrent: () => isNewestRead() && writeSeq === writeSeqRef.current,
+        }
+      },
+      commitLocalWrite(): void {
+        writeSeqRef.current += 1
+      },
+    }),
+    [],
+  )
+}

--- a/docs/using/board.md
+++ b/docs/using/board.md
@@ -42,6 +42,8 @@ The board renders **seven columns**, one per task status, in lifecycle order:
 
 Each column shows its label and a live count of the tasks in it. The panel header shows a total task count (`{N} tasks`) and polls `GET /api/board` every five seconds, so status changes and new tasks appear without a manual refresh. A **Refresh** button forces an immediate re-fetch.
 
+Those reads overlap on purpose (the poll, the Refresh button, and the reconcile that follows a manual create all share one path), so they are **sequenced**: a response may only update the board while it is still the newest read and no local change has been committed since it was issued. A read that resolves out of order is discarded and the next poll reconciles instead, so a card you just created or dragged is never briefly reverted by a request that was already in flight.
+
 Because the board is a live projection of agent activity — cards are created and moved by agents as they work — a one-line hint under the header (_"AI agents continuously create and move work. You can also manage tasks manually."_) sets that expectation up front. The manual path is real, though, and there are three ways to drive the board by hand: a **New task** button in the header opens a composer, each task's status is editable from its [detail drawer](#the-task-detail-drawer), and you can **drag a card between columns** (see below).
 
 A task whose status falls outside the canonical seven is not silently dropped; an **Other** column is appended only when such a task exists, so off-list statuses stay visible and counted.
@@ -54,7 +56,7 @@ A genuinely empty board (loaded fine, zero tasks) shows one **"No tasks yet"** e
 
 ## Creating a task manually
 
-The header's **New task** button opens a small composer for adding work to the board by hand — the human counterpart to agent delegation. It collects a **title** (required), an optional **description**, a **team** (prefilled from the active team filter), and an initial **status** (**To do** by default, or **Backlog** for triage), then writes it through `POST /api/board`. On success the task appears on the board immediately (optimistically, then reconciled by the next poll) and a toast confirms it; a failed write keeps the composer open and toasts the error. Once on the board, a manually-created task is indistinguishable from a delegated one — an agent can claim and run it normally.
+The header's **New task** button opens a small composer for adding work to the board by hand — the human counterpart to agent delegation. It collects a **title** (required), an optional **description**, a **team** (prefilled from the active team filter), and an initial **status** (**To do** by default, or **Backlog** for triage), then writes it through `POST /api/board`. On success the task appears on the board immediately (optimistically, then reconciled by the next poll) and a toast confirms it; a poll that was already in flight when the task was created is discarded rather than blanking the new card. A failed write keeps the composer open and toasts the error. Once on the board, a manually-created task is indistinguishable from a delegated one — an agent can claim and run it normally.
 
 ## Moving a task by drag-and-drop
 
@@ -62,7 +64,7 @@ Each card has a **grip handle** (top-right, visible on hover or keyboard focus).
 
 - **Only legal moves are offered.** Mid-drag, columns the card can't legally transition to (per the [state machine](/concepts/the-board)) are dimmed and won't accept a drop; terminal cards (`done` / `cancelled`) and off-list **Other** cards aren't draggable at all.
 - **The agent-release guard still applies.** Dragging an _assigned_ task to **To do** — which unassigns its agent — asks for confirmation first, exactly as the drawer editor does.
-- **Optimistic + poll-safe.** The card moves instantly and is reconciled against the server; a rejected move (e.g. a `→ done` verification gate) rolls back with a toast, and an in-flight move isn't reverted by the five-second poll.
+- **Optimistic + poll-safe.** The card moves instantly and is reconciled against the server; a rejected move (e.g. a `→ done` verification gate) rolls back with a toast. Neither an in-flight move nor a just-committed one is reverted by the five-second poll, including a poll already in flight when the move landed.
 - **Keyboard and touch.** Focus a card's handle and press **Space** to pick it up, **arrow keys** to choose a column, **Space** to drop, **Escape** to cancel; touch drag is supported too.
 
 Clicking a card (rather than its handle) still opens the detail drawer — a click and a drag don't conflict.

--- a/docs/using/governance-dashboard.md
+++ b/docs/using/governance-dashboard.md
@@ -122,7 +122,7 @@ The budget routes accept fields the panel does not surface directly:
 
 - **A new/raised budget** appears (or updates) in the Budgets list within the 5-second poll; its `spent / cap` line, percentage, and mode/status pills reflect the change. You can confirm directly with `curl http://localhost:18790/api/governance/budgets` (use your resolved API port).
 - **A resumed scope** flips its status pill from `paused` (red) back to `active` (mint). If it shows `will re-pause`, raise the cap.
-- **A resolved approval** disappears from the Approval queue on the next 3-second refetch.
+- **A resolved approval** disappears from the Approval queue immediately, and stays gone: a refetch that was already in flight when you decided still lists it, and is discarded rather than briefly restoring the card.
 - **An audit entry** for the action lands in the Audit log, e.g. setting/raising a `cap`-mode budget that later crosses produces `budget` events; a cap hit produces `cap_hit`; a verification produces `verification`.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

* Introduces `useReadSequencer` to coordinate asynchronous read operations and ensure only the latest responses update application state.
* Applies the shared sequencing mechanism across multiple panels and hooks to prevent stale responses from overwriting newer data during concurrent requests.
* Expands test coverage to verify outdated responses are ignored, improving UI consistency during rapid state changes.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [x] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — internal state management refactor)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated refresh results from overwriting newer data across approvals, boards, fleet health, governance, system health, observability, runtimes, and scheduling.
  * Resolved approvals remain hidden after dismissal instead of briefly reappearing.
  * Preserved board changes, including newly created or moved tasks and team filters, during concurrent refreshes.
  * Ensured loading indicators reflect the most recent request.
  * Prevented outdated trace selections and runtime diagnostics from replacing fresher results.

* **Documentation**
  * Clarified refresh behavior, optimistic updates, and approval dismissal guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #105