### PR TITLE
fix(web): reflect live WebSocket connection state in the UI

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,7 @@ import { AppTopBar } from '@/features/promo/AppTopBar'
 import { SettingsModal } from '@/features/settings/SettingsModal'
 import { ConfirmDialog } from '@/features/shared/ConfirmDialog'
 import { useViewStore } from '@/stores/view'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 import { shouldShowGlobalTopBar } from '@/lib/topBar'
 
@@ -19,8 +19,9 @@ export function App() {
   const isBooZero = viewMode.type === 'booZero'
   const columnCollapsed = useViewStore((s) => s.columnCollapsed)
   // The first-run nudge only belongs on the settled dashboard (status 'connected'
-  // in both gateway and native mode), never over the onboarding wizard.
-  const onDashboard = useConnectionStore((s) => s.status === 'connected')
+  // in both gateway and native mode), never over the onboarding wizard. Uses the
+  // live-session predicate so a transient socket drop does not unmount these.
+  const onDashboard = useConnectionStore((s) => isSessionLive(s.status))
   // While the Settings modal is open, the whole app shell is inert so
   // background controls leave the tab order + AT tree (honouring aria-modal).
   const settingsOpen = useSettingsModalStore((s) => s.open)

--- a/apps/web/src/__vitest__/fakeGatewayClient.ts
+++ b/apps/web/src/__vitest__/fakeGatewayClient.ts
@@ -1,0 +1,61 @@
+// A minimal stand-in for a live `GatewayClient`, for tests that need to drive
+// socket-status transitions (the `useGatewayEvents` mirror, the live-reconnect
+// banner) without a real WebSocket.
+//
+// `useGatewayEvents` touches exactly two client methods — `onEvent` and
+// `onStatus` — so that is all this implements, plus a `disconnect` spy for the
+// paths that tear a client down.
+//
+// FIDELITY NOTE: the real `onStatus` (gateway-client `client.ts:102-106`) invokes
+// the handler SYNCHRONOUSLY at subscribe time, replaying the current status. This
+// fake does the same. Without that replay the mirror's "unchanged → no write"
+// branch is never exercised and a regression there would slip through.
+
+import { vi } from 'vitest'
+import type { ConnectionStatus, GatewayClient } from '@clawboo/gateway-client'
+
+export interface FakeGatewayClient {
+  /** Pass this where a real `GatewayClient` is expected. */
+  client: GatewayClient
+  /** Drive a socket transition, the way `updateStatus` fans out. */
+  emit: (next: ConnectionStatus) => void
+  /** Live `onStatus` subscriber count — 0 proves cleanup ran. */
+  statusSubscribers: () => number
+  /** Live `onEvent` subscriber count. */
+  eventSubscribers: () => number
+  disconnect: ReturnType<typeof vi.fn>
+}
+
+export function makeFakeGatewayClient(initial: ConnectionStatus = 'connected'): FakeGatewayClient {
+  const statusHandlers = new Set<(s: ConnectionStatus) => void>()
+  const eventHandlers = new Set<(frame: unknown) => void>()
+  let current = initial
+  const disconnect = vi.fn()
+
+  const client = {
+    get status() {
+      return current
+    },
+    onStatus(handler: (s: ConnectionStatus) => void) {
+      statusHandlers.add(handler)
+      handler(current) // replay, mirroring the real client
+      return () => statusHandlers.delete(handler)
+    },
+    onEvent(handler: (frame: unknown) => void) {
+      eventHandlers.add(handler)
+      return () => eventHandlers.delete(handler)
+    },
+    disconnect,
+  } as unknown as GatewayClient
+
+  return {
+    client,
+    emit: (next) => {
+      current = next
+      for (const h of [...statusHandlers]) h(next)
+    },
+    statusSubscribers: () => statusHandlers.size,
+    eventSubscribers: () => eventHandlers.size,
+    disconnect,
+  }
+}

--- a/apps/web/src/features/agent-detail/AgentDetailView.tsx
+++ b/apps/web/src/features/agent-detail/AgentDetailView.tsx
@@ -7,6 +7,7 @@ import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { ChatPanel } from '@/features/chat/ChatPanel'
 import { ResizeHandle } from '@/features/shared/ResizeHandle'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
+import { connectionStatusLabel } from '@/features/connection/connectionStatusDisplay'
 import { useNativeRuntimeState } from '@/features/runtimes/useNativeRuntimeState'
 import { Spinner } from '@/features/shared/Spinner'
 
@@ -106,10 +107,14 @@ export function AgentDetailView({ agentId }: { agentId: string }) {
                   'inline-block h-1.5 w-1.5 rounded-full',
                   connectionStatus === 'connected'
                     ? 'bg-mint shadow-[0_0_6px_rgb(var(--mint-rgb)/0.6)]'
-                    : 'bg-amber/70',
+                    : // A retrying socket pulses — it distinguishes "coming back"
+                      // from a flat "not connected".
+                      connectionStatus === 'reconnecting'
+                      ? 'bg-amber/70 animate-pulse'
+                      : 'bg-amber/70',
                 ].join(' ')}
               />
-              {connectionStatus === 'connected' ? 'Connected' : connectionStatus}
+              {connectionStatusLabel(connectionStatus)}
             </span>
           )}
         </div>

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -3,7 +3,7 @@ import type { TranscriptEntry } from '@clawboo/protocol'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { useFleetStore } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { useBooZeroStore } from '@/stores/booZero'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 import { useTeamStore } from '@/stores/team'
@@ -18,6 +18,10 @@ import {
   MessageComposer,
   type MessageComposerHandle,
 } from './chatComponents'
+import {
+  connectionStatusLabel,
+  connectionStatusTone,
+} from '@/features/connection/connectionStatusDisplay'
 import { InlineApprovalTray } from '@/features/approvals/InlineApprovalTray'
 import { parseTeamOrAgentMention } from '@/lib/parseTeamOrAgentMention'
 import { buildBooZeroRulesBlock } from '@/lib/booZeroRules'
@@ -109,15 +113,20 @@ export function ChatPanel({
   // null (probe pending/failed) never degrades the UI.
   const nativeState = useNativeRuntimeState(isNativeChat)
   const nativeKeyless = isNativeChat && nativeState === 'needs-auth'
-  // A native chat needs NO Gateway client; an OpenClaw chat does.
-  const canSend = Boolean(
-    (isNativeChat || client) &&
-    connectionStatus === 'connected' &&
-    agent &&
-    sessionKey &&
-    !isRunning &&
-    !nativeKeyless,
-  )
+  // A native chat rides the SERVER's SSE — no Gateway client, and a dropped
+  // Gateway socket is irrelevant to it, so `reconnecting` must not gate it off
+  // (mixed fleets are real: `hydrateFleetFromClient` merges non-OpenClaw agents
+  // into a Gateway-connected fleet). An OpenClaw chat needs BOTH a live client
+  // and a live socket, so a mid-session drop gates its composer until the WS is
+  // back — the send could not land anyway.
+  const transportReady = isNativeChat
+    ? isSessionLive(connectionStatus)
+    : Boolean(client) && connectionStatus === 'connected'
+  const canSend = Boolean(transportReady && agent && sessionKey && !isRunning && !nativeKeyless)
+  // The composer is live but the socket is not: say so, rather than leaving a
+  // silently-dead "Message…" box.
+  const gatewayReconnecting = !isNativeChat && connectionStatus === 'reconnecting'
+  const connectionTone = connectionStatusTone(connectionStatus)
 
   const booZeroAgentId = useBooZeroStore((s) => s.booZeroAgentId)
   const teams = useTeamStore((s) => s.teams)
@@ -292,17 +301,25 @@ export function ChatPanel({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <span
-              className={`h-1.5 w-1.5 rounded-full ${nativeKeyless ? 'bg-amber/80' : connectionStatus === 'connected' ? 'bg-mint' : 'bg-foreground/25'}`}
+              className={`h-1.5 w-1.5 rounded-full ${
+                nativeKeyless
+                  ? 'bg-amber/80'
+                  : connectionTone === 'live'
+                    ? 'bg-mint'
+                    : connectionTone === 'warn'
+                      ? 'bg-amber/80 animate-pulse'
+                      : 'bg-foreground/25'
+              }`}
               aria-hidden
             />
+            {/* The DOT carries the reconnect signal (amber + pulse); the label
+                keeps the standard muted tone. Same split as AgentDetailView, and
+                it keeps `nativeKeyless` — a real error — as the only state that
+                colours the text. */}
             <span
-              className={`font-mono text-[10px] uppercase tracking-[0.1em] ${nativeKeyless ? 'text-amber/90' : 'text-foreground/45'}`}
+              className={`font-mono text-[10px] uppercase tracking-[0.1em] ${nativeKeyless ? 'text-amber/90' : 'text-muted-foreground'}`}
             >
-              {nativeKeyless
-                ? 'Disconnected'
-                : connectionStatus === 'connected'
-                  ? 'Connected'
-                  : connectionStatus}
+              {nativeKeyless ? 'Disconnected' : connectionStatusLabel(connectionStatus)}
             </span>
             {nativeKeyless && (
               <button
@@ -369,15 +386,17 @@ export function ChatPanel({
             ? 'Clawboo Native is disconnected — set it up in Settings → Runtimes…'
             : !isNativeChat && !client
               ? 'Gateway not connected…'
-              : !sessionKey
-                ? 'No active session…'
-                : isRunning
-                  ? isNativeChat
-                    ? 'Thinking…'
-                    : 'Agent is working…'
-                  : isBooZeroChat
-                    ? 'Ask me anything… use @ to tag a team'
-                    : 'Message…'
+              : gatewayReconnecting
+                ? 'Reconnecting to Gateway…'
+                : !sessionKey
+                  ? 'No active session…'
+                  : isRunning
+                    ? isNativeChat
+                      ? 'Thinking…'
+                      : 'Agent is working…'
+                    : isBooZeroChat
+                      ? 'Ask me anything… use @ to tag a team'
+                      : 'Message…'
         }
       />
     </div>

--- a/apps/web/src/features/chat/__tests__/ChatPanel.reconnectGating.test.tsx
+++ b/apps/web/src/features/chat/__tests__/ChatPanel.reconnectGating.test.tsx
@@ -1,0 +1,106 @@
+// Composer gating across a live Gateway drop. The two runtimes must diverge here:
+// an OpenClaw chat rides the browser's Gateway socket, so a send cannot land while
+// it is down; a native chat is driven server-side over SSE and is unaffected.
+// Gating both (which a naive `status === 'connected'` check does) would disable a
+// native composer for a reason that has nothing to do with it — and mixed fleets
+// are real, since the Gateway hydrate merges non-OpenClaw agents in.
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { useBooZeroStore } from '@/stores/booZero'
+import { useChatStore } from '@/stores/chat'
+import { useConnectionStore, type ConnectionStatus } from '@/stores/connection'
+import { useFleetStore, type AgentState } from '@/stores/fleet'
+import { useTeamStore } from '@/stores/team'
+import { ThemeProvider } from '@/features/theme/ThemeProvider'
+import { makeFakeGatewayClient } from '@/__vitest__/fakeGatewayClient'
+import { server } from '@/__vitest__/mswServer'
+
+import { ChatPanel } from '../ChatPanel'
+
+function agent(runtime: AgentState['runtime']): AgentState {
+  return {
+    id: 'a1',
+    name: 'Test Boo',
+    status: 'idle',
+    sessionKey: 'agent:a1:main',
+    model: null,
+    createdAt: 0,
+    streamingText: null,
+    runId: null,
+    lastSeenAt: null,
+    teamId: null,
+    runtime,
+    execConfig: null,
+  }
+}
+
+function seed(runtime: AgentState['runtime'], status: ConnectionStatus): void {
+  useFleetStore.setState({ agents: [agent(runtime)], selectedAgentId: 'a1' })
+  // A live client is present throughout: the drop is a SOCKET state, not a
+  // missing client, so `!client` cannot be what gates the composer.
+  useConnectionStore.setState({
+    status,
+    client: makeFakeGatewayClient(status === 'connected' ? 'connected' : 'reconnecting').client,
+    gatewayUrl: 'ws://localhost:18789',
+  })
+  useChatStore.setState({ transcripts: new Map(), streamingText: new Map() })
+  useBooZeroStore.setState({ booZeroAgentId: null })
+  useTeamStore.setState({ teams: [], selectedTeamId: null })
+}
+
+function renderPanel() {
+  return render(
+    <ThemeProvider>
+      <ChatPanel agentId="a1" />
+    </ThemeProvider>,
+  )
+}
+
+beforeEach(() => {
+  server.use(http.get('/api/chat-history', () => HttpResponse.json({ entries: [] })))
+})
+
+afterEach(() => {
+  cleanup()
+  useFleetStore.setState({ agents: [], selectedAgentId: null })
+  useConnectionStore.setState({ status: 'disconnected', client: null, gatewayUrl: null })
+})
+
+describe('ChatPanel — OpenClaw composer follows the live socket', () => {
+  it('is live while the socket is connected', () => {
+    seed('openclaw', 'connected')
+    renderPanel()
+    expect(screen.getByTestId('chat-composer-input')).not.toBeDisabled()
+  })
+
+  it('gates off while the socket is reconnecting', () => {
+    seed('openclaw', 'reconnecting')
+    renderPanel()
+    expect(screen.getByTestId('chat-composer-input')).toBeDisabled()
+  })
+
+  it('says WHY it is disabled instead of leaving a dead "Message…" box', () => {
+    seed('openclaw', 'reconnecting')
+    renderPanel()
+    expect(screen.getByPlaceholderText('Reconnecting to Gateway…')).toBeInTheDocument()
+  })
+
+  it('reports the drop in the header indicator', () => {
+    seed('openclaw', 'reconnecting')
+    renderPanel()
+    expect(screen.getByText('Reconnecting')).toBeInTheDocument()
+  })
+})
+
+describe('ChatPanel — a native composer is unaffected by a Gateway drop', () => {
+  it('stays live while the Gateway socket is reconnecting', () => {
+    // Native runs server-side over SSE. Its send does not touch the Gateway, so
+    // disabling it here would be a pure false negative.
+    seed('clawboo-native', 'reconnecting')
+    renderPanel()
+    expect(screen.getByTestId('chat-composer-input')).not.toBeDisabled()
+  })
+})

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -37,6 +37,7 @@ import {
   type GatewayDegradeReason,
   type ReconnectPhase,
 } from './GatewayReconnectBanner'
+import { LiveReconnectBanner } from './LiveReconnectBanner'
 import { classifyReconnectError, type ReconnectErrorKind } from './reconnectError'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 import {
@@ -53,7 +54,7 @@ import {
   decideOnboardingView,
 } from '@/lib/onboardingProgress'
 import { useGatewayEvents } from './useGatewayEvents'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { useFleetStore } from '@/stores/fleet'
 import { useApprovalsStore } from '@/stores/approvals'
 import { fetchExecConfigMap } from '@/lib/execConfigMap'
@@ -748,7 +749,10 @@ export function GatewayBootstrap() {
     const tryAutoConnect = async () => {
       // Native mode (or any path that already connected) needs no Gateway — the
       // reload native branch sets status='connected' with a null client.
-      if (useConnectionStore.getState().status === 'connected') return
+      // `isSessionLive` also covers 'reconnecting': a live client whose socket
+      // dropped is already retrying on its own backoff, so a second connect here
+      // would race it and leak a duplicate client.
+      if (isSessionLive(useConnectionStore.getState().status)) return
       // A native-mode hydrate FAILURE sets status='error' (+ surfaces the nativeError
       // retry overlay). Don't kick off a pointless Gateway auto-connect round-trip,
       // which would also flash the 'Reconnecting…' spinner on top of the error — the
@@ -817,12 +821,21 @@ export function GatewayBootstrap() {
         // No token here: the same-origin proxy injects the upstream token server-side,
         // so the browser never holds it (GET /api/settings returns only `hasToken`).
         const autoClient = new GatewayClient()
-        await autoClient.connect(resolveProxyGatewayUrl(), {
-          clientName: 'openclaw-control-ui',
-          clientVersion: '0.1.0',
-          authScopeKey: data.gatewayUrl.trim(),
-          disableDeviceAuth: true,
-        })
+        // A failed connect rejects from `ws.onclose` — which ALSO arms the
+        // client's own reconnect loop (the close was not a manual disconnect).
+        // Without this disconnect the discarded client keeps retrying against
+        // the Gateway forever, invisible to the app.
+        try {
+          await autoClient.connect(resolveProxyGatewayUrl(), {
+            clientName: 'openclaw-control-ui',
+            clientVersion: '0.1.0',
+            authScopeKey: data.gatewayUrl.trim(),
+            disableDeviceAuth: true,
+          })
+        } catch (err) {
+          autoClient.disconnect()
+          throw err
+        }
 
         setStatus('connected')
         setGatewayUrl(data.gatewayUrl.trim())
@@ -883,11 +896,18 @@ export function GatewayBootstrap() {
             if (prev) prev.disconnect()
 
             const autoClient = new GatewayClient()
-            await autoClient.connect(resolveProxyGatewayUrl(), {
-              clientName: 'openclaw-control-ui',
-              clientVersion: '0.1.0',
-              disableDeviceAuth: true,
-            })
+            // See the auto-connect path: a rejected connect leaves the client
+            // retrying on its own backoff unless it is explicitly disconnected.
+            try {
+              await autoClient.connect(resolveProxyGatewayUrl(), {
+                clientName: 'openclaw-control-ui',
+                clientVersion: '0.1.0',
+                disableDeviceAuth: true,
+              })
+            } catch (err) {
+              autoClient.disconnect()
+              throw err
+            }
 
             setStatus('connected')
             setGatewayUrl(url)
@@ -961,11 +981,19 @@ export function GatewayBootstrap() {
     const prev = useConnectionStore.getState().client
     if (prev) prev.disconnect()
     const gwClient = new GatewayClient()
-    await gwClient.connect(resolveProxyGatewayUrl(), {
-      clientName: 'openclaw-control-ui',
-      clientVersion: '0.1.0',
-      disableDeviceAuth: true,
-    })
+    // See the auto-connect path: the throw propagates to `failGatewayRecovery`,
+    // which never sees `gwClient` — so stop its reconnect loop here or it retries
+    // against the Gateway forever.
+    try {
+      await gwClient.connect(resolveProxyGatewayUrl(), {
+        clientName: 'openclaw-control-ui',
+        clientVersion: '0.1.0',
+        disableDeviceAuth: true,
+      })
+    } catch (err) {
+      gwClient.disconnect()
+      throw err
+    }
     await enterGatewayMode(gwClient, url)
   }, [])
 
@@ -1043,6 +1071,20 @@ export function GatewayBootstrap() {
     setReconnectErrorKind(null)
   }, [])
 
+  // ── Escape from a live socket that never comes back ────────────────────────
+  // The client retries forever (800ms x 1.7, capped 15s), so a permanently-dead
+  // Gateway would otherwise pin the app on 'reconnecting' with no route back to
+  // the connect form. `disconnect()` sets the client's manual flag, which stops
+  // the backoff loop; nulling the client tears down the event + status
+  // subscriptions; 'disconnected' drops out of the live session so the connect
+  // screen can render.
+  const handleConnectManually = useCallback(() => {
+    const conn = useConnectionStore.getState()
+    conn.client?.disconnect()
+    conn.setClient(null)
+    conn.setStatus('disconnected')
+  }, [])
+
   // Clear the degraded banner the moment a LIVE Gateway client comes up by ANY
   // path — e.g. the user re-pairs via the banner's "Settings" escape → Runtimes →
   // `enterGatewayMode` — not only via the banner's own Reconnect. Gated to
@@ -1084,6 +1126,12 @@ export function GatewayBootstrap() {
       // Wizard run finished — drop the in-progress marker so future refreshes
       // take the returning-user fast path instead of resuming the wizard.
       clearWizardActive()
+      // ...and retire it for THIS page session too (the native branch above does
+      // the same). Without this, `showWizard` stays true for the rest of the
+      // session and the only thing keeping the wizard unmounted is the connected
+      // status — so any later drop back out of a live session would re-open the
+      // full onboarding wizard over a working dashboard.
+      setShowWizard(false)
 
       // Disconnect old client before replacing to avoid leaked WS listeners
       const prev = useConnectionStore.getState().client
@@ -1126,13 +1174,19 @@ export function GatewayBootstrap() {
     [setStatus, setGatewayUrl, setClient, hydrateFleet],
   )
 
-  const isConnected = status === 'connected'
+  // "Inside a live session" — connected, OR connected with the socket transiently
+  // down and the client retrying. Every overlay below gates on this rather than a
+  // strict `=== 'connected'`, so a mid-session drop keeps the workspace up instead
+  // of throwing the connect modal (or the onboarding wizard) over it. Surfaces
+  // that mean "the Gateway is usable RIGHT NOW" stay strict — see the degraded
+  // banner below and the auto-clear effect above.
+  const inSession = isSessionLive(status)
 
   return (
     <>
       <AnimatePresence>
         {/* First-time onboarding wizard */}
-        {!isConnected && showWizard === true && (
+        {!inSession && showWizard === true && (
           <OnboardingWizard
             key="onboarding"
             onComplete={handleOnboardingComplete}
@@ -1140,9 +1194,11 @@ export function GatewayBootstrap() {
           />
         )}
 
-        {/* Auto-connecting spinner — shown while we attempt a silent reconnect.
-            Suppressed during a native-mode error so it never overlays the retry. */}
-        {!isConnected && showWizard === false && autoConnecting && !nativeError && (
+        {/* Auto-connecting spinner — the MOUNT-TIME silent reconnect for a
+            returning user. Distinct from the live-drop banner further down (this
+            one blocks; that one floats). Suppressed during a native-mode error so
+            it never overlays the retry. */}
+        {!inSession && showWizard === false && autoConnecting && !nativeError && (
           <motion.div
             key="auto-connecting"
             initial={{ opacity: 0 }}
@@ -1159,7 +1215,7 @@ export function GatewayBootstrap() {
         )}
 
         {/* Gateway offline — can auto-start */}
-        {!isConnected && showWizard === false && !autoConnecting && gatewayOffline && (
+        {!inSession && showWizard === false && !autoConnecting && gatewayOffline && (
           <motion.div
             key="gateway-offline"
             initial={{ opacity: 0 }}
@@ -1242,8 +1298,11 @@ export function GatewayBootstrap() {
           </motion.div>
         )}
 
-        {/* Returning-user quick reconnect modal — only shown when auto-connect is not in progress */}
-        {!isConnected &&
+        {/* Returning-user quick reconnect modal — only shown when auto-connect is
+            not in progress. Gated on `inSession`, NOT on a strict 'connected', so
+            a live socket drop does not throw this full-screen modal over a
+            working dashboard on every blip. */}
+        {!inSession &&
           showWizard === false &&
           !autoConnecting &&
           !gatewayOffline &&
@@ -1252,7 +1311,7 @@ export function GatewayBootstrap() {
 
       {/* Fleet hydration error overlay */}
       <AnimatePresence>
-        {isConnected && fleetError && (
+        {inSession && fleetError && (
           <motion.div
             key="fleet-error"
             initial={{ opacity: 0 }}
@@ -1278,6 +1337,9 @@ export function GatewayBootstrap() {
                   onClick={() => {
                     setFleetError(null)
                     client?.disconnect()
+                    // Drop the dead client too, so its subscriptions tear down
+                    // and nothing downstream reads a disconnected client as live.
+                    setClient(null)
                     setStatus('disconnected')
                   }}
                   className="rounded-lg border border-border px-4 py-2 text-[13px] text-secondary"
@@ -1324,9 +1386,15 @@ export function GatewayBootstrap() {
 
       {/* Non-blocking degraded-Gateway reconnect banner — floats over the loaded
           dashboard for a user with gateway-independent agents, instead of a
-          full-screen block. */}
+          full-screen block.
+
+          Deliberately gated on the STRICT `status === 'connected'`, not
+          `inSession`: it shares its fixed coordinates with the live-drop banner
+          below, and keeping one on 'connected' and the other on 'reconnecting'
+          makes the two mutually exclusive by construction (no overlap, and never
+          two simultaneous aria-live regions). */}
       <AnimatePresence>
-        {isConnected && gatewayDegraded && (
+        {status === 'connected' && gatewayDegraded && (
           <GatewayReconnectBanner
             key="gateway-reconnect"
             reason={gatewayDegraded}
@@ -1341,6 +1409,19 @@ export function GatewayBootstrap() {
         )}
       </AnimatePresence>
 
+      {/* Live socket drop — the client is already retrying on its own backoff, so
+          this is a slim informational banner rather than a block. Its own
+          AnimatePresence: sharing the degraded banner's would cross-fade two
+          elements at identical fixed coordinates. */}
+      <AnimatePresence>
+        {status === 'reconnecting' && (
+          <LiveReconnectBanner
+            key="gateway-live-reconnect"
+            onConnectManually={handleConnectManually}
+          />
+        )}
+      </AnimatePresence>
+
       {/* Post-onboarding "Click a Boo" tip — separate from the wizard stack */}
       <AnimatePresence>
         {showBooTip && <BooTip key="boo-tip" onDismiss={() => setShowBooTip(false)} />}
@@ -1348,7 +1429,7 @@ export function GatewayBootstrap() {
 
       {/* One-time capability tour — auto-opens once the shell is settled (no
           onboarding tip showing) and never again. */}
-      <CapabilityTour show={isConnected && !showBooTip} />
+      <CapabilityTour show={inSession && !showBooTip} />
     </>
   )
 }

--- a/apps/web/src/features/connection/GatewayConnectScreen.tsx
+++ b/apps/web/src/features/connection/GatewayConnectScreen.tsx
@@ -130,6 +130,12 @@ export function GatewayConnectScreen({
       setGatewayUrl(trimmedUrl)
       onConnected(client)
     } catch (err) {
+      // A failed connect rejects from `ws.onclose`, which ALSO arms the client's
+      // own reconnect loop (the close was not a manual disconnect). Dropping the
+      // ref alone would leave that discarded client retrying against the Gateway
+      // forever, so stop it before we let go of it.
+      client.disconnect()
+
       // OpenClaw 2026.5+ requires explicit device-pairing approval before a
       // new client can connect. Detect that specific rejection and surface
       // the in-dashboard approval UI instead of the raw error toast.

--- a/apps/web/src/features/connection/GatewayReconnectBanner.tsx
+++ b/apps/web/src/features/connection/GatewayReconnectBanner.tsx
@@ -136,6 +136,9 @@ export function GatewayReconnectBanner({
 
       {/* Copy */}
       <div style={{ minWidth: 0, marginRight: 2 }}>
+        {/* See LiveReconnectBanner's twin: no-wrap in a `minWidth: 0` flex item
+            clips rather than wraps. This one's titles are longer still
+            ("OpenClaw Gateway is unreachable"), so it truncates sooner. */}
         <div
           style={{
             fontSize: 13,
@@ -143,15 +146,16 @@ export function GatewayReconnectBanner({
             color: 'var(--foreground)',
             letterSpacing: '-0.01em',
             lineHeight: 1.25,
-            whiteSpace: 'nowrap',
           }}
         >
           {title}
         </div>
         <div
           style={{
+            // See LiveReconnectBanner's twin: a 0.55 foreground alpha composites
+            // to 3.94:1 on a light surface, below the 4.5:1 AA floor.
             fontSize: 11.5,
-            color: 'rgb(var(--foreground-rgb) / 0.55)',
+            color: 'var(--muted-foreground)',
             marginTop: 1,
             lineHeight: 1.35,
           }}

--- a/apps/web/src/features/connection/LiveReconnectBanner.tsx
+++ b/apps/web/src/features/connection/LiveReconnectBanner.tsx
@@ -1,0 +1,119 @@
+// A slim, NON-BLOCKING banner for a live Gateway socket that dropped mid-session
+// and is retrying on its own backoff (the client's `'reconnecting'` status,
+// mirrored into the store by `useGatewayEvents`).
+//
+// Distinct from two neighbours it is easy to confuse with:
+//   * `GatewayReconnectBanner` — the DEGRADED-gateway banner, shown when a
+//     Gateway failure pushed a native-capable user into native mode. That one is
+//     action-driven ("press Reconnect"); this one is informational, because the
+//     client is already retrying. They share the same fixed coordinates, so they
+//     are made mutually exclusive by their gates: the degraded banner renders
+//     only on status 'connected', this one only on 'reconnecting'.
+//   * `GatewayBootstrap`'s full-screen "Reconnecting…" spinner — the MOUNT-TIME
+//     auto-connect overlay for a returning user. That one blocks; this one never
+//     covers the workspace.
+//
+// The one action is an ESCAPE, not a retry: the client retries forever (800ms x
+// 1.7, capped 15s), so a Gateway that never comes back would otherwise pin the
+// app on 'reconnecting' with no way to re-enter a token or re-pair. "Connect
+// manually" stops the loop and drops the user on the connect screen.
+
+import { motion, useReducedMotion } from 'framer-motion'
+import { Loader2 } from 'lucide-react'
+
+interface Props {
+  /** Stop the client's retry loop and fall back to the manual connect screen. */
+  onConnectManually: () => void
+}
+
+export function LiveReconnectBanner({ onConnectManually }: Props) {
+  const reduce = useReducedMotion()
+
+  return (
+    <motion.div
+      role="status"
+      aria-live="polite"
+      data-testid="gateway-live-reconnect-banner"
+      initial={reduce ? { opacity: 0 } : { opacity: 0, y: -18 }}
+      animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
+      exit={reduce ? { opacity: 0 } : { opacity: 0, y: -18, transition: { duration: 0.18 } }}
+      transition={{ type: 'spring', stiffness: 420, damping: 34 }}
+      className="surface-floating-tier"
+      style={{
+        position: 'fixed',
+        top: 14,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        zIndex: 60,
+        borderRadius: 16,
+        padding: '9px 10px 9px 12px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        maxWidth: 'min(460px, calc(100vw - 24px))',
+        boxShadow: 'var(--shadow-floating)',
+      }}
+    >
+      {/* Leading disc — a spinner, because a retry is genuinely in flight. */}
+      <span
+        style={{
+          flexShrink: 0,
+          width: 34,
+          height: 34,
+          borderRadius: 10,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'color-mix(in srgb, var(--amber) 15%, transparent)',
+          color: 'var(--amber)',
+        }}
+      >
+        <Loader2 className="h-[18px] w-[18px] animate-spin" strokeWidth={2.25} />
+      </span>
+
+      {/* Copy */}
+      <div style={{ minWidth: 0, marginRight: 2 }}>
+        {/* No `whiteSpace: nowrap` here. The copy column is a `minWidth: 0` flex
+            item, so it shrinks below its content width — and a no-wrap title then
+            CLIPS instead of wrapping. Measured at a 460px viewport: the title
+            wants 169px and gets 118px, losing the last word. Wrapping grows the
+            banner vertically, which the layout already handles. */}
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'var(--foreground)',
+            letterSpacing: '-0.01em',
+            lineHeight: 1.25,
+          }}
+        >
+          Reconnecting to Gateway…
+        </div>
+        <div
+          style={{
+            // `--muted-foreground`, not a foreground alpha: the 0.55 this used to
+            // carry composites to 3.94:1 on a light surface, under the 4.5:1 AA
+            // floor for body text. The token is contrast-checked in both themes
+            // by `app/__tests__/tokenContrast.test.ts`.
+            fontSize: 11.5,
+            color: 'var(--muted-foreground)',
+            marginTop: 1,
+            lineHeight: 1.35,
+          }}
+        >
+          The live connection dropped. Retrying automatically.
+        </div>
+      </div>
+
+      {/* Escape hatch — secondary, so it never reads as "you must act". */}
+      <button
+        type="button"
+        onClick={onConnectManually}
+        data-testid="gateway-live-reconnect-manual"
+        className="shrink-0 rounded-lg px-2.5 py-1.5 text-[12px] font-medium text-foreground/60 transition-colors hover:bg-foreground/[0.06] hover:text-foreground/85"
+      >
+        Connect manually
+      </button>
+    </motion.div>
+  )
+}

--- a/apps/web/src/features/connection/__tests__/GatewayBootstrap.liveReconnect.test.tsx
+++ b/apps/web/src/features/connection/__tests__/GatewayBootstrap.liveReconnect.test.tsx
@@ -1,0 +1,168 @@
+// End-to-end for the issue's acceptance criterion: emit `onStatus('reconnecting')`
+// from the live client and assert BOTH that the store updates AND that the banner
+// renders — plus the regression locks that make the feature safe. Before this
+// change, `GatewayBootstrap` gated every overlay on a strict `status ===
+// 'connected'`, so simply mirroring the drop would have thrown the full-screen
+// connect modal (and the onboarding wizard) over a working dashboard.
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { makeFakeGatewayClient } from '@/__vitest__/fakeGatewayClient'
+import { server } from '@/__vitest__/mswServer'
+import { useConnectionStore } from '@/stores/connection'
+import { useFleetStore } from '@/stores/fleet'
+import { useTeamStore } from '@/stores/team'
+
+import { GatewayBootstrap } from '../GatewayBootstrap'
+
+// A fully configured OpenClaw with a running Gateway. `configured` (installed &&
+// configExists && envExists) is what makes the mount effect resolve to
+// 'dashboard' — i.e. a returning user, no wizard, no extra probes.
+const CONFIGURED_SYSTEM_INFO = {
+  node: { version: 'v22.0.0', major: 22, sufficient: true, path: '/usr/bin/node' },
+  openclaw: {
+    installed: true,
+    version: '0.3.0',
+    path: '/usr/bin/openclaw',
+    stateDir: '/tmp/.openclaw',
+    configExists: true,
+    envExists: true,
+  },
+  gateway: { running: true, port: 18789, pid: 1, managedByClawboo: false, uptimeMs: 1 },
+}
+
+let teamsHits = 0
+
+beforeEach(() => {
+  teamsHits = 0
+  localStorage.setItem('clawboo.onboarded', '1')
+  localStorage.removeItem('clawboo.wizard.active')
+  // Otherwise the one-time tour opens a focus-trapped full-screen overlay.
+  localStorage.setItem('clawboo.tour.shown', '1')
+  localStorage.setItem('clawboo.firstTask.shown', '1')
+
+  useConnectionStore.setState({ status: 'disconnected', client: null, gatewayUrl: null })
+  useFleetStore.setState({ agents: [] })
+  useTeamStore.setState({ teams: [], selectedTeamId: null })
+
+  server.use(
+    http.get('/api/system/status', () => HttpResponse.json(CONFIGURED_SYSTEM_INFO)),
+    http.get('/api/teams', () => {
+      teamsHits += 1
+      return HttpResponse.json({ teams: [] })
+    }),
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+/**
+ * Render the bootstrap as a settled, connected returning user.
+ *
+ * Seeds 'connected' rather than 'reconnecting' so the transition under test is a
+ * real one, and so the auto-connect effect takes its early-return instead of
+ * firing a rogue `/api/settings` (deliberately absent from the msw defaults, so a
+ * spurious fetch fails the test loudly).
+ */
+async function renderConnected() {
+  const fake = makeFakeGatewayClient('connected')
+  useConnectionStore.setState({
+    status: 'connected',
+    client: fake.client,
+    gatewayUrl: 'ws://localhost:18789',
+  })
+  const view = render(<GatewayBootstrap />)
+  // `/api/teams` is the last fetch of the mount decision chain, so one hit means
+  // the view has been decided and `setShowWizard(false)` has flushed.
+  await waitFor(() => expect(teamsHits).toBe(1))
+  return { fake, ...view }
+}
+
+describe('GatewayBootstrap — live socket drop', () => {
+  it('mirrors onStatus("reconnecting") into the store and renders the banner', async () => {
+    const { fake } = await renderConnected()
+    expect(screen.queryByTestId('gateway-live-reconnect-banner')).not.toBeInTheDocument()
+
+    act(() => fake.emit('reconnecting'))
+
+    expect(useConnectionStore.getState().status).toBe('reconnecting')
+    expect(await screen.findByTestId('gateway-live-reconnect-banner')).toBeInTheDocument()
+  })
+
+  it('returns the store to connected when the socket recovers', async () => {
+    const { fake } = await renderConnected()
+    act(() => fake.emit('reconnecting'))
+    expect(await screen.findByTestId('gateway-live-reconnect-banner')).toBeInTheDocument()
+
+    act(() => fake.emit('connected'))
+
+    expect(useConnectionStore.getState().status).toBe('connected')
+    // The banner's presence gate is `status === 'reconnecting'`, which this now
+    // fails — the test above already proves it is absent at 'connected'. We do
+    // NOT assert the node is gone here: it sits inside an <AnimatePresence>, and
+    // framer-motion's exit transition does not settle under jsdom, so it would
+    // be asserting on the animation library rather than on our gate.
+  })
+})
+
+describe('GatewayBootstrap — a drop must not blow away the workspace', () => {
+  it('does NOT pop the full-screen connect screen', async () => {
+    // The highest-value lock in the file: every overlay used to gate on a strict
+    // `=== 'connected'`, so mirroring the drop without widening those gates would
+    // throw this modal over a working dashboard on every transient blip.
+    const { fake } = await renderConnected()
+
+    act(() => fake.emit('reconnecting'))
+
+    await screen.findByTestId('gateway-live-reconnect-banner')
+    expect(screen.queryByTestId('gateway-connect-screen')).not.toBeInTheDocument()
+  })
+
+  it('does NOT re-open the onboarding wizard', async () => {
+    const { fake } = await renderConnected()
+
+    act(() => fake.emit('reconnecting'))
+
+    await screen.findByTestId('gateway-live-reconnect-banner')
+    expect(screen.queryByText('Connect to an OpenClaw Gateway')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('onboarding-wizard')).not.toBeInTheDocument()
+  })
+
+  it('does NOT show the blocking mount-time auto-connect spinner', async () => {
+    // Two distinct surfaces that both say "reconnecting": the mount-time overlay
+    // renders the exact string "Reconnecting…", the live banner "Reconnecting to
+    // Gateway…". Assert on the exact strings so they can never be conflated.
+    const { fake } = await renderConnected()
+
+    act(() => fake.emit('reconnecting'))
+
+    await screen.findByTestId('gateway-live-reconnect-banner')
+    expect(screen.queryByText('Reconnecting…')).not.toBeInTheDocument()
+  })
+})
+
+describe('GatewayBootstrap — escape from a Gateway that never comes back', () => {
+  it('"Connect manually" stops the retry loop and lands on the connect screen', async () => {
+    // The client retries forever, so without this the app would be stuck on
+    // 'reconnecting' with no route back to the token / pairing form.
+    const user = userEvent.setup()
+    const { fake } = await renderConnected()
+    act(() => fake.emit('reconnecting'))
+    await screen.findByTestId('gateway-live-reconnect-banner')
+
+    await user.click(screen.getByRole('button', { name: 'Connect manually' }))
+
+    // `disconnect()` sets the client's manual flag, which is what stops the backoff.
+    expect(fake.disconnect).toHaveBeenCalledOnce()
+    const s = useConnectionStore.getState()
+    expect(s.status).toBe('disconnected')
+    expect(s.client).toBeNull()
+    expect(await screen.findByTestId('gateway-connect-screen')).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/connection/__tests__/LiveReconnectBanner.test.tsx
+++ b/apps/web/src/features/connection/__tests__/LiveReconnectBanner.test.tsx
@@ -1,0 +1,50 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LiveReconnectBanner } from '../LiveReconnectBanner'
+
+afterEach(() => cleanup())
+
+describe('LiveReconnectBanner', () => {
+  it('states that the socket dropped and is retrying on its own', () => {
+    render(<LiveReconnectBanner onConnectManually={vi.fn()} />)
+
+    expect(screen.getByTestId('gateway-live-reconnect-banner')).toBeInTheDocument()
+    expect(screen.getByText('Reconnecting to Gateway…')).toBeInTheDocument()
+    // Honest copy: the user does not have to do anything.
+    expect(
+      screen.getByText('The live connection dropped. Retrying automatically.'),
+    ).toBeInTheDocument()
+  })
+
+  it('is a polite live region, not a modal', () => {
+    render(<LiveReconnectBanner onConnectManually={vi.fn()} />)
+
+    const banner = screen.getByTestId('gateway-live-reconnect-banner')
+    expect(banner).toHaveAttribute('role', 'status')
+    expect(banner).toHaveAttribute('aria-live', 'polite')
+    // Non-blocking is the whole point — it must never trap the workspace.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('offers the manual escape and fires its handler', async () => {
+    // Without this the client retries forever, so a Gateway that never comes back
+    // would pin the app on 'reconnecting' with no route to the connect form.
+    const user = userEvent.setup()
+    const onConnectManually = vi.fn()
+    render(<LiveReconnectBanner onConnectManually={onConnectManually} />)
+
+    await user.click(screen.getByRole('button', { name: 'Connect manually' }))
+
+    expect(onConnectManually).toHaveBeenCalledOnce()
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(<LiveReconnectBanner onConnectManually={vi.fn()} />)
+    expect(
+      await axe(container, { rules: { 'color-contrast': { enabled: false } } }),
+    ).toHaveNoViolations()
+  })
+})

--- a/apps/web/src/features/connection/__tests__/socketStatusMirror.test.ts
+++ b/apps/web/src/features/connection/__tests__/socketStatusMirror.test.ts
@@ -1,0 +1,94 @@
+// The mirror policy is the whole safety story for reflecting a live socket into
+// the app's connection store, so it is pinned exhaustively here. Two of these
+// cases are deliberate DEVIATIONS from the issue text and will look like bugs to
+// a future reader — see the comments (and the module header) before "fixing" one.
+
+import { describe, expect, it } from 'vitest'
+import type { ConnectionStatus as SocketStatus } from '@clawboo/gateway-client'
+
+import type { ConnectionStatus } from '@/stores/connection'
+import { nextMirroredStatus } from '../socketStatusMirror'
+
+const STORE_STATUSES: ConnectionStatus[] = [
+  'disconnected',
+  'connecting',
+  'connected',
+  'reconnecting',
+  'error',
+]
+
+describe('nextMirroredStatus — the live-drop signal', () => {
+  it('mirrors a drop into the store from every non-terminal status', () => {
+    expect(nextMirroredStatus('reconnecting', 'connected')).toBe('reconnecting')
+    expect(nextMirroredStatus('reconnecting', 'connecting')).toBe('reconnecting')
+    expect(nextMirroredStatus('reconnecting', 'disconnected')).toBe('reconnecting')
+  })
+
+  it('does not rewrite an unchanged status (the client re-emits on every retry)', () => {
+    // `updateStatus` has no dedupe and fires 'reconnecting' again on each failed
+    // backoff attempt, so the mirror has to absorb the repeats.
+    expect(nextMirroredStatus('reconnecting', 'reconnecting')).toBeNull()
+    expect(nextMirroredStatus('connected', 'connected')).toBeNull()
+  })
+})
+
+describe('nextMirroredStatus — recovery', () => {
+  it('mirrors a recovered socket back to connected', () => {
+    expect(nextMirroredStatus('connected', 'reconnecting')).toBe('connected')
+    expect(nextMirroredStatus('connected', 'disconnected')).toBe('connected')
+  })
+
+  it('lets a recovered socket CLEAR the app-level error', () => {
+    // The complement of the non-downgrade rule below: a live socket is real
+    // evidence the error is over, so it must not be sticky.
+    expect(nextMirroredStatus('connected', 'error')).toBe('connected')
+  })
+})
+
+describe('nextMirroredStatus — what it refuses to write', () => {
+  it('never downgrades the app-level error to a transient reconnecting', () => {
+    // 'error' means a failed native hydrate / a rejected connect, whose retry UI
+    // the manual flows own. Replacing it with a banner that just spins would
+    // strand the user with no way forward.
+    expect(nextMirroredStatus('reconnecting', 'error')).toBeNull()
+  })
+
+  it('ignores disconnected from ANY store status', () => {
+    // DELIBERATE deviation from the issue's acceptance criteria. Every
+    // 'disconnected' the client emits is downstream of an app-initiated
+    // `disconnect()`, and every browser call site disconnects the OLD client
+    // while it is still `store.client` and only then swaps in the new one — so
+    // mirroring it would let a teardown stamp 'disconnected' over a connection
+    // that just succeeded. See the module header.
+    for (const current of STORE_STATUSES) {
+      expect(nextMirroredStatus('disconnected', current)).toBeNull()
+    }
+  })
+
+  it('ignores connecting from ANY store status', () => {
+    // Only ever emitted inside `connect()`, before the client is in the store —
+    // and the mount-time auto-connect spinner already owns that surface.
+    for (const current of STORE_STATUSES) {
+      expect(nextMirroredStatus('connecting', current)).toBeNull()
+    }
+  })
+})
+
+describe('nextMirroredStatus — totality', () => {
+  it('returns either null or the socket status itself, never anything else', () => {
+    const socketStatuses: SocketStatus[] = [
+      'disconnected',
+      'connecting',
+      'connected',
+      'reconnecting',
+    ]
+    for (const socket of socketStatuses) {
+      for (const current of STORE_STATUSES) {
+        const next = nextMirroredStatus(socket, current)
+        expect(next === null || next === socket).toBe(true)
+        // A no-op write is never emitted, so the store's `set` can stay naive.
+        expect(next).not.toBe(current)
+      }
+    }
+  })
+})

--- a/apps/web/src/features/connection/__tests__/useGatewayEvents.status.test.tsx
+++ b/apps/web/src/features/connection/__tests__/useGatewayEvents.status.test.tsx
@@ -1,0 +1,148 @@
+// The live-socket → connection-store mirror. This is the wiring the issue asks
+// for: the browser client already reports 'reconnecting' when its WebSocket
+// drops, and until now nothing in the SPA subscribed, so the store kept saying
+// "Connected" over a dead socket.
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import type { ConnectionStatus as SocketStatus } from '@clawboo/gateway-client'
+
+import { makeFakeGatewayClient } from '@/__vitest__/fakeGatewayClient'
+import { useConnectionStore, type ConnectionStatus } from '@/stores/connection'
+
+import { useGatewayEvents } from '../useGatewayEvents'
+
+beforeEach(() => {
+  useConnectionStore.setState({ status: 'disconnected', client: null, gatewayUrl: null })
+})
+afterEach(() => cleanup())
+
+/**
+ * Mount the hook against a fake client already installed in the store, as every
+ * real connect flow does (setClient lands before the effect subscribes).
+ *
+ * `socketStatus` is explicit because `onStatus` REPLAYS it synchronously at
+ * subscribe time — so it is itself a mirrored transition, not just setup.
+ */
+function mountWith(status: ConnectionStatus, socketStatus: SocketStatus = 'connected') {
+  const fake = makeFakeGatewayClient(socketStatus)
+  useConnectionStore.setState({ status, client: fake.client, gatewayUrl: 'ws://localhost:18789' })
+  const view = renderHook(({ c }) => useGatewayEvents(c), { initialProps: { c: fake.client } })
+  return { fake, ...view }
+}
+
+describe('useGatewayEvents — live socket status mirror', () => {
+  it('mirrors a mid-session drop into the store', () => {
+    const { fake } = mountWith('connected')
+
+    act(() => fake.emit('reconnecting'))
+
+    expect(useConnectionStore.getState().status).toBe('reconnecting')
+  })
+
+  it('mirrors the recovery back to connected', () => {
+    const { fake } = mountWith('connected')
+    act(() => fake.emit('reconnecting'))
+
+    act(() => fake.emit('connected'))
+
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+
+  it('absorbs the repeated reconnecting emitted on every failed retry', () => {
+    const { fake } = mountWith('connected')
+
+    act(() => {
+      fake.emit('reconnecting')
+      fake.emit('reconnecting')
+      fake.emit('reconnecting')
+    })
+
+    expect(useConnectionStore.getState().status).toBe('reconnecting')
+  })
+
+  it('subscribing replays the current status without stomping a matching store', () => {
+    // The real `onStatus` fires synchronously at subscribe time; a client that is
+    // already connected must not produce a spurious write.
+    const { fake } = mountWith('connected')
+    expect(fake.statusSubscribers()).toBe(1)
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+})
+
+describe('useGatewayEvents — what the mirror refuses to do', () => {
+  it('does not downgrade the app-level error to reconnecting', () => {
+    // The socket is down at subscribe time, so the replay itself is the drop.
+    const { fake } = mountWith('error', 'reconnecting')
+    expect(useConnectionStore.getState().status).toBe('error')
+
+    act(() => fake.emit('reconnecting'))
+
+    // 'error' owns its own retry overlay; a spinning banner would replace a real
+    // affordance with a dead one.
+    expect(useConnectionStore.getState().status).toBe('error')
+  })
+
+  it('DOES let a recovered socket clear the error', () => {
+    const { fake } = mountWith('error', 'reconnecting')
+
+    act(() => fake.emit('connected'))
+
+    // The complement of the rule above: a live socket is real evidence the error
+    // is over, so it must not be sticky.
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+
+  it('ignores a socket-reported disconnect (owned by the explicit flows)', () => {
+    const { fake } = mountWith('connected')
+
+    act(() => fake.emit('disconnected'))
+
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+
+  it('ignores a SUPERSEDED client so its teardown cannot stomp the replacement', () => {
+    // Every connect flow disconnects the previous client, and that teardown
+    // emits. If the store has already moved on to a new client, the old one has
+    // no business writing status.
+    const { fake } = mountWith('connected')
+    const replacement = makeFakeGatewayClient('connected')
+    useConnectionStore.setState({ status: 'connected', client: replacement.client })
+
+    act(() => fake.emit('reconnecting'))
+
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+})
+
+describe('useGatewayEvents — subscription lifetime', () => {
+  it('never subscribes in native mode (client is null)', () => {
+    const fake = makeFakeGatewayClient('connected')
+    useConnectionStore.setState({ status: 'connected', client: null })
+
+    const { rerender } = renderHook(({ c }) => useGatewayEvents(c), {
+      initialProps: { c: null as null | typeof fake.client },
+    })
+    expect(fake.statusSubscribers()).toBe(0)
+
+    // ...and it arms/disarms as the client comes and goes.
+    useConnectionStore.setState({ client: fake.client })
+    rerender({ c: fake.client })
+    expect(fake.statusSubscribers()).toBe(1)
+
+    useConnectionStore.setState({ client: null })
+    rerender({ c: null })
+    expect(fake.statusSubscribers()).toBe(0)
+  })
+
+  it('unsubscribes on unmount, and later emits are inert', () => {
+    const { fake, unmount } = mountWith('connected')
+
+    unmount()
+
+    expect(fake.statusSubscribers()).toBe(0)
+    act(() => fake.emit('reconnecting'))
+    expect(useConnectionStore.getState().status).toBe('connected')
+  })
+})

--- a/apps/web/src/features/connection/connectionStatusDisplay.ts
+++ b/apps/web/src/features/connection/connectionStatusDisplay.ts
@@ -1,0 +1,38 @@
+// Shared presentation for the app-shell connection indicator, so the chat header,
+// the agent-detail header and the group-chat dot cannot drift apart on what a
+// given status looks like.
+//
+// Before this existed each site rendered the raw status token for anything that
+// was not 'connected' ("disconnected", "error"), which read fine only because the
+// callers uppercase it in CSS. Adding 'reconnecting' made the tone matter — a
+// retrying socket is a WARNING, not the same dead grey as "never connected".
+
+import type { ConnectionStatus } from '@/stores/connection'
+
+/** Human label for the indicator. Callers uppercase it via CSS. */
+export function connectionStatusLabel(status: ConnectionStatus): string {
+  switch (status) {
+    case 'connected':
+      return 'Connected'
+    case 'reconnecting':
+      return 'Reconnecting'
+    case 'connecting':
+      return 'Connecting'
+    case 'error':
+      return 'Error'
+    case 'disconnected':
+      return 'Disconnected'
+  }
+}
+
+/**
+ * Semantic tone for the status dot:
+ *   'live'  — a healthy socket (mint)
+ *   'warn'  — transiently down but recovering on its own (amber)
+ *   'idle'  — not connected, and nothing is happening about it (muted)
+ */
+export function connectionStatusTone(status: ConnectionStatus): 'live' | 'warn' | 'idle' {
+  if (status === 'connected') return 'live'
+  if (status === 'reconnecting' || status === 'connecting') return 'warn'
+  return 'idle'
+}

--- a/apps/web/src/features/connection/socketStatusMirror.ts
+++ b/apps/web/src/features/connection/socketStatusMirror.ts
@@ -1,0 +1,67 @@
+// The one decision point for mirroring the LIVE Gateway socket's status into the
+// app's connection store. Pure + total so the policy is unit-testable and lives
+// in exactly one place (the same shape as `reconnectError.ts` /
+// `lib/onboardingProgress.ts`).
+//
+// Only TWO of the client's four transitions cross over:
+//
+//   'reconnecting' — the whole point of the mirror. It is the ONLY status the SPA
+//                    cannot learn any other way: the client emits it from
+//                    `ws.onclose` when the close was NOT a manual disconnect
+//                    (gateway-client `client.ts:251`), then retries on its own
+//                    backoff (800ms x 1.7, capped 15s).
+//   'connected'    — its counterpart. Without it a recovered socket would leave
+//                    the store stuck on 'reconnecting' forever.
+//
+// 'disconnected' and 'connecting' are deliberately NOT mirrored:
+//
+//   * They carry no new information. The client emits 'connecting' only inside
+//     `connect()` (before the client is ever in the store) and 'disconnected'
+//     only downstream of an app-initiated `disconnect()`. An UNEXPECTED close
+//     always routes to 'reconnecting', never to 'disconnected'. So every one of
+//     those emissions is already owned by the code that caused it, which sets the
+//     store status itself at the right moment.
+//   * Mirroring 'disconnected' would be actively wrong. Every browser call site
+//     disconnects the OLD client while it is STILL `store.client` and only then
+//     calls `setClient(next)` — so the stale-client guard in `useGatewayEvents`
+//     cannot filter it. In `handleConnected` the write would land AFTER
+//     `GatewayConnectScreen` already set 'connected', and nothing sets it back:
+//     the store would stick on 'disconnected' over a healthy connection and the
+//     connect modal would sit on top of a working dashboard.
+//     (The SERVER-side mirror in `server/lib/agentSource/openClawAgentSource.ts`
+//     does handle 'disconnected' — it can, because its `teardownClient` unsubs
+//     BEFORE disconnecting. The browser ordering is the opposite.)
+//
+// Please don't "complete" the union here without fixing that ordering first.
+
+import type { ConnectionStatus as SocketStatus } from '@clawboo/gateway-client'
+
+import type { ConnectionStatus } from '@/stores/connection'
+
+/**
+ * The store status a live socket transition should produce, or `null` for
+ * "leave the store alone".
+ *
+ * @param socketStatus what the live GatewayClient just reported
+ * @param current      the app's current connection-store status
+ */
+export function nextMirroredStatus(
+  socketStatus: SocketStatus,
+  current: ConnectionStatus,
+): ConnectionStatus | null {
+  // Owned by the explicit connect/disconnect flows — see the header.
+  if (socketStatus !== 'reconnecting' && socketStatus !== 'connected') return null
+
+  // 'error' is a terminal APP-level state (a failed native hydrate, a rejected
+  // connect) whose recovery UI the manual flows own. A dropped socket must never
+  // downgrade it to a transient 'reconnecting' — that would swap the retry
+  // affordance for a banner that just spins. A socket that comes back UP is a
+  // genuine recovery, though, so 'connected' is allowed to clear it.
+  if (socketStatus === 'reconnecting' && current === 'error') return null
+
+  // `updateStatus` in the client does not dedupe, and it re-emits 'reconnecting'
+  // on every failed retry, so drop the no-op writes here.
+  if (socketStatus === current) return null
+
+  return socketStatus
+}

--- a/apps/web/src/features/connection/useGatewayEvents.ts
+++ b/apps/web/src/features/connection/useGatewayEvents.ts
@@ -12,13 +12,51 @@ import { useApprovalsStore, type ApprovalRequest } from '@/stores/approvals'
 import { parseApprovalRequestPayload } from '@/features/approvals/useApprovalActions'
 import { nextSeq } from '@/lib/sequenceKey'
 import { refreshFleetFromRegistry } from '@/lib/agentSourceClient'
+import { nextMirroredStatus } from './socketStatusMirror'
 
 // ─── useGatewayEvents ─────────────────────────────────────────────────────────
 //
-// Wires a live GatewayClient into the Bridge → Policy → Handler pipeline.
+// Wires a live GatewayClient into the Bridge → Policy → Handler pipeline, and
+// mirrors the live socket's status into the connection store.
 // Call this hook once at the top of the app; it is a no-op when client is null.
 
 export function useGatewayEvents(client: GatewayClient | null): void {
+  // ── Live socket status → connection store ────────────────────────────────
+  //
+  // Deliberately its OWN effect rather than a few lines inside the pipeline
+  // effect below. `client.onStatus(h)` invokes `h` synchronously at subscribe
+  // time (it replays the current status), so a throw from this handler inside
+  // the pipeline effect would abort that effect part-way: no event
+  // subscriptions, no approval-expiry interval, and — worst — no cleanup
+  // registered, permanently leaking the patch queue and handler. Same `[client]`
+  // dep, so the lifetime is identical; the blast radius is not.
+  //
+  // Per-client subscription, so native mode (client === null) never arms it.
+  useEffect(() => {
+    if (!client) return
+
+    const unsubStatus = client.onStatus((socketStatus) => {
+      // NOTHING may throw out of here. The client fans handlers out bare from
+      // `updateStatus`, and its 'connected' emission happens inside
+      // `sendConnect()`'s try — a throw there is misread as a connect failure
+      // (device token cleared, socket closed 4008, infinite retry).
+      try {
+        const conn = useConnectionStore.getState()
+        // A superseded client must never stomp its replacement: every connect
+        // flow disconnects the previous client, and that teardown emits.
+        if (conn.client !== client) return
+        const next = nextMirroredStatus(socketStatus, conn.status)
+        if (next) conn.setStatus(next)
+      } catch {
+        // Best-effort mirror — a broken status write must not break the socket.
+      }
+    })
+
+    return () => {
+      unsubStatus()
+    }
+  }, [client])
+
   useEffect(() => {
     if (!client) return
 
@@ -32,12 +70,6 @@ export function useGatewayEvents(client: GatewayClient | null): void {
     // ── Event handler with all deps wired to Zustand stores ────────────────
     const handler = createEventHandler({
       // State queries
-      getConnectionStatus: () => {
-        const s = useConnectionStore.getState().status
-        // Map our local 'error' state → 'disconnected' (handler only knows gateway statuses)
-        return s === 'error' ? 'disconnected' : s
-      },
-
       getAgentRunId: (agentId) =>
         useFleetStore.getState().agents.find((a) => a.id === agentId)?.runId ?? null,
 

--- a/apps/web/src/features/fleet/FleetSidebar.tsx
+++ b/apps/web/src/features/fleet/FleetSidebar.tsx
@@ -14,7 +14,7 @@ import {
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { EmptyState } from '@/features/shared/EmptyState'
 import { useFleetStore, type AgentState } from '@/stores/fleet'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { useViewStore } from '@/stores/view'
 import { PersonalitySliders } from '@/features/settings/PersonalitySliders'
 import { CreateBooModal } from './CreateBooModal'
@@ -211,7 +211,9 @@ export function FleetSidebar() {
 
   // Delayed empty state — only show after 1s to avoid flash during hydration
   const [showEmpty, setShowEmpty] = useState(false)
-  const isEmptyConnected = agents.length === 0 && connectionStatus === 'connected' && !query
+  // Live-session, not strictly 'connected' — see AgentListColumn: the empty card
+  // should survive a transient socket drop rather than restart its 1s timer.
+  const isEmptyConnected = agents.length === 0 && isSessionLive(connectionStatus) && !query
   useEffect(() => {
     if (!isEmptyConnected) {
       setShowEmpty(false)

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -8,6 +8,7 @@ import { useChatStore } from '@/stores/chat'
 import { useConnectionStore } from '@/stores/connection'
 import { useBoardStore } from '@/stores/board'
 import { useBooZeroStore, isBooZeroEligibleForTeam } from '@/stores/booZero'
+import { connectionStatusTone } from '@/features/connection/connectionStatusDisplay'
 import { agentIdFromSessionKey, buildTeamSessionKey } from '@/lib/sessionUtils'
 import { parseMention } from './parseMention'
 import { useTeamChatStream } from './useTeamChatStream'
@@ -69,6 +70,7 @@ export function GroupChatPanel({
   const team = useTeamStore((s) => s.teams.find((t) => t.id === teamId) ?? null)
   const agents = useFleetStore((s) => s.agents)
   const connectionStatus = useConnectionStore((s) => s.status)
+  const connectionTone = connectionStatusTone(connectionStatus)
   const transcripts = useChatStore((s) => s.transcripts)
   const streamingTextMap = useChatStore((s) => s.streamingText)
   // Subscribe to stream-start timestamps so live StreamingCards can position
@@ -591,8 +593,22 @@ export function GroupChatPanel({
               {teamAgents.length} agent{teamAgents.length !== 1 ? 's' : ''}
             </p>
           </div>
+          {/* Shell connection dot. Team chat itself is server-orchestrated (it
+              keeps sending through a Gateway drop), so this only REPORTS the
+              socket — the composer is deliberately not gated on it. */}
           <span
-            className={`h-2 w-2 shrink-0 rounded-full ${connectionStatus === 'connected' ? 'bg-mint' : 'bg-foreground/25'}`}
+            // `role="img"` is load-bearing: aria-label is only honoured on an
+            // element whose role supports naming, and this dot has no text of
+            // its own — on a bare span the label would be dropped entirely.
+            role="img"
+            aria-label={`Connection: ${connectionStatus}`}
+            className={`h-2 w-2 shrink-0 rounded-full ${
+              connectionTone === 'live'
+                ? 'bg-mint'
+                : connectionTone === 'warn'
+                  ? 'bg-amber/80 animate-pulse'
+                  : 'bg-foreground/25'
+            }`}
           />
         </div>
       )}

--- a/apps/web/src/features/layout/AgentListColumn.tsx
+++ b/apps/web/src/features/layout/AgentListColumn.tsx
@@ -19,7 +19,7 @@ import { EmptyState } from '@/features/shared/EmptyState'
 import { SearchInput } from '@/features/shared/SearchInput'
 import { useFleetStore, type AgentState } from '@/stores/fleet'
 import { useTeamStore, type Team } from '@/stores/team'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { useViewStore, type NavView } from '@/stores/view'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 import { CreateBooModal } from '@/features/fleet/CreateBooModal'
@@ -483,7 +483,10 @@ export function AgentListColumn() {
 
   // Delayed empty state
   const [showEmpty, setShowEmpty] = useState(false)
-  const isEmptyConnected = agents.length === 0 && connectionStatus === 'connected' && !query
+  // Live-session, not strictly 'connected': "we have a session and the fleet is
+  // empty" stays true across a socket drop, so the delayed empty card should not
+  // blink out and restart its 1s timer on every blip.
+  const isEmptyConnected = agents.length === 0 && isSessionLive(connectionStatus) && !query
   useEffect(() => {
     if (!isEmptyConnected) {
       setShowEmpty(false)

--- a/apps/web/src/features/layout/WelcomeState.tsx
+++ b/apps/web/src/features/layout/WelcomeState.tsx
@@ -4,7 +4,7 @@ import { BarChart3, Globe, Loader2, ShoppingCart, type LucideIcon } from 'lucide
 import { useTeamStore } from '@/stores/team'
 import { useViewStore } from '@/stores/view'
 import { useSettingsModalStore } from '@/stores/settingsModal'
-import { useConnectionStore } from '@/stores/connection'
+import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { CreateTeamModal } from '@/features/teams/CreateTeamModal'
 import { consumeApiSSE } from '@clawboo/control-client'
 import { SkyAtmosphere } from '@/features/atmosphere'
@@ -123,7 +123,10 @@ function SystemHint({ isConnected }: { isConnected: boolean }) {
 export function WelcomeState() {
   const teams = useTeamStore((s) => s.teams)
   const status = useConnectionStore((s) => s.status)
-  const isConnected = status === 'connected'
+  // Live-session, not strictly 'connected': `SystemHint` renders on the INVERSE
+  // of this, so a mid-session socket drop would otherwise wipe the quick-start
+  // steps and pop a "Start Gateway" panel at a user who is already working.
+  const isConnected = isSessionLive(status)
   const hasTeams = teams.length > 0
   const [showCreateModal, setShowCreateModal] = useState(false)
 

--- a/apps/web/src/stores/__tests__/connection.test.ts
+++ b/apps/web/src/stores/__tests__/connection.test.ts
@@ -1,0 +1,43 @@
+// `isSessionLive` is the predicate behind every app-shell overlay gate, so which
+// statuses count as "inside a live session" is pinned here rather than left
+// implicit at a dozen call sites.
+
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { isSessionLive, useConnectionStore } from '../connection'
+
+beforeEach(() => {
+  useConnectionStore.setState({ status: 'disconnected', client: null, gatewayUrl: null })
+})
+
+describe('isSessionLive', () => {
+  it('treats a connected session as live', () => {
+    expect(isSessionLive('connected')).toBe(true)
+  })
+
+  it('treats a dropped-but-retrying socket as STILL live', () => {
+    // The whole point: the client is reconnecting on its own backoff, so the
+    // workspace must stay up rather than being covered by the connect modal.
+    expect(isSessionLive('reconnecting')).toBe(true)
+  })
+
+  it('does not treat pre-session or failed states as live', () => {
+    expect(isSessionLive('disconnected')).toBe(false)
+    expect(isSessionLive('connecting')).toBe(false)
+    // Load-bearing: 'error' must keep BLOCKING, so its retry overlay can render.
+    expect(isSessionLive('error')).toBe(false)
+  })
+})
+
+describe('useConnectionStore', () => {
+  it('starts disconnected with no client', () => {
+    const s = useConnectionStore.getState()
+    expect(s.status).toBe('disconnected')
+    expect(s.client).toBeNull()
+  })
+
+  it('round-trips the reconnecting status', () => {
+    useConnectionStore.getState().setStatus('reconnecting')
+    expect(useConnectionStore.getState().status).toBe('reconnecting')
+  })
+})

--- a/apps/web/src/stores/connection.ts
+++ b/apps/web/src/stores/connection.ts
@@ -1,11 +1,34 @@
 import { create } from 'zustand'
-import type { GatewayClient } from '@clawboo/gateway-client'
+import type { ConnectionStatus as SocketStatus, GatewayClient } from '@clawboo/gateway-client'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-// Superset of @clawboo/gateway-client's ConnectionStatus — adds 'error' state
-// that the UI surfaces distinctly from transient 'disconnected'.
+// The live socket's own status (`disconnected` | `connecting` | `connected` |
+// `reconnecting`) plus an app-only `error` the UI surfaces distinctly from a
+// transient `disconnected`.
+//
+// DERIVED from the client's union rather than re-listing it, so the two cannot
+// drift: if the client ever gains a status, this follows automatically and the
+// exhaustive switch in `features/connection/connectionStatusDisplay.ts` fails to
+// compile until someone decides how to render it.
+//
+// `reconnecting` is mirrored from the live client by `useGatewayEvents`; see
+// `features/connection/socketStatusMirror.ts` for which transitions cross over.
 
-export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
+export type ConnectionStatus = SocketStatus | 'error'
+
+/**
+ * True while the app is inside a LIVE session — either connected, or connected
+ * with the socket transiently down and the client retrying on its own backoff.
+ *
+ * Every app-shell / overlay gate must use this rather than `=== 'connected'`, so
+ * a mid-session drop keeps the dashboard up instead of throwing the full-screen
+ * connect modal (or the onboarding wizard) over a working workspace. Gates that
+ * mean "the Gateway is usable RIGHT NOW" — deploying an OpenClaw team, sending on
+ * an OpenClaw chat, the Runtimes health row — deliberately stay strict.
+ */
+export function isSessionLive(status: ConnectionStatus): boolean {
+  return status === 'connected' || status === 'reconnecting'
+}
 
 // ─── Store ────────────────────────────────────────────────────────────────────
 

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,18 @@ const alias = { '@': path.resolve(__dirname, 'src') }
 export default defineConfig({
   test: {
     globals: true,
+    // Bound the TOTAL worker pool. Vitest runs the two projects below
+    // CONCURRENTLY, and each one sizes its own pool to the full CPU count — so
+    // the default is ~2x cores of workers fighting over the machine. The
+    // jsdom project's transforms (framer-motion / React Flow / jest-axe) are
+    // CPU-bound, so that over-subscription starves whole files past their
+    // timeout: on an 8-core box the suite took ~42 min with 18-62 spurious
+    // "Test timed out" failures, and 48 s with ZERO at 50%. The failures were
+    // never real — every one of those files passes on its own.
+    //
+    // This is the actual fix for that starvation; the widened per-project
+    // timeouts below are the older, blunter mitigation for the same cause.
+    maxWorkers: '50%',
     projects: [
       {
         resolve: { alias },

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -1,4 +1,4 @@
-import type { AgentStatus, ConnectionStatus, EventFrame } from '@clawboo/gateway-client'
+import type { AgentStatus, EventFrame } from '@clawboo/gateway-client'
 import type { Logger } from '@clawboo/logger'
 
 // ── Chat and Agent event payloads ──────────────────────────────────────────
@@ -109,7 +109,6 @@ export type EventIntent =
 
 export type EventHandlerDeps = {
   // State queries
-  getConnectionStatus: () => ConnectionStatus
   getAgentRunId: (agentId: string) => string | null
 
   // Dispatchers (to Zustand stores — injected from apps/web)

--- a/packages/gateway-client/src/__tests__/client.test.ts
+++ b/packages/gateway-client/src/__tests__/client.test.ts
@@ -403,6 +403,64 @@ describe('GatewayClient', () => {
       client.onStatus((s) => statuses.push(s))
       expect(statuses).toContain('disconnected')
     })
+
+    // The SPA mirrors these emissions into its connection store, so the SEQUENCE
+    // a subscriber observes is load-bearing — not just the terminal
+    // `client.status`. In particular a non-manual drop must surface as
+    // 'reconnecting' (never 'disconnected'), because that is the only signal the
+    // dashboard has that a live socket went away.
+    it('emits the full transition sequence across connect then a non-manual drop', async () => {
+      const client = new GatewayClient()
+      const seen: string[] = []
+      client.onStatus((s) => seen.push(s)) // replays 'disconnected'
+
+      const ws = await connectClient(client)
+      expect(seen).toEqual(['disconnected', 'connecting', 'connected'])
+
+      ws.simulateClose(1006, 'dropped')
+      expect(seen).toEqual(['disconnected', 'connecting', 'connected', 'reconnecting'])
+
+      // A manual stop clears the scheduled reconnect and reports 'disconnected'.
+      client.disconnect()
+      expect(seen[seen.length - 1]).toBe('disconnected')
+    })
+
+    it('unsubscribe stops status callbacks', async () => {
+      const client = new GatewayClient()
+      const seen: string[] = []
+      const unsub = client.onStatus((s) => seen.push(s))
+      expect(seen).toEqual(['disconnected'])
+
+      unsub()
+      const ws = await connectClient(client)
+      ws.simulateClose(1006, 'dropped')
+
+      expect(seen).toEqual(['disconnected'])
+      client.disconnect()
+    })
+
+    // Load-bearing: 'connected' is emitted INSIDE `sendConnect()`'s try block, so
+    // an unguarded fan-out would let a subscriber's throw be caught there and
+    // misread as a connect failure — clearing the device token, rejecting a
+    // connect that succeeded, and closing a healthy socket into a retry loop.
+    it('a throwing subscriber cannot break the connect or the other subscribers', async () => {
+      const client = new GatewayClient()
+      const seen: string[] = []
+      // The subscribe-time REPLAY is a status delivery too, so this must not
+      // throw out of `onStatus` either.
+      expect(() =>
+        client.onStatus(() => {
+          throw new Error('subscriber blew up')
+        }),
+      ).not.toThrow()
+      client.onStatus((s) => seen.push(s))
+
+      await expect(connectClient(client)).resolves.toBeDefined()
+
+      expect(client.status).toBe('connected')
+      expect(seen).toContain('connected')
+      client.disconnect()
+    })
   })
 
   describe('call() throws when not connected', () => {

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -101,7 +101,10 @@ export class GatewayClient {
 
   onStatus(handler: StatusHandler): () => void {
     this.statusHandlers.add(handler)
-    handler(this._status)
+    // Replay the current status so a late subscriber is never blind. Guarded for
+    // the same reason as the fan-out in `updateStatus`: a subscriber's throw must
+    // not escape into whoever happened to be subscribing.
+    this.notifyStatus(handler, this._status)
     return () => this.statusHandlers.delete(handler)
   }
 
@@ -484,10 +487,29 @@ export class GatewayClient {
     this.rejectConnect = null
   }
 
+  /**
+   * Deliver one status to one handler, absorbing anything it throws.
+   *
+   * Load-bearing: `updateStatus('connected')` fires INSIDE `sendConnect()`'s try
+   * block, so an unguarded subscriber throw would be caught there and misread as
+   * a connect failure — clearing the stored device token, rejecting a connect
+   * that actually succeeded, and closing a healthy socket with 4008 (which then
+   * starts an endless reconnect loop that re-throws each pass). A subscriber's
+   * bug must not be able to do that. Mirrors the event fan-out in
+   * `handleMessage`.
+   */
+  private notifyStatus(handler: StatusHandler, status: ConnectionStatus): void {
+    try {
+      handler(status)
+    } catch (err) {
+      log.error({ err, status }, 'status handler threw')
+    }
+  }
+
   private updateStatus(status: ConnectionStatus): void {
     log.debug({ from: this._status, to: status }, 'status transition')
     this._status = status
-    this.statusHandlers.forEach((h) => h(status))
+    this.statusHandlers.forEach((h) => this.notifyStatus(h, status))
   }
 
   // ── Typed method helpers ────────────────────────────────────────────────────

--- a/tests/e2e/15-live-reconnect.spec.ts
+++ b/tests/e2e/15-live-reconnect.spec.ts
@@ -1,0 +1,71 @@
+// A REAL mid-session WebSocket drop, end to end: browser → /api/gateway/ws proxy
+// → mock Gateway. Killing the upstream makes the proxy close the browser socket
+// with 1012, which is a non-manual close — so the browser GatewayClient goes to
+// `reconnecting` and starts its own backoff. This is the exact scenario from
+// issue #67 (machine sleep / Gateway restart), and the only place it can be
+// exercised against a real socket rather than a faked client.
+
+import { test, expect, connectToMockGateway } from './helpers/fixtures'
+
+test.describe('Live Gateway reconnect', () => {
+  test('a dropped socket surfaces the banner, keeps the workspace, and self-heals', async ({
+    page,
+    request,
+    gateway,
+  }) => {
+    await connectToMockGateway(page, request, gateway.url)
+
+    const banner = page.locator('[data-testid="gateway-live-reconnect-banner"]')
+    const connectScreen = page.locator('[data-testid="gateway-connect-screen"]')
+    const sidebar = page.locator('[data-testid="agent-list-column"]')
+
+    // Baseline: connected, no banner.
+    await expect(banner).toBeHidden()
+
+    // Kill the live connection but keep listening, so the client's retry can land.
+    gateway.dropConnections()
+
+    // 1. The drop is reflected in the UI.
+    await expect(banner).toBeVisible({ timeout: 15_000 })
+    await expect(banner).toContainText('Reconnecting to Gateway')
+
+    // 2. It is NON-BLOCKING: the workspace stays, and the full-screen connect
+    //    modal must NOT appear. Before this change every overlay was gated on a
+    //    strict `status === 'connected'`, so a blip threw that modal over a
+    //    working dashboard — this is the regression this test exists to catch.
+    await expect(sidebar).toBeVisible()
+    await expect(sidebar.getByText('Research Boo')).toBeVisible()
+    await expect(connectScreen).toHaveCount(0)
+
+    // 3. The client reconnects on its own backoff (800ms, then x1.7) and the
+    //    banner clears without the user touching anything.
+    await expect(banner).toBeHidden({ timeout: 30_000 })
+    await expect(sidebar.getByText('Research Boo')).toBeVisible()
+  })
+
+  test('"Connect manually" escapes a Gateway that never comes back', async ({
+    page,
+    request,
+    gateway,
+  }) => {
+    await connectToMockGateway(page, request, gateway.url)
+
+    const banner = page.locator('[data-testid="gateway-live-reconnect-banner"]')
+
+    // Stop listening entirely, then drop: every retry now fails, so the client
+    // would spin on `reconnecting` forever. Without an escape the user could
+    // never reach the connect form again.
+    gateway.close()
+    gateway.dropConnections()
+
+    await expect(banner).toBeVisible({ timeout: 15_000 })
+
+    await page.locator('[data-testid="gateway-live-reconnect-manual"]').click()
+
+    // The retry loop is stopped and the manual connect screen takes over.
+    await expect(page.locator('[data-testid="gateway-connect-screen"]')).toBeVisible({
+      timeout: 15_000,
+    })
+    await expect(banner).toBeHidden()
+  })
+})

--- a/tests/e2e/helpers/mockGateway.ts
+++ b/tests/e2e/helpers/mockGateway.ts
@@ -17,6 +17,13 @@ export interface MockGateway {
   port: number
   /** Shut down the server */
   close: () => void
+  /**
+   * Kill every live connection but KEEP listening — simulates a Gateway that
+   * dropped the socket (sleep / restart) and will accept a reconnect. The proxy
+   * mirrors the upstream close onto the browser socket, which is what drives the
+   * browser client into its `reconnecting` state.
+   */
+  dropConnections: () => void
   /** All received frames (for assertions) */
   received: Frame[]
 }
@@ -178,6 +185,9 @@ export async function startMockGateway(): Promise<MockGateway> {
     url: `ws://127.0.0.1:${port}`,
     port,
     close: () => wss.close(),
+    dropConnections: () => {
+      for (const client of wss.clients) client.terminate()
+    },
     received,
   }
 }


### PR DESCRIPTION
## Summary

* Fixes the UI to accurately reflect the current WebSocket connection state in real time.
* Synchronizes connection indicators with live connection events so users receive immediate and consistent status updates.
* Improves the reliability of connection-related feedback during reconnects, disconnects, and other WebSocket state transitions.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff

Closes #67


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-blocking reconnecting banner with status messaging and a manual connection option.
  * Connection indicators now distinguish connected, reconnecting, warning, and offline states.
  * Chat sending pauses during Gateway reconnection while native chats remain available.
* **Bug Fixes**
  * Transient connection drops no longer hide dashboard or session content.
  * Failed connection attempts now stop retrying discarded connections.
  * Improved recovery when connections reconnect or remain unavailable.
* **Tests**
  * Expanded coverage for reconnection, status updates, accessibility, and end-to-end recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->