### PR TITLE
fix(web): prevent destructive Backspace actions and contain dialog Escape handling

### DIFF
--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -1247,6 +1247,14 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
         // default <Controls> lock, which is why <Controls> is no longer rendered.
         nodesDraggable={!locked}
         elementsSelectable={!locked}
+        // React Flow's default `deleteKeyCode` is 'Backspace', and its keyboard
+        // a11y binds Enter/Space to select a focused node — so Tab, Enter,
+        // Backspace removes an agent from the canvas. That path runs through
+        // `onNodesChange` → `applyNodeChanges`, which only splices the node out of
+        // the local store: no confirmation, no `deleteAgentOperation`, no server
+        // call. The agent is untouched and silently reappears on reload.
+        // Deletion belongs to the context menu, which does all three.
+        deleteKeyCode={null}
         // The hidden text every node's `aria-describedby` points at. NOTE the key
         // names are inverted in @xyflow/system: with keyboard a11y ON (our case)
         // React Flow renders `node.a11yDescription.keyboardDisabled`, NOT

--- a/apps/web/src/features/graph/__tests__/GhostGraph.deleteKey.test.tsx
+++ b/apps/web/src/features/graph/__tests__/GhostGraph.deleteKey.test.tsx
@@ -1,0 +1,66 @@
+// Backspace must not delete an agent from the canvas.
+//
+// React Flow's default `deleteKeyCode` is 'Backspace', and its keyboard a11y
+// binds Enter/Space to select a focused node — so Tab, Enter, Backspace removed
+// an agent. That path goes through `onNodesChange` → `applyNodeChanges`, which
+// only splices the node out of the local graph store: no confirmation, no
+// `deleteAgentOperation`, no server call. The agent was untouched and reappeared
+// on the next load.
+//
+// Only `<ReactFlow>` is stubbed, to capture its props; everything else in
+// @xyflow/react stays real, so the surrounding hooks (`useReactFlow`,
+// `useViewport`, …) work against a genuine ReactFlowProvider. Rendering the real
+// canvas would drag in a layout engine and prove nothing extra — the guarantee
+// lives entirely in the prop.
+
+import { render, waitFor } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+import { http, HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { server } from '@/__vitest__/mswServer'
+
+const reactFlowProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }))
+
+vi.mock('@xyflow/react', async (importActual) => ({
+  ...(await importActual<typeof import('@xyflow/react')>()),
+  ReactFlow: (props: Record<string, unknown>) => {
+    reactFlowProps.current = props
+    return <div data-testid="react-flow-stub" />
+  },
+}))
+
+const { GhostGraph } = await import('../GhostGraph')
+
+describe('GhostGraph — destructive key bindings', () => {
+  beforeEach(() => {
+    // The canvas fetches its saved layout and the observability overlay on mount.
+    // Empty responses are enough — this asserts a prop, not rendered content.
+    server.use(
+      http.get('/api/graph-layout', () => HttpResponse.json({ positions: {} })),
+      http.get('/api/obs/graph', () => HttpResponse.json({ nodes: [], edges: [] })),
+      http.get('/api/obs/health', () => HttpResponse.json({ agents: [] })),
+    )
+  })
+
+  it('disables React Flow’s Backspace-to-delete', async () => {
+    render(
+      <ReactFlowProvider>
+        <GhostGraph scope="atlas" />
+      </ReactFlowProvider>,
+    )
+
+    await waitFor(() => expect(reactFlowProps.current).not.toBeNull())
+
+    // `null` disables it outright. Anything else — including leaving the prop
+    // off, which is how this shipped — restores 'Backspace'.
+    expect(reactFlowProps.current?.deleteKeyCode).toBeNull()
+  })
+
+  it('still allows selection, so the fix did not disable the canvas', () => {
+    // Guards the lazy "fix": turning off `elementsSelectable` would also stop the
+    // deletion, at the cost of the selection the hover cascade and the context
+    // menu both rely on.
+    expect(reactFlowProps.current?.elementsSelectable).toBe(true)
+  })
+})

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -18,6 +18,15 @@ import type { NavView } from '@/stores/view'
 
 // ─── View transition config ─────────────────────────────────────────────────
 
+/**
+ * True when something is layered over the content area and owns the keyboard, so
+ * the app-shell shortcuts must stand down. See the call site for why each of the
+ * three surfaces has to be named individually.
+ */
+function overlayOwnsKeyboard(): boolean {
+  return hasOpenTrap() || useSettingsModalStore.getState().open || useEditorStore.getState().isOpen
+}
+
 const VIEW_TRANSITION = { duration: 0.15, ease: 'easeOut' as const }
 const VIEW_STYLE = {
   display: 'flex' as const,
@@ -116,13 +125,24 @@ export function ContentArea() {
         return
       }
 
-      // Every remaining shortcut moves the view BEHIND a dialog, which is never
-      // what the user meant while one is open: Cmd/Ctrl+1..4 call `navigateTo`
-      // directly, and Cmd/Ctrl+, would stack Settings — whose own Tab trap does
-      // not go through `useFocusTrap` — on top of a dialog that still owns the
-      // keyboard. Escape is handled above because it has its own layering
-      // (Settings first, then the trap stack, then the editor).
-      if (hasOpenTrap()) return
+      // Every remaining shortcut moves the view BEHIND whatever is layered over
+      // the content area, which is never what the user meant: Cmd/Ctrl+1..4 call
+      // `navigateTo` directly, and Cmd/Ctrl+, would stack Settings on top of a
+      // dialog that still owns the keyboard. Escape is handled above instead,
+      // because it has its own layering (Settings closes first, then the trap
+      // stack, then the editor).
+      //
+      // All three surfaces have to be named separately — there is no single
+      // registry:
+      //   • `hasOpenTrap()` covers every `Modal`.
+      //   • SettingsModal traps Tab itself rather than going through
+      //     `useFocusTrap`, so it never reaches the stack.
+      //   • The file editor is `fixed inset-y-0 right-0` over the whole content
+      //     area and does not close on a view change, so navigating behind it
+      //     strands the user in an editor over a view they never chose.
+      // The input guard at the top of this handler masks all three while a text
+      // field holds focus; Tab to any button and the shortcut gets through.
+      if (overlayOwnsKeyboard()) return
 
       // Cmd/Ctrl+, — open the Settings modal (the universal settings shortcut)
       if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === ',') {

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -116,6 +116,14 @@ export function ContentArea() {
         return
       }
 
+      // Every remaining shortcut moves the view BEHIND a dialog, which is never
+      // what the user meant while one is open: Cmd/Ctrl+1..4 call `navigateTo`
+      // directly, and Cmd/Ctrl+, would stack Settings — whose own Tab trap does
+      // not go through `useFocusTrap` — on top of a dialog that still owns the
+      // keyboard. Escape is handled above because it has its own layering
+      // (Settings first, then the trap stack, then the editor).
+      if (hasOpenTrap()) return
+
       // Cmd/Ctrl+, — open the Settings modal (the universal settings shortcut)
       if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === ',') {
         e.preventDefault()

--- a/apps/web/src/features/layout/ContentArea.tsx
+++ b/apps/web/src/features/layout/ContentArea.tsx
@@ -5,6 +5,7 @@ import { AgentFileEditorOverlay } from '@/features/editor/AgentFileEditorOverlay
 import { AgentDetailView } from '@/features/agent-detail'
 import { GroupChatView } from '@/features/group-chat/GroupChatView'
 import { ErrorBoundary } from '@/features/shared/ErrorBoundary'
+import { hasOpenTrap } from '@/features/shared/useFocusTrap'
 import { NAV_VIEW_LABELS } from '@/lib/navLabels'
 import { WelcomeState } from './WelcomeState'
 import { useViewStore } from '@/stores/view'
@@ -91,6 +92,17 @@ export function ContentArea() {
           useSettingsModalStore.getState().close()
           return
         }
+        // A `Modal` is open: it owns Escape and closes itself from its own
+        // window-BUBBLE listener. THIS handler is on document-BUBBLE, which fires
+        // FIRST, so the dialog cannot suppress it with stopPropagation — the trap
+        // stack is the arbitration. Without this, Escape inside a dialog opened
+        // over an agent / group-chat view would ALSO deselect the agent and jump
+        // the app to Welcome behind the still-closing dialog.
+        //
+        // Deliberately AFTER the Settings branch: SettingsModal traps Tab itself
+        // rather than going through `useFocusTrap`, so it never registers on the
+        // stack and its Escape ordering is unchanged.
+        if (hasOpenTrap()) return
         if (useEditorStore.getState().isOpen) return
         if (
           viewMode.type === 'agent' ||

--- a/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
+++ b/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
@@ -33,6 +33,8 @@ const { ContentArea } = await import('../ContentArea')
 const { Modal } = await import('@/features/shared/Modal')
 const { useViewStore } = await import('@/stores/view')
 const { useTeamStore } = await import('@/stores/team')
+const { useSettingsModalStore } = await import('@/stores/settingsModal')
+const { useEditorStore } = await import('@/stores/editor')
 
 beforeEach(() => {
   // The team must exist in the store: ContentArea has a guard effect that sends a
@@ -47,6 +49,8 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup()
+  useSettingsModalStore.getState().close()
+  useEditorStore.getState().closeEditor()
   useTeamStore.setState({ teams: [], selectedTeamId: null })
 })
 
@@ -95,6 +99,36 @@ describe('ContentArea — Escape arbitration', () => {
       </>,
     )
     await screen.findByTestId('overlay')
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+  })
+
+  it('ignores the Cmd/Ctrl+number nav shortcuts while Settings is open', async () => {
+    // SettingsModal traps Tab itself instead of going through `useFocusTrap`, so
+    // it never lands on the trap stack — `hasOpenTrap()` alone does not cover it.
+    // Its search field is focused on open, which the input guard above skips, but
+    // Tab to any control in the left rail and the shortcut gets through.
+    const user = userEvent.setup()
+    render(<ContentArea />)
+    await screen.findByTestId('stub-group-chat')
+    useSettingsModalStore.getState().openSettings()
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+  })
+
+  it('ignores the Cmd/Ctrl+number nav shortcuts while the file editor is open', async () => {
+    // The editor is `fixed inset-y-0 right-0 left:268` — it covers the whole
+    // content area and does not close on a view change, so navigating behind it
+    // strands the user in an editor over a view they never chose. The Escape
+    // branch already defers to it; the shortcuts have to as well.
+    const user = userEvent.setup()
+    render(<ContentArea />)
+    await screen.findByTestId('stub-group-chat')
+    useEditorStore.getState().openEditor('a1', 'Agent One')
 
     await user.keyboard('{Meta>}2{/Meta}')
 

--- a/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
+++ b/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
@@ -1,0 +1,103 @@
+// The app-shell Escape fallback vs. an open dialog — against the REAL ContentArea.
+//
+// `ContentArea` registers its Escape handler on DOCUMENT in the BUBBLE phase, and
+// `Modal` registers its own on WINDOW in the bubble phase. Document-bubble runs
+// FIRST, so the dialog cannot defer to the shell and cannot suppress it with
+// `stopPropagation` (they are not the same node). The focus-trap stack is the
+// arbitration: if any trap is mounted, the shell stands down.
+//
+// Without it, Escape inside a dialog opened over an agent / group-chat view also
+// deselects the agent and jumps the app to Welcome behind the closing dialog.
+//
+// The view components are mocked to stubs: this exercises ContentArea's keyboard
+// handler, not the panels it renders (which would each need their own /api
+// handlers under msw's onUnhandledRequest:'error').
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/features/agent-detail', () => ({
+  AgentDetailView: () => <div data-testid="stub-agent-detail" />,
+}))
+vi.mock('@/features/group-chat/GroupChatView', () => ({
+  GroupChatView: () => <div data-testid="stub-group-chat" />,
+}))
+vi.mock('@/features/editor/AgentFileEditorOverlay', () => ({
+  AgentFileEditorOverlay: () => null,
+}))
+vi.mock('../WelcomeState', () => ({ WelcomeState: () => <div data-testid="stub-welcome" /> }))
+vi.mock('../navPanels', () => ({ NavPanel: () => null }))
+
+const { ContentArea } = await import('../ContentArea')
+const { Modal } = await import('@/features/shared/Modal')
+const { useViewStore } = await import('@/stores/view')
+const { useTeamStore } = await import('@/stores/team')
+
+beforeEach(() => {
+  // The team must exist in the store: ContentArea has a guard effect that sends a
+  // groupChat view for a deleted team straight back to Welcome, which would
+  // otherwise look exactly like the regression under test.
+  useTeamStore.setState({
+    teams: [{ id: 't1', name: 'Team One' } as never],
+    selectedTeamId: 't1',
+  })
+  useViewStore.getState().setViewMode({ type: 'groupChat', teamId: 't1' })
+})
+
+afterEach(() => {
+  cleanup()
+  useTeamStore.setState({ teams: [], selectedTeamId: null })
+})
+
+describe('ContentArea — Escape arbitration', () => {
+  it('navigates to Welcome when no dialog is open', async () => {
+    const user = userEvent.setup()
+    render(<ContentArea />)
+    await screen.findByTestId('stub-group-chat')
+
+    await user.keyboard('{Escape}')
+
+    expect(useViewStore.getState().viewMode.type).toBe('welcome')
+  })
+
+  it('leaves the view alone while a dialog owns Escape', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(
+      <>
+        <ContentArea />
+        <Modal open onClose={onClose} label="An overlay" data-testid="overlay">
+          <button type="button">something</button>
+        </Modal>
+      </>,
+    )
+    await screen.findByTestId('overlay')
+
+    await user.keyboard('{Escape}')
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    // The load-bearing half: the app did NOT navigate out from under the dialog.
+    expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+  })
+
+  it('hands Escape back to the app shell once the dialog closes', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <>
+        <ContentArea />
+        <Modal open onClose={vi.fn()} label="An overlay" data-testid="overlay">
+          <button type="button">something</button>
+        </Modal>
+      </>,
+    )
+    await screen.findByTestId('overlay')
+
+    rerender(<ContentArea />)
+    await waitFor(() => expect(screen.queryByTestId('overlay')).not.toBeInTheDocument())
+
+    await user.keyboard('{Escape}')
+
+    expect(useViewStore.getState().viewMode.type).toBe('welcome')
+  })
+})

--- a/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
+++ b/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
@@ -90,10 +90,11 @@ describe('ContentArea — Escape arbitration', () => {
     // dialog: Cmd/Ctrl+1..4 call `navigateTo` directly. Containment has to cover
     // every global shortcut, not just the one that surfaced the bug.
     const user = userEvent.setup()
+    const onClose = vi.fn()
     render(
       <>
         <ContentArea />
-        <Modal open onClose={vi.fn()} label="An overlay" data-testid="overlay">
+        <Modal open onClose={onClose} label="An overlay" data-testid="overlay">
           <button type="button">something</button>
         </Modal>
       </>,
@@ -103,6 +104,9 @@ describe('ContentArea — Escape arbitration', () => {
     await user.keyboard('{Meta>}2{/Meta}')
 
     expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+    // The shortcut must be wholly inert, not merely non-navigating: dismissing
+    // the dialog instead would also leave the view on groupChat and pass.
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it('ignores the Cmd/Ctrl+number nav shortcuts while Settings is open', async () => {
@@ -118,6 +122,9 @@ describe('ContentArea — Escape arbitration', () => {
     await user.keyboard('{Meta>}2{/Meta}')
 
     expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+    // As above: closing Settings instead of navigating would also leave the view
+    // on groupChat, so assert the overlay itself survived.
+    expect(useSettingsModalStore.getState().open).toBe(true)
   })
 
   it('ignores the Cmd/Ctrl+number nav shortcuts while the file editor is open', async () => {
@@ -133,6 +140,7 @@ describe('ContentArea — Escape arbitration', () => {
     await user.keyboard('{Meta>}2{/Meta}')
 
     expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+    expect(useEditorStore.getState().isOpen).toBe(true)
   })
 
   it('honours the Cmd/Ctrl+number nav shortcuts when no dialog is open', async () => {

--- a/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
+++ b/apps/web/src/features/layout/__tests__/contentAreaEscape.test.tsx
@@ -81,6 +81,36 @@ describe('ContentArea — Escape arbitration', () => {
     expect(useViewStore.getState().viewMode.type).toBe('groupChat')
   })
 
+  it('ignores the Cmd/Ctrl+number nav shortcuts while a dialog is open', async () => {
+    // Escape is not the only way the shell can move the view out from under a
+    // dialog: Cmd/Ctrl+1..4 call `navigateTo` directly. Containment has to cover
+    // every global shortcut, not just the one that surfaced the bug.
+    const user = userEvent.setup()
+    render(
+      <>
+        <ContentArea />
+        <Modal open onClose={vi.fn()} label="An overlay" data-testid="overlay">
+          <button type="button">something</button>
+        </Modal>
+      </>,
+    )
+    await screen.findByTestId('overlay')
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(useViewStore.getState().viewMode.type).toBe('groupChat')
+  })
+
+  it('honours the Cmd/Ctrl+number nav shortcuts when no dialog is open', async () => {
+    const user = userEvent.setup()
+    render(<ContentArea />)
+    await screen.findByTestId('stub-group-chat')
+
+    await user.keyboard('{Meta>}2{/Meta}')
+
+    expect(useViewStore.getState().viewMode).toMatchObject({ type: 'nav', view: 'fleet' })
+  })
+
   it('hands Escape back to the app shell once the dialog closes', async () => {
     const user = userEvent.setup()
     const { rerender } = render(

--- a/apps/web/src/features/shared/useFocusTrap.ts
+++ b/apps/web/src/features/shared/useFocusTrap.ts
@@ -52,6 +52,20 @@ export function isTopmostTrap(token: symbol | null): boolean {
 }
 
 /**
+ * True when ANY dialog is open.
+ *
+ * The app-shell keyboard handler (`features/layout/ContentArea.tsx`) needs this
+ * because it listens on `document` in the BUBBLE phase, which fires BEFORE a
+ * `Modal`'s `window`-bubble Escape — so a dialog cannot defer to it, and cannot
+ * suppress it with `stopPropagation` either. Without this check, Escape inside a
+ * dialog opened over an agent / group-chat view ALSO deselects the agent and
+ * jumps the app to Welcome behind the dialog.
+ */
+export function hasOpenTrap(): boolean {
+  return trapStack.length > 0
+}
+
+/**
  * @param ref               the dialog element to trap focus within.
  * @param focusKey          re-run the focus move when this changes (a wizard step).
  * @param initialFocusRef   focus this on entry instead of the root's first focusable.


### PR DESCRIPTION
## Summary

* Prevents `Backspace` from accidentally deleting the selected graph agent when focus is outside an intended destructive action.
* Stops `Escape` key events handled by dialogs from propagating to underlying application views.
* Improves keyboard interaction safety by ensuring shortcuts respect focused controls, modal boundaries, and active UI context.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff

refs #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Disabled accidental graph node deletion via the Backspace key; nodes can still be deleted from the context menu.
  * Improved keyboard handling so Escape and navigation shortcuts remain within open dialogs, Settings, and the file editor.
  * Restored normal Escape and navigation behavior after overlays are closed.

* **Tests**
  * Added coverage for graph deletion controls, overlay keyboard handling, and restored navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->