### PR TITLE
board: reflect a drawer status change in the columns immediately

### DIFF
--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -387,8 +387,9 @@ export function BoardPanel() {
   // the card never lingers with a stale runtime or a misleading verification pill until the
   // poll catches up. Drops any in-flight override for the task so the committed status is
   // authoritative; the next poll then simply agrees (same id, one column) — no flicker,
-  // no duplicate. Other server side effects (e.g. cancelling dependents) reconcile on that
-  // next poll, exactly as they do after a drag.
+  // no duplicate. The PATCH's only row mutations are the status and, on a →todo release,
+  // the three fields cleared above — both mirrored here — so the next poll has nothing to
+  // correct on this row; it just stays authoritative for any concurrent agent change.
   const commitStatus = useCallback(
     (taskId: string, newStatus: string) => {
       // Fence off any read issued before this local write (the 5s poll, Refresh, a

--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -104,6 +104,10 @@ function TaskCard({ task, onClick }: { task: BoardTask; onClick: () => void }) {
     <button
       type="button"
       data-testid="board-card"
+      // A card is destroyed and re-created whenever its task changes column, so the
+      // drawer it opened cannot return focus to the captured node. This tags the card
+      // with its task id so `useFocusTrap` can re-find it on close (#98).
+      data-focus-restore-id={task.id}
       onClick={onClick}
       className="group block w-full cursor-pointer rounded-2xl border border-border bg-surface p-4 text-left transition-[border-color,box-shadow,transform] duration-150 hover:-translate-y-px hover:border-border-strong"
       style={{ boxShadow: 'var(--shadow-raised)' }}
@@ -387,9 +391,10 @@ export function BoardPanel() {
   // the card never lingers with a stale runtime or a misleading verification pill until the
   // poll catches up. Drops any in-flight override for the task so the committed status is
   // authoritative; the next poll then simply agrees (same id, one column) — no flicker,
-  // no duplicate. The PATCH's only row mutations are the status and, on a →todo release,
-  // the three fields cleared above — both mirrored here — so the next poll has nothing to
-  // correct on this row; it just stays authoritative for any concurrent agent change.
+  // no duplicate. The PATCH's only DISPLAYED row writes are the status and, on a →todo
+  // release, the three fields cleared above — both mirrored here — so the poll has no field
+  // left to correct. It still re-sorts the row (the server bumps `updatedAt`, which the
+  // board query orders by) and stays authoritative for any concurrent agent change.
   const commitStatus = useCallback(
     (taskId: string, newStatus: string) => {
       // Fence off any read issued before this local write (the 5s poll, Refresh, a

--- a/apps/web/src/features/board/BoardPanel.tsx
+++ b/apps/web/src/features/board/BoardPanel.tsx
@@ -379,6 +379,40 @@ export function BoardPanel() {
     [],
   )
 
+  // Commit a status change into the authoritative `tasks` so the card moves to its new
+  // column at once — shared by the drawer's editor (via onStatusCommitted, issue #98) and
+  // the drag commit below, so the two manual paths behave identically (the same optimistic
+  // local-state patch handleCreated uses for a new card). Mirrors the server AND the
+  // drawer's own setDetail: a →todo release also clears the assignee/runtime/verdict, so
+  // the card never lingers with a stale runtime or a misleading verification pill until the
+  // poll catches up. Drops any in-flight override for the task so the committed status is
+  // authoritative; the next poll then simply agrees (same id, one column) — no flicker,
+  // no duplicate. Other server side effects (e.g. cancelling dependents) reconcile on that
+  // next poll, exactly as they do after a drag.
+  const commitStatus = useCallback(
+    (taskId: string, newStatus: string) => {
+      // Fence off any read issued before this local write (the 5s poll, Refresh, a
+      // reconcile) so a response that predates the change can't land and snap the card
+      // back to its old column — the same guard handleCreated and the drag commit use.
+      reads.commitLocalWrite()
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === taskId
+            ? {
+                ...t,
+                status: newStatus,
+                ...(newStatus === 'todo'
+                  ? { assigneeAgentId: null, assigneeRuntime: null, verification: null }
+                  : {}),
+              }
+            : t,
+        ),
+      )
+      clearOverride(taskId)
+    },
+    [clearOverride, reads],
+  )
+
   const onDragEnd = useCallback(
     async ({ active, over }: DragEndEvent) => {
       setActiveTask(null)
@@ -393,17 +427,12 @@ export function BoardPanel() {
         applyOptimistic: () => setOverrides((o) => ({ ...o, [move.taskId]: move.to })),
         rollback: () => clearOverride(move.taskId),
       })
-      if (ok) {
-        // The override bridged the in-flight PATCH (it layers over `tasks`, so no read
-        // could clobber it). Clearing it hands authority back to `tasks`, so the commit
-        // must also fence off any read issued before this point — otherwise that read
-        // lands with the pre-drag status and snaps the card back to its old column.
-        reads.commitLocalWrite()
-        setTasks((prev) => prev.map((t) => (t.id === move.taskId ? { ...t, status: move.to } : t)))
-        clearOverride(move.taskId)
-      }
+      // The commit fences off any read issued before this point (via commitStatus →
+      // reads.commitLocalWrite) so a pre-drag snapshot can't snap the card back, then
+      // hands authority from the override back to `tasks`.
+      if (ok) commitStatus(move.taskId, move.to)
     },
-    [effectiveTasks, mutate, clearOverride, reads],
+    [effectiveTasks, mutate, clearOverride, commitStatus],
   )
 
   // Mid-drag, a card may only land on a column it can legally transition to; all other
@@ -573,7 +602,13 @@ export function BoardPanel() {
       </div>
 
       <AnimatePresence>
-        {openTaskId && <TaskDetailDrawer taskId={openTaskId} onClose={() => setOpenTaskId(null)} />}
+        {openTaskId && (
+          <TaskDetailDrawer
+            taskId={openTaskId}
+            onClose={() => setOpenTaskId(null)}
+            onStatusCommitted={commitStatus}
+          />
+        )}
       </AnimatePresence>
 
       <NewTaskDialog

--- a/apps/web/src/features/board/TaskDetailDrawer.tsx
+++ b/apps/web/src/features/board/TaskDetailDrawer.tsx
@@ -123,7 +123,18 @@ function kvControl(label: string, control: React.ReactNode) {
   )
 }
 
-export function TaskDetailDrawer({ taskId, onClose }: { taskId: string; onClose: () => void }) {
+export function TaskDetailDrawer({
+  taskId,
+  onClose,
+  onStatusCommitted,
+}: {
+  taskId: string
+  onClose: () => void
+  /** Fires after a status change commits (success only), so the parent board can move
+   *  the card to its new column immediately instead of waiting for the next ~5s
+   *  reconciliation poll (#98). Mirrors the drawer's own optimistic `setDetail`. */
+  onStatusCommitted?: (taskId: string, newStatus: string) => void
+}) {
   const [detail, setDetail] = useState<TaskDetail | null>(null)
   const [executions, setExecutions] = useState<BoardExecution[]>([])
   const [workspace, setWorkspace] = useState<WorkspaceDetail | null>(null)
@@ -249,7 +260,7 @@ export function TaskDetailDrawer({ taskId, onClose }: { taskId: string; onClose:
                   taskId={task.id}
                   status={task.status}
                   assigneeAgentId={task.assigneeAgentId}
-                  onChange={(next) =>
+                  onChange={(next) => {
                     setDetail((d) =>
                       d
                         ? {
@@ -273,7 +284,10 @@ export function TaskDetailDrawer({ taskId, onClose }: { taskId: string; onClose:
                           }
                         : d,
                     )
-                  }
+                    // Reflect the move on the board at once (#98). onChange fires only
+                    // on a committed change, so this never moves a card for a failed one.
+                    onStatusCommitted?.(taskId, next)
+                  }}
                 />,
               )}
               {kv('Assignee', String(task['assigneeAgentId'] ?? '—'))}

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -745,6 +745,16 @@ describe('BoardPanel', () => {
     await user.keyboard('{Escape}')
     await waitFor(() => expect(screen.queryByTestId('task-detail-drawer')).toBeNull())
 
+    // Focus comes back to the card, not <body>. Moving columns destroyed the exact node
+    // the drawer was opened from, so the return only works because the card carries
+    // `data-focus-restore-id` for useFocusTrap to re-find it. Without it a keyboard user
+    // closes the drawer and the next Tab restarts at the top of the document.
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('board-column-in_progress')).getByTestId('board-card'),
+      ).toHaveFocus(),
+    )
+
     // The next poll (Refresh runs the identical refresh()) reconciles against the advanced
     // server and keeps the card put — no flicker back to To do, still exactly one card.
     await user.click(screen.getByRole('button', { name: 'Refresh' }))

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -658,4 +658,130 @@ describe('BoardPanel', () => {
     expect(dropped).toContain('Done')
     expect(dropped).not.toMatch(/t1|in_progress/)
   })
+
+  it('moves a card to its new column immediately when a status change commits in the drawer (#98)', async () => {
+    // A drawer status commit patches BoardPanel.tasks via onStatusCommitted, so the card
+    // jumps columns at once instead of waiting up to ~5s for the reconciliation poll.
+    // Server truth advances on the PATCH (a real backend would), so the next poll —
+    // proxied by Refresh, the same refresh() path the 5s poll uses — keeps the card in
+    // its new column with no flicker and no duplicate.
+    let board = [{ id: 't1', title: 'Ship it', status: 'todo' }]
+    let boardGets = 0
+    server.use(
+      http.get('/api/board', () => {
+        boardGets++
+        return HttpResponse.json({ tasks: board })
+      }),
+      // The drawer's on-mount fetches; the detail reflects the current server status.
+      http.get('/api/board/t1', () =>
+        HttpResponse.json({
+          task: { id: 't1', title: 'Ship it', status: board[0]!.status },
+          comments: [],
+          ancestors: [],
+        }),
+      ),
+      http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
+      http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
+      http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
+      http.patch('/api/board/t1', async ({ request }) => {
+        const body = (await request.json()) as { status: string }
+        board = [{ id: 't1', title: 'Ship it', status: body.status }] // the server advances
+        return HttpResponse.json({ ok: true, task: { id: 't1', status: body.status } })
+      }),
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+
+    // The card starts in To do.
+    await screen.findByTestId('board-card')
+    expect(
+      within(screen.getByTestId('board-column-todo')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+
+    // Open the drawer and pick the In progress target.
+    await user.click(screen.getByTestId('board-card'))
+    await screen.findByTestId('task-detail-drawer')
+    await user.click(screen.getByTestId('task-status-select'))
+    const option = await screen.findByRole('option', { name: 'In progress' })
+
+    // Snapshot the board-list fetch count right before the commit. Nothing in the window
+    // below fetches the list, so the only thing that can move the card is the optimistic
+    // onStatusCommitted patch — a poll/refetch would bump this count and fail the assert.
+    // (Captured here, not before opening the drawer, to keep the window tiny so the real
+    // 5s poll can't race it.)
+    const getsBeforeMove = boardGets
+    await user.click(option)
+
+    // The card is in the In progress column right away — optimistic, not poll-driven.
+    await waitFor(() =>
+      expect(
+        within(screen.getByTestId('board-column-in_progress')).getByTestId('board-card'),
+      ).toBeInTheDocument(),
+    )
+    expect(within(screen.getByTestId('board-column-todo')).queryByTestId('board-card')).toBeNull()
+    expect(boardGets).toBe(getsBeforeMove) // moved without waiting for the poll
+    expect(screen.getAllByTestId('board-card')).toHaveLength(1) // no duplicate
+
+    // Close the drawer; the board keeps the card in its new column.
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByTestId('task-detail-drawer')).toBeNull())
+
+    // The next poll (Refresh runs the identical refresh()) reconciles against the advanced
+    // server and keeps the card put — no flicker back to To do, still exactly one card.
+    await user.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(boardGets).toBeGreaterThan(getsBeforeMove))
+    expect(
+      within(screen.getByTestId('board-column-in_progress')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+    expect(screen.getAllByTestId('board-card')).toHaveLength(1)
+  })
+
+  it('leaves the card in its column when a drawer status change is rejected (#98)', async () => {
+    // Board analog of the drag-rollback test: onStatusCommitted is wired to StatusSelect's
+    // success-only onChange, so a 500'd PATCH never calls it — the card must not move, and
+    // no refetch is triggered. Guards against a regression that moves the callback outside
+    // the success gate.
+    let boardGets = 0
+    server.use(
+      http.get('/api/board', () => {
+        boardGets++
+        return HttpResponse.json({ tasks: [{ id: 't1', title: 'Ship it', status: 'todo' }] })
+      }),
+      http.get('/api/board/t1', () =>
+        HttpResponse.json({
+          task: { id: 't1', title: 'Ship it', status: 'todo' },
+          comments: [],
+          ancestors: [],
+        }),
+      ),
+      http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
+      http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
+      http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
+      http.patch('/api/board/t1', () => new HttpResponse(null, { status: 500 })), // server refuses
+    )
+    const user = userEvent.setup()
+    render(<BoardPanel />)
+
+    await screen.findByTestId('board-card')
+    await user.click(screen.getByTestId('board-card'))
+    await screen.findByTestId('task-detail-drawer')
+    await user.click(screen.getByTestId('task-status-select'))
+    const option = await screen.findByRole('option', { name: 'In progress' })
+    const getsBeforeMove = boardGets
+    await user.click(option)
+
+    // The rejection is surfaced (error toast) — i.e. the failure path ran to completion.
+    await waitFor(() =>
+      expect(useToastStore.getState().toasts.some((t) => t.type === 'error')).toBe(true),
+    )
+    // ...and the board card never moved: still in To do, exactly one card, and no refetch.
+    expect(
+      within(screen.getByTestId('board-column-todo')).getByTestId('board-card'),
+    ).toBeInTheDocument()
+    expect(
+      within(screen.getByTestId('board-column-in_progress')).queryByTestId('board-card'),
+    ).toBeNull()
+    expect(screen.getAllByTestId('board-card')).toHaveLength(1)
+    expect(boardGets).toBe(getsBeforeMove)
+  })
 })

--- a/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
+++ b/apps/web/src/features/board/__tests__/BoardPanel.test.tsx
@@ -559,7 +559,14 @@ describe('BoardPanel', () => {
       http.get('/api/board', () =>
         HttpResponse.json({
           tasks: [
-            { id: 't1', title: 'Ship it', status: 'in_progress', assigneeAgentId: 'agent-7' },
+            {
+              id: 't1',
+              title: 'Ship it',
+              status: 'in_progress',
+              assigneeAgentId: 'agent-7',
+              assigneeRuntime: 'claude-code',
+              verification: JSON.stringify({ status: 'fail' }),
+            },
           ],
         }),
       ),
@@ -575,7 +582,10 @@ describe('BoardPanel', () => {
         <ConfirmDialog />
       </>,
     )
-    await screen.findByTestId('board-card')
+    // Sanity: before the move the card carries its runtime + verdict pills.
+    const card = await screen.findByTestId('board-card')
+    expect(within(card).getByText('claude-code')).toBeInTheDocument()
+    expect(within(card).getByText('fail')).toBeInTheDocument()
 
     await act(async () => {
       dnd.onDragEnd?.({ active: { id: 't1' }, over: { id: 'todo' } }) // in_progress → todo (release)
@@ -586,6 +596,15 @@ describe('BoardPanel', () => {
     expect(patched).toBeNull()
     await user.click(within(dialog).getByTestId('confirm-ok'))
     await waitFor(() => expect(patched).toEqual({ status: 'todo' }))
+
+    // The commit mirrors the server's →todo release: it also clears assignee/runtime/verdict,
+    // so the card in To do no longer shows the stale 'claude-code' runtime or the misleading
+    // 'fail' verdict — the reflection is complete, not just the column. (Deleting the →todo
+    // branch in commitStatus fails this.)
+    const todoCard = () => within(screen.getByTestId('board-column-todo')).getByTestId('board-card')
+    await waitFor(() => expect(within(todoCard()).queryByText('claude-code')).toBeNull())
+    expect(within(todoCard()).queryByText('fail')).toBeNull()
+    expect(within(todoCard()).getByText('openclaw')).toBeInTheDocument()
   })
 
   it('offers "Complete anyway" when a drag to Done hits the verification gate', async () => {
@@ -742,6 +761,7 @@ describe('BoardPanel', () => {
     // no refetch is triggered. Guards against a regression that moves the callback outside
     // the success gate.
     let boardGets = 0
+    let patchCalls = 0
     server.use(
       http.get('/api/board', () => {
         boardGets++
@@ -757,7 +777,10 @@ describe('BoardPanel', () => {
       http.get('/api/board/t1/executions', () => HttpResponse.json({ executions: [] })),
       http.get('/api/board/t1/workspace/detail', () => HttpResponse.json({ ok: false })),
       http.get('/api/obs/events', () => HttpResponse.json({ events: [] })),
-      http.patch('/api/board/t1', () => new HttpResponse(null, { status: 500 })), // server refuses
+      http.patch('/api/board/t1', () => {
+        patchCalls++
+        return new HttpResponse(null, { status: 500 }) // legal move todo→in_progress, refused
+      }),
     )
     const user = userEvent.setup()
     render(<BoardPanel />)
@@ -770,10 +793,14 @@ describe('BoardPanel', () => {
     const getsBeforeMove = boardGets
     await user.click(option)
 
-    // The rejection is surfaced (error toast) — i.e. the failure path ran to completion.
+    // The failure surfaced as an error toast — the rejection path ran to completion.
     await waitFor(() =>
       expect(useToastStore.getState().toasts.some((t) => t.type === 'error')).toBe(true),
     )
+    // ...driven by a REAL server rejection: the PATCH fired exactly once. This is what
+    // distinguishes a 500 from a client-side illegal-transition refusal that never sends a
+    // request — todo→in_progress is legal, so the request goes out and comes back refused.
+    expect(patchCalls).toBe(1)
     // ...and the board card never moved: still in To do, exactly one card, and no refetch.
     expect(
       within(screen.getByTestId('board-column-todo')).getByTestId('board-card'),

--- a/apps/web/src/features/shared/__tests__/useFocusTrap.test.tsx
+++ b/apps/web/src/features/shared/__tests__/useFocusTrap.test.tsx
@@ -57,6 +57,37 @@ function TriggerAndDialog() {
 }
 
 /**
+ * A trigger that is DESTROYED and re-created while its dialog is open — the board card
+ * whose task changes column under an open drawer. Flipping `moved` swaps the wrapper
+ * element type, so React cannot reuse the button: the replacement is a genuinely
+ * different DOM node carrying the same `data-focus-restore-id`.
+ */
+function RecreatedTrigger() {
+  const [open, setOpen] = useState(false)
+  const [moved, setMoved] = useState(false)
+  const card = (
+    <button type="button" data-focus-restore-id="t1" onClick={() => setOpen(true)}>
+      Card
+    </button>
+  )
+  return (
+    <>
+      {moved ? <section>{card}</section> : <div>{card}</div>}
+      {open && (
+        <Dialog name="outer">
+          <button type="button" onClick={() => setMoved(true)}>
+            Move
+          </button>
+          <button type="button" onClick={() => setOpen(false)}>
+            Close
+          </button>
+        </Dialog>
+      )}
+    </>
+  )
+}
+
+/**
  * Two stacked dialogs in the topology the app actually uses: the inner one is a
  * DOM SIBLING of the outer, not a descendant — `CreateTeamModal` renders
  * `TeamTemplateDetail` as a sibling `<Modal>` at a higher layer.
@@ -163,6 +194,42 @@ describe('useFocusTrap', () => {
     await user.click(trigger)
     await waitFor(() => expect(screen.getByRole('button', { name: 'outer first' })).toHaveFocus())
 
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+    expect(trigger).toHaveFocus()
+  })
+
+  it('re-finds a trigger that was re-created while the dialog was open', async () => {
+    // `.focus()` on a detached node is a SILENT no-op, so restoring to the captured
+    // reference would strand focus on <body> and send the next Tab to the top of the
+    // document. The trigger's `data-focus-restore-id` is what makes the return survive
+    // its own node being replaced (a board card moving column under an open drawer).
+    const user = userEvent.setup()
+    render(<RecreatedTrigger />)
+    const original = screen.getByRole('button', { name: 'Card' })
+
+    await user.click(original)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'outer first' })).toHaveFocus())
+
+    await user.click(screen.getByRole('button', { name: 'Move' }))
+    expect(original.isConnected).toBe(false) // the captured trigger is gone
+
+    await user.click(screen.getByRole('button', { name: 'Close' }))
+    const replacement = screen.getByRole('button', { name: 'Card' })
+    expect(replacement).not.toBe(original)
+    expect(replacement).toHaveFocus()
+    expect(document.activeElement).not.toBe(document.body)
+  })
+
+  it('leaves focus alone when a re-created trigger is untagged', async () => {
+    // The re-find is opt-in. An untagged trigger keeps the plain node behavior rather
+    // than the trap guessing at a replacement, so this pins the fallback's boundary.
+    const user = userEvent.setup()
+    render(<TriggerAndDialog />)
+    const trigger = screen.getByRole('button', { name: 'Open' })
+    expect(trigger.dataset['focusRestoreId']).toBeUndefined()
+
+    await user.click(trigger)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'outer first' })).toHaveFocus())
     await user.click(screen.getByRole('button', { name: 'Close' }))
     expect(trigger).toHaveFocus()
   })

--- a/apps/web/src/features/shared/__tests__/useFocusTrap.test.tsx
+++ b/apps/web/src/features/shared/__tests__/useFocusTrap.test.tsx
@@ -62,11 +62,17 @@ function TriggerAndDialog() {
  * element type, so React cannot reuse the button: the replacement is a genuinely
  * different DOM node carrying the same `data-focus-restore-id`.
  */
-function RecreatedTrigger() {
+function RecreatedTrigger({ tagged = true }: { tagged?: boolean }) {
   const [open, setOpen] = useState(false)
   const [moved, setMoved] = useState(false)
   const card = (
-    <button type="button" data-focus-restore-id="t1" onClick={() => setOpen(true)}>
+    // `undefined` omits the attribute entirely, so `tagged={false}` is a genuinely
+    // untagged trigger rather than one carrying an empty id.
+    <button
+      type="button"
+      data-focus-restore-id={tagged ? 't1' : undefined}
+      onClick={() => setOpen(true)}
+    >
       Card
     </button>
   )
@@ -220,18 +226,28 @@ describe('useFocusTrap', () => {
     expect(document.activeElement).not.toBe(document.body)
   })
 
-  it('leaves focus alone when a re-created trigger is untagged', async () => {
-    // The re-find is opt-in. An untagged trigger keeps the plain node behavior rather
-    // than the trap guessing at a replacement, so this pins the fallback's boundary.
+  it('does not re-find a re-created trigger that is untagged', async () => {
+    // The re-find is strictly opt-in: with no `data-focus-restore-id` the trap has no
+    // way to tell the replacement apart from any other button, so it must NOT guess.
+    // Same journey as the test above, minus the tag — the replacement stays unfocused.
+    // This is the boundary of the opt-in, and the reason a consumer has to tag its
+    // trigger to get the behavior at all.
     const user = userEvent.setup()
-    render(<TriggerAndDialog />)
-    const trigger = screen.getByRole('button', { name: 'Open' })
-    expect(trigger.dataset['focusRestoreId']).toBeUndefined()
+    render(<RecreatedTrigger tagged={false} />)
+    const original = screen.getByRole('button', { name: 'Card' })
+    expect(original.dataset['focusRestoreId']).toBeUndefined()
 
-    await user.click(trigger)
+    await user.click(original)
     await waitFor(() => expect(screen.getByRole('button', { name: 'outer first' })).toHaveFocus())
+
+    await user.click(screen.getByRole('button', { name: 'Move' }))
+    expect(original.isConnected).toBe(false)
+
     await user.click(screen.getByRole('button', { name: 'Close' }))
-    expect(trigger).toHaveFocus()
+    const replacement = screen.getByRole('button', { name: 'Card' })
+    expect(replacement).not.toBe(original)
+    expect(replacement).not.toHaveFocus()
+    expect(document.activeElement).toBe(document.body)
   })
 
   describe('stacked traps', () => {

--- a/apps/web/src/features/shared/useFocusTrap.ts
+++ b/apps/web/src/features/shared/useFocusTrap.ts
@@ -5,7 +5,9 @@
  *   - move focus into the dialog on mount and whenever `focusKey` changes
  *     (step entry), but never steal focus from a control that's already inside,
  *   - trap Tab / Shift+Tab within the dialog,
- *   - restore focus to whatever was focused before the trap mounted, on unmount.
+ *   - restore focus to whatever was focused before the trap mounted, on unmount —
+ *     re-finding the trigger by `data-focus-restore-id` when it was re-created
+ *     while the dialog was open (see the restore effect).
  *
  * The dialog is the element referenced by `ref`. This is the interaction-level
  * a11y that jest-axe cannot catch.
@@ -93,18 +95,38 @@ export function useFocusTrap(
   }, [])
 
   // Capture the element that had focus before the dialog opened, restore on close.
+  //
+  // The trigger is not always the same DOM node by the time the dialog closes. A board
+  // card that opened the task drawer is destroyed and re-created the moment its task
+  // changes column — a status commit made inside the drawer, or the 5s poll landing
+  // under it — because React cannot reuse a node across two different parents. The
+  // captured reference is then detached, and `.focus()` on a detached node is a SILENT
+  // no-op: focus stays on <body> and the next Tab restarts at the top of the document,
+  // which for a keyboard or screen-reader user means losing their place entirely.
+  //
+  // So capture the trigger's logical identity alongside the node. A trigger that may be
+  // re-created tags itself `data-focus-restore-id`; on close we re-find it by that when
+  // the original is gone. Triggers without the tag keep the plain node behavior.
   const restoreToRef = useRef<HTMLElement | null>(null)
+  const restoreIdRef = useRef<string | null>(null)
   useEffect(() => {
-    restoreToRef.current = (document.activeElement as HTMLElement | null) ?? null
+    const active = (document.activeElement as HTMLElement | null) ?? null
+    restoreToRef.current = active
+    restoreIdRef.current = active?.dataset['focusRestoreId'] ?? null
     return () => {
-      // Restore focus to the trigger — but only if it's still in the DOM. If the trigger
-      // was unmounted while the dialog was open (e.g. a board card that moved columns under
-      // an open drawer, or a poll re-render swapping the node), the captured reference is
-      // detached, and `.focus()` on a detached node is a silent no-op that leaves focus
-      // stranded on <body>. Guarding it stops the primitive from chasing a stale node; a
-      // live trigger still gets focus back.
       const el = restoreToRef.current
-      if (el?.isConnected) el.focus?.()
+      if (el?.isConnected) {
+        el.focus?.()
+        return
+      }
+      const id = restoreIdRef.current
+      if (!id) return
+      // Matched by attribute VALUE rather than a selector: jsdom ships no `CSS.escape`,
+      // and these ids are opaque server strings that must never be spliced into a query.
+      const replacement = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-focus-restore-id]'),
+      ).find((n) => n.dataset['focusRestoreId'] === id)
+      replacement?.focus?.()
     }
   }, [])
 

--- a/apps/web/src/features/shared/useFocusTrap.ts
+++ b/apps/web/src/features/shared/useFocusTrap.ts
@@ -97,7 +97,14 @@ export function useFocusTrap(
   useEffect(() => {
     restoreToRef.current = (document.activeElement as HTMLElement | null) ?? null
     return () => {
-      restoreToRef.current?.focus?.()
+      // Restore focus to the trigger — but only if it's still in the DOM. If the trigger
+      // was unmounted while the dialog was open (e.g. a board card that moved columns under
+      // an open drawer, or a poll re-render swapping the node), the captured reference is
+      // detached, and `.focus()` on a detached node is a silent no-op that leaves focus
+      // stranded on <body>. Guarding it stops the primitive from chasing a stale node; a
+      // live trigger still gets focus back.
+      const el = restoreToRef.current
+      if (el?.isConnected) el.focus?.()
     }
   }, [])
 


### PR DESCRIPTION
Closes #98

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- A successful status change in the task drawer now moves the card to its new board column **immediately**, instead of waiting up to ~5s for the reconciliation poll. `BoardPanel` passes an `onStatusCommitted(taskId, newStatus)` callback into the drawer; the drawer's status editor calls it (success only) alongside its existing local `setDetail`.
- The commit is handled by a small shared `commitStatus` helper that patches the matching task in `BoardPanel.tasks` in place (the same optimistic-patch idea `handleCreated` uses for a new card) and drops any in-flight override. The **drag commit now routes through the same helper**, so the drawer and drag paths are identical. The card is keyed by id in exactly one column, so the next poll simply agrees: no flicker, no duplicate.
- The reflection is **complete**, not just the column: a `→ todo` release also clears the assignee/runtime/verdict on the patched card (mirroring the server and the drawer's own `setDetail`), so the card never lingers with a stale runtime badge or a misleading verification pill. Other side effects (e.g. cancelling dependents) reconcile on the next poll, as they already do after a drag.

## Type

<!-- Check one: -->

- [x] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [ ] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

<!-- Required for user-facing changes to packages/* or apps/cli. -->
<!-- Run `pnpm changeset` and commit the generated file. -->

- [x] Not needed: `apps/web`-only change — the dashboard is not published to npm (`@clawboo/web` is `private` and in the changesets `ignore` list), so there's no package version to bump.

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Self-reviewed the diff

---

### Notes for reviewers

- **Why no `refresh()` (unlike `handleCreated`):** a status change is the exact analog of a drag move, so both manual paths share one commit-on-success helper and stay uniform. `handleCreated` calls `refresh()` to hydrate a brand-new entity's server-assigned fields; a status change creates nothing, the 5s poll reconciles remaining side effects, and an immediate `refresh()` would make the test unable to prove the move is *optimistic* rather than poll-driven.
- **`onStatusCommitted` fires on success only** — it's called from `StatusSelect.onChange`, which `useStatusMutation` invokes only when the PATCH commits, so a rejected/rolled-back change never moves the card (covered by a dedicated test).
- **Shared `commitStatus` helper:** the drag path's success commit now calls the same helper instead of its own inline `setTasks`, removing duplication and guaranteeing the two manual paths behave identically — including the `→ todo` field-clearing. `clearOverride` inside it is defensive for the drawer path (which sets no override) but load-bearing for drag. *This is the only line the PR touches in the drag path; if you'd prefer #98 stay strictly drawer-only, I can keep the drawer's commit separate — say the word.*
- **Tests** (`BoardPanel.test.tsx`): (1) the card jumps `To do → In progress` from the optimistic patch, guarded by a `GET /api/board` fetch-count check proving no re-fetch drove the move, then survives a poll (Refresh, the same `refresh()` path) with exactly one card — no flicker, no duplicate; (2) a rejected (500) drawer change leaves the card in place, with no move and no re-fetch.
- Follow-up to #91.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Board cards now update immediately when task statuses change from the detail drawer or by dragging.
  * Status changes remain consistent after refreshing board data.
  * Moving a task back to “To do” clears outdated assignment, runtime, and verification details.
  * Failed status updates no longer move cards incorrectly or trigger unnecessary refreshes; an error notification is shown.
  * Focus restoration now works when dialog triggers are recreated and avoids removed elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->