### PR TITLE
ci: add a windows + macos test matrix for the platform-sensitive suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,11 +148,14 @@ jobs:
 
       # apps/web/server: runtime CLI spawning, process-tree abort, the boot probe,
       # and path handling — the node-environment server/ suites only (the `server/`
-      # filter excludes the jsdom UI tests, which aren't platform-sensitive).
-      # Unix-only perms / process-tree assertions still skip on `win32` (they guard
-      # behavior with no Windows analogue yet — see the PR notes); they DO run on
-      # macOS, since the guards key on `win32`.
-      - run: pnpm --filter @clawboo/web exec vitest run server/
+      # filter excludes the jsdom UI tests). Runs on macOS here; NOT yet on Windows.
+      # The SQLite-backed harness leaks state between tests on Windows — better-sqlite3
+      # holds the DB file open and Windows can't reset an open file between tests, so
+      # fixtures cascade into UNIQUE-constraint errors (~166 failures). Bringing this
+      # suite to Windows is the "platform familiarity" follow-through the issue calls
+      # out; the real-git worktrees suite above already covers the Windows path.
+      - if: runner.os != 'Windows'
+        run: pnpm --filter @clawboo/web exec vitest run server/
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,18 +144,28 @@ jobs:
 
       # packages/worktrees: the real-git, per-task worktree lifecycle that underpins
       # every file-mutating task. Drives a real `git` binary via its gitHarness.
-      - run: pnpm --filter @clawboo/worktrees exec vitest run
+      # `--fail-if-no-match` so a mistyped filter can't yield a green leg that ran nothing.
+      - run: pnpm --filter @clawboo/worktrees --fail-if-no-match exec vitest run
 
-      # apps/web/server: runtime CLI spawning, process-tree abort, the boot probe,
-      # and path handling — the node-environment server/ suites only (the `server/`
-      # filter excludes the jsdom UI tests). Runs on macOS here; NOT yet on Windows.
-      # The SQLite-backed harness leaks state between tests on Windows — better-sqlite3
-      # holds the DB file open and Windows can't reset an open file between tests, so
-      # fixtures cascade into UNIQUE-constraint errors (~166 failures). Bringing this
-      # suite to Windows is the "platform familiarity" follow-through the issue calls
-      # out; the real-git worktrees suite above already covers the Windows path.
+      # apps/web/server platform surface (Windows leg): npm.cmd resolution, the
+      # which→where shim, and .exe candidate lookup — the DB-free slice of the server
+      # suite that runs green on Windows today, and the exact npm.cmd/shim regression
+      # surface #75 targets. Scoped to the FILE, not the dir: vitest's positional filter
+      # is a substring match, so `server/lib/runtimes/` would also pull in
+      # hermesDriver.test.ts, which fails on Windows.
+      - if: runner.os == 'Windows'
+        run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/lib/__tests__/platform.test.ts
+
+      # apps/web/server (full node server/ suite): macOS only for now — it already covers
+      # the platform test above. On Windows the suite fails two INDEPENDENT ways: (1) the
+      # SQLite-backed harness can't reset an open DB file between tests (better-sqlite3
+      # holds it → EBUSY on unlink), and (2) some suites override HOME but not
+      # USERPROFILE/CLAWBOO_HOME, so they resolve the real home rather than the sandbox
+      # (this PR fixes that class in executorRunner.test.ts; other suites still need it).
+      # Both are the "platform familiarity" follow-through the issue names — both, so the
+      # follow-up isn't mis-scoped as SQLite-only.
       - if: runner.os != 'Windows'
-        run: pnpm --filter @clawboo/web exec vitest run server/
+        run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,56 @@ jobs:
         env:
           CLAWBOO_CONCURRENCY_TEST: '1'
 
+  # A cost-bounded cross-platform leg for the most platform-sensitive suites, so a
+  # Windows / macOS regression in runtime spawning, process-tree termination on
+  # abort, per-task git worktrees, or path handling is caught on a PR rather than
+  # only after a release. The full Vitest suite still runs Linux-only in `test`
+  # above; this runs just the highest-value packages — `packages/worktrees` (the
+  # real-git per-task worktree lifecycle) and `apps/web/server` (runtime spawning,
+  # boot probe, executor). `fail-fast: false` so Windows and macOS report
+  # independently. macOS is otherwise only exercised by `smoke-test-bundle`'s boot
+  # check; Windows adds the unit coverage its boot smoke lacks. Issue #75.
+  test-cross-platform:
+    name: Test (cross-platform)
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # Matches smoke-test-bundle's budget: a cold Windows runner plus a from-source
+    # build of better-sqlite3's native binding is the slow part.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # The scoped suites import @clawboo/* packages through their built dist/
+      # (there is no source export condition, and nothing builds dist during
+      # install). The Linux `test` job gets this for free from `turbo test`, which
+      # builds a package's dependencies first; here we invoke Vitest directly to
+      # scope to the platform-sensitive suites, so the dependency build is explicit.
+      - run: pnpm build
+
+      # packages/worktrees: the real-git, per-task worktree lifecycle that underpins
+      # every file-mutating task. Drives a real `git` binary via its gitHarness.
+      - run: pnpm --filter @clawboo/worktrees exec vitest run
+
+      # apps/web/server: runtime CLI spawning, process-tree abort, the boot probe,
+      # and path handling — the node-environment server/ suites only (the `server/`
+      # filter excludes the jsdom UI tests, which aren't platform-sensitive).
+      # Unix-only perms / process-tree assertions still skip on `win32` (they guard
+      # behavior with no Windows analogue yet — see the PR notes); they DO run on
+      # macOS, since the guards key on `win32`.
+      - run: pnpm --filter @clawboo/web exec vitest run server/
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/apps/web/server/lib/__tests__/executorRunner.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.test.ts
@@ -838,22 +838,27 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'materializes the persistent identity home as 0700',
-    async () => {
-      const taskId = newTask('perms')
-      await runTaskOnRuntime({
-        db: createDb(getDbPath()),
-        makeAdapter: () => makeConcurrencyAdapter('clawboo-native', { active: 0, max: 0 }),
-        taskId,
-        assigneeAgentId: 'agent-perms',
-      })
-      const homeDir = runtimeIdentityHomePath('clawboo-native', 'agent-perms')
-      expect(resolveClawbooDir()).toContain(home) // sanity: the home is sandboxed
-      const st = await stat(homeDir)
-      expect(st.mode & 0o777).toBe(0o700)
-    },
-  )
+  // Runs on EVERY platform now (issue #75, criterion 3): the identity-home
+  // materialization — path handling + directory creation — is exactly the
+  // Windows-sensitive behavior worth exercising, so it no longer skips on win32.
+  // Only the `0700` hardening is gated: Windows has no POSIX mode bits and the
+  // source applies no ACL equivalent yet, so asserting it there would be false.
+  it('materializes the persistent identity home (0700 on POSIX)', async () => {
+    const taskId = newTask('perms')
+    await runTaskOnRuntime({
+      db: createDb(getDbPath()),
+      makeAdapter: () => makeConcurrencyAdapter('clawboo-native', { active: 0, max: 0 }),
+      taskId,
+      assigneeAgentId: 'agent-perms',
+    })
+    const homeDir = runtimeIdentityHomePath('clawboo-native', 'agent-perms')
+    expect(resolveClawbooDir()).toContain(home) // sanity: the home is sandboxed
+    const st = await stat(homeDir)
+    expect(st.isDirectory()).toBe(true) // materialized on all platforms
+    if (process.platform !== 'win32') {
+      expect(st.mode & 0o777).toBe(0o700) // POSIX-only hardening
+    }
+  })
 })
 
 // A CodexDriver / HermesDriver double that REPLAYS its native events the moment the

--- a/apps/web/server/lib/__tests__/executorRunner.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.test.ts
@@ -119,18 +119,23 @@ describe('executor runner (real board + real git worktree)', () => {
   let repo: string
   let home: string
   let prevHome: string | undefined
+  let prevClawbooHome: string | undefined
 
   beforeEach(async () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-exec-home-'))
     await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
     prevHome = process.env['HOME']
+    prevClawbooHome = process.env['CLAWBOO_HOME']
     process.env['HOME'] = home // → getDbPath() + worktree root land in the sandbox
+    process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     repo = await initRepo()
   })
 
   afterEach(async () => {
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
+    if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevClawbooHome
     await rm(home, { recursive: true, force: true })
     await rm(repo, { recursive: true, force: true })
   })
@@ -452,17 +457,22 @@ describe('executor runner — circuit breakers', () => {
   let repo: string
   let home: string
   let prevHome: string | undefined
+  let prevClawbooHome: string | undefined
 
   beforeEach(async () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-brk-home-'))
     await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
     prevHome = process.env['HOME']
+    prevClawbooHome = process.env['CLAWBOO_HOME']
     process.env['HOME'] = home
+    process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     repo = await initRepo()
   })
   afterEach(async () => {
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
+    if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevClawbooHome
     await rm(home, { recursive: true, force: true })
     await rm(repo, { recursive: true, force: true })
   })
@@ -686,16 +696,21 @@ const PERSISTENT_CAPS: Capabilities = {
 describe('executor runner — per-identity home serialization + cancellation + 0700', () => {
   let home: string
   let prevHome: string | undefined
+  let prevClawbooHome: string | undefined
 
   beforeEach(async () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-exec-conc-'))
     await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
     prevHome = process.env['HOME']
+    prevClawbooHome = process.env['CLAWBOO_HOME']
     process.env['HOME'] = home
+    process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
   })
   afterEach(async () => {
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
+    if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevClawbooHome
     await rm(home, { recursive: true, force: true })
   })
 
@@ -838,27 +853,26 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
   })
 
-  // Runs on EVERY platform now (issue #75, criterion 3): the identity-home
-  // materialization — path handling + directory creation — is exactly the
-  // Windows-sensitive behavior worth exercising, so it no longer skips on win32.
-  // Only the `0700` hardening is gated: Windows has no POSIX mode bits and the
-  // source applies no ACL equivalent yet, so asserting it there would be false.
-  it('materializes the persistent identity home (0700 on POSIX)', async () => {
-    const taskId = newTask('perms')
-    await runTaskOnRuntime({
-      db: createDb(getDbPath()),
-      makeAdapter: () => makeConcurrencyAdapter('clawboo-native', { active: 0, max: 0 }),
-      taskId,
-      assigneeAgentId: 'agent-perms',
-    })
-    const homeDir = runtimeIdentityHomePath('clawboo-native', 'agent-perms')
-    expect(resolveClawbooDir()).toContain(home) // sanity: the home is sandboxed
-    const st = await stat(homeDir)
-    expect(st.isDirectory()).toBe(true) // materialized on all platforms
-    if (process.platform !== 'win32') {
-      expect(st.mode & 0o777).toBe(0o700) // POSIX-only hardening
-    }
-  })
+  // win32-skipped: this file is not Windows-runnable yet (SQLite reset + a
+  // HOME/USERPROFILE sandbox gap, see the beforeEach fix below and #75), so the
+  // 0700 assertion can't be demonstrated green on a Windows runner in this PR.
+  // Un-skips in the follow-up that makes the whole file run on Windows.
+  it.skipIf(process.platform === 'win32')(
+    'materializes the persistent identity home as 0700',
+    async () => {
+      const taskId = newTask('perms')
+      await runTaskOnRuntime({
+        db: createDb(getDbPath()),
+        makeAdapter: () => makeConcurrencyAdapter('clawboo-native', { active: 0, max: 0 }),
+        taskId,
+        assigneeAgentId: 'agent-perms',
+      })
+      const homeDir = runtimeIdentityHomePath('clawboo-native', 'agent-perms')
+      expect(resolveClawbooDir()).toContain(home) // sanity: the home is sandboxed
+      const st = await stat(homeDir)
+      expect(st.mode & 0o777).toBe(0o700)
+    },
+  )
 })
 
 // A CodexDriver / HermesDriver double that REPLAYS its native events the moment the
@@ -891,17 +905,22 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
   let repo: string
   let home: string
   let prevHome: string | undefined
+  let prevClawbooHome: string | undefined
 
   beforeEach(async () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-cost-home-'))
     await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
     prevHome = process.env['HOME']
+    prevClawbooHome = process.env['CLAWBOO_HOME']
     process.env['HOME'] = home
+    process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     repo = await initRepo()
   })
   afterEach(async () => {
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
+    if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevClawbooHome
     await rm(home, { recursive: true, force: true })
     await rm(repo, { recursive: true, force: true })
   })

--- a/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
@@ -85,8 +85,12 @@ describe('hermes driver (preserved runtime)', () => {
   it('provisions a 0700 home; the same path re-provisions with created=false (stable across runs)', async () => {
     const first = await provisionHermesHome(identityHome())
     expect(first.created).toBe(true)
-    const st = await stat(first.home)
-    expect(st.mode & 0o777).toBe(0o700)
+    // 0700 hardening is POSIX-only (Windows has no mode bits), so gate that assertion;
+    // the provisioning + re-provision stability below still runs on every platform.
+    if (process.platform !== 'win32') {
+      const st = await stat(first.home)
+      expect(st.mode & 0o777).toBe(0o700)
+    }
 
     const second = await provisionHermesHome(identityHome())
     expect(second.home).toBe(first.home)

--- a/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
@@ -85,12 +85,8 @@ describe('hermes driver (preserved runtime)', () => {
   it('provisions a 0700 home; the same path re-provisions with created=false (stable across runs)', async () => {
     const first = await provisionHermesHome(identityHome())
     expect(first.created).toBe(true)
-    // 0700 hardening is POSIX-only (Windows has no mode bits), so gate that assertion;
-    // the provisioning + re-provision stability below still runs on every platform.
-    if (process.platform !== 'win32') {
-      const st = await stat(first.home)
-      expect(st.mode & 0o777).toBe(0o700)
-    }
+    const st = await stat(first.home)
+    expect(st.mode & 0o777).toBe(0o700)
 
     const second = await provisionHermesHome(identityHome())
     expect(second.home).toBe(first.home)

--- a/packages/worktrees/src/__tests__/scaffold.test.ts
+++ b/packages/worktrees/src/__tests__/scaffold.test.ts
@@ -56,9 +56,13 @@ describe('system-of-record scaffold', () => {
       ]) {
         await expect(readFile(path.join(dir, leaf), 'utf8')).resolves.toBeTruthy()
       }
-      // init.sh is executable (owner exec bit set).
-      const st = await stat(path.join(dir, SOR_FILES.init))
-      expect(st.mode & 0o100).toBeTruthy()
+      // init.sh gets the owner exec bit on POSIX. Windows has no executable bit
+      // (the chmod is a no-op there and the script runs via its interpreter, not +x),
+      // so gate the assertion — the file-creation checks above still run everywhere.
+      if (process.platform !== 'win32') {
+        const st = await stat(path.join(dir, SOR_FILES.init))
+        expect(st.mode & 0o100).toBeTruthy()
+      }
       // AGENT_HANDOFF.json is the clock-out artifact — not written by the scaffold.
       await expect(readFile(path.join(dir, SOR_FILES.handoff), 'utf8')).rejects.toThrow()
     })


### PR DESCRIPTION
Closes #75

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

- Adds a **`test-cross-platform`** job to `ci.yml` — a `[windows-latest, macos-latest]` matrix (`fail-fast: false`) running the most platform-sensitive Vitest suites so a cross-platform regression in per-task git worktrees, runtime spawning, or path handling is caught on a PR instead of after a release. The full suite still runs Linux-only in `test`.
- **Windows** runs `packages/worktrees` (the real-git per-task worktree lifecycle — criterion 4's must-have) **plus** `apps/web/server`'s DB-free `platform.test.ts` (npm.cmd / which→where shim / `.exe` resolution — the exact Windows-compat surface #75 was written for). **macOS** runs `packages/worktrees` + the full `apps/web/server` node suite.
- The **full** server suite is **held off Windows for now**: it fails two independent ways there — (1) SQLite file-locking test-isolation (better-sqlite3 keeps the DB file open; Windows can't reset it between tests → `UNIQUE constraint` / `EBUSY unlink`), and (2) a HOME/USERPROFILE sandbox gap (this PR fixes that class in `executorRunner.test.ts`; other suites still need it). That's the "platform familiarity" follow-through the issue names — "start with the highest-value packages before expanding to the full suite." macOS was previously only in the boot smoke; this gives it real unit coverage.

## Type

<!-- Check one: -->

- [ ] Feature (`feat:`)
- [ ] Bug fix (`fix:`)
- [ ] Refactor (`refactor:`)
- [x] Chore (CI, deps, config)
- [ ] Documentation
- [ ] Test

## Changeset

<!-- Required for user-facing changes to packages/* or apps/cli. -->
<!-- Run `pnpm changeset` and commit the generated file. -->

- [ ] Added changeset (not needed — CI and test-only changes)

## Checklist

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] `pnpm e2e` passes (or n/a — CI runs it on every PR either way)
- [x] Self-reviewed the diff

---

### Notes for reviewers

- **Scope / acceptance criteria:**
  - ✅ **Windows leg on `test`** — runs `packages/worktrees` (**27/27** on CI) **and** `apps/web/server/lib/__tests__/platform.test.ts` (12 tests: npm.cmd / which→where shim / `.exe` resolution — scoped to the file, since vitest's positional filter is a substring match and the directory would pull in `hermesDriver.test.ts`, which fails on Windows). The **full** server suite is a **Windows follow-up** — 166 failures from two independent causes: (1) SQLite file-locking test-isolation (`EBUSY` on unlink; the DB is held open), and (2) a HOME/USERPROFILE sandbox gap (fixed for `executorRunner.test.ts` here; other suites still need it). Runs the rest on macOS per "start with the highest-value packages before expanding."
  - ✅ **macOS leg** — same matrix; runs `packages/worktrees` + the full `apps/web/server` node suite, and the smoke test already covered macOS.
  - ✅ **Worktrees run on Windows** — `pnpm --filter @clawboo/worktrees --fail-if-no-match exec vitest run` is in the leg (and `--fail-if-no-match` so a bad filter can't produce a green leg that ran nothing).
  - ✅ **Reviewed the `skipIf(win32)` guards; added the safe Windows coverage.** The npm.cmd / which→where shim surface #75 was written for is now asserted on Windows via `platform.test.ts` (previously untested there). The four permission/process guards **stay `win32`-skipped** — their behavior has **no analogue in the current source** on Windows, so a Windows assertion would be *false*, not merely unvalidated: `killTree` (POSIX signals / process-groups / SIGKILL escalation — Windows uses `taskkill /T /F`), `bootProbe` vaultPerms + `executorRunner`'s identity-home `0700` (POSIX mode bits, no ACL equivalent yet), and `proxy-device-auth`'s `0600` (also in `packages/gateway-proxy`, outside this leg). Un-skipping those needs *source-level* features validated on a real Windows runner — the follow-through the issue names. *(An earlier revision un-skipped the identity-home test; CI showed it can't pass on Windows — the sandbox resolves `USERPROFILE`, not `HOME` — so the skip is restored and that sandbox bug is fixed, next bullet.)*
  - 🐛 **Sandbox bug fixed (in scope):** `executorRunner.test.ts` overrode `HOME` but not `CLAWBOO_HOME` in its four `beforeEach` blocks, so on Windows those suites resolve the **real** `~/.clawboo` instead of a temp dir (`resolveClawbooDir` reads `CLAWBOO_HOME` first, then falls through to `os.homedir()`, which uses `USERPROFILE` on Windows and ignores `HOME`). Added `CLAWBOO_HOME` with matching restore — the house pattern (36 server suites, `identityHome.test.ts`, `sharedConnection.test.ts:16`). It resolves to the same path on POSIX, so green runs are unchanged.
  - ⏳ **Required check before publish** — **not done in this PR.** Making the leg a required status check is a branch-protection/ruleset setting only the maintainer can configure, and we're deliberately letting the new legs build a track record first rather than hard-gating the npm release on a young Windows leg (a transient runner flake blocking a release would be worse than the regression it guards).
- **Validated on macOS:** the full gauntlet (`build`, `typecheck`, `lint`, `test`, `e2e`) plus the affected suites directly — `executorRunner` (23), `hermesDriver` (28), `platform` (12), `worktrees` (27). The `CLAWBOO_HOME` change resolves to the same POSIX path, so those counts don't move. CI is the Windows validator (no Windows machine available to me): Windows runs `worktrees` + `platform.test.ts`; macOS runs `worktrees` + the full server suite.
- **Dependency build is explicit** (`pnpm build` before the Vitest calls) because the scoped suites import `@clawboo/*` through their built `dist/`; the Linux `test` job gets this from `turbo test` building deps first, but this leg invokes Vitest directly to scope the suites.
- **Independently landable:** per the issue, the macOS and Windows legs stand alone — if the maintainer prefers, the macOS coverage can land first and the Windows follow-through iterate separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform test coverage for Windows and macOS.
  * Updated environment handling tests to reliably restore settings between runs.
  * Adjusted scaffold validation to account for platform-specific executable permissions.

* **Chores**
  * Added automated cross-platform builds and test execution to continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->