### PR TITLE
fix(website): correct false and stale claims on the marketing site

### DIFF
--- a/website/src/components/TerminalDemo.astro
+++ b/website/src/components/TerminalDemo.astro
@@ -10,7 +10,7 @@ const command = 'npx clawboo'
 const lines = [
   { text: 'Clawboo Native ready. No gateway, no cloud account.', tone: 'ok' },
   { text: 'Provider key found. Anthropic, OpenAI, OpenRouter, or local Ollama.', tone: 'ok' },
-  { text: 'Starter team seeded. A leader and a specialist, ready to work.', tone: 'ok' },
+  { text: 'Marketplace ready. Deploy a pre-built team or build your own.', tone: 'ok' },
   { text: 'Dashboard at http://localhost:18790', tone: 'link' },
 ]
 ---

--- a/website/src/lib/faq.ts
+++ b/website/src/lib/faq.ts
@@ -20,11 +20,11 @@ export const faqs: FaqItem[] = [
   },
   {
     q: 'Which providers and models can I use?',
-    a: 'Clawboo Native talks directly to Anthropic, OpenAI, and OpenRouter, or to a local Ollama with no key needed. Connected runtimes bring their own: Claude Code uses Anthropic, Codex uses OpenAI, and Hermes runs over OpenRouter. You only paste the keys for the runtimes you actually turn on.',
+    a: 'Clawboo Native talks directly to Anthropic, OpenAI, OpenRouter and a local Ollama, plus seven more OpenAI-compatible providers: Google, xAI, Groq, Mistral, Together, Cerebras and Moonshot. Connected runtimes bring their own: Claude Code uses Anthropic, Codex uses OpenAI, and Hermes runs over OpenRouter. You only paste the keys for the runtimes you actually turn on.',
   },
   {
     q: 'Where does my data live?',
-    a: 'On your machine. Everything is local-first. The board persists in SQLite at ~/.clawboo/clawboo.db, and your API keys live in an AES-256-GCM encrypted vault under ~/.clawboo/secrets/. No SaaS, no cloud account, nothing uploaded.',
+    a: 'On your machine. The Clawboo app does not collect telemetry, usage data, or analytics. Your board, chat history, memory and settings are stored locally in ~/.clawboo/, with the board in SQLite at ~/.clawboo/clawboo.db and your API keys in an AES-256-GCM encrypted vault under ~/.clawboo/secrets/. Model calls go only to the provider you configure, whether that is Anthropic, OpenRouter, or a local Ollama that never leaves your machine.',
   },
   {
     q: 'Is it production-ready?',
@@ -44,11 +44,11 @@ export const faqs: FaqItem[] = [
   },
   {
     q: 'How do agents avoid stepping on each other?',
-    a: 'The board is the canonical source of truth. Claims are race-free, every delegation is a real board mutation, and each runtime executes its tasks isolated in its own git worktree. Coordination flows over structured lifecycle events and MCP calls.',
+    a: 'The board is the canonical source of truth. Claims are race-free, every delegation is a real board mutation, and code tasks get their own git worktree on Native, Claude Code, Codex and Hermes. OpenClaw runs over its own Gateway connection, without a worktree. Coordination flows over structured lifecycle events and MCP calls.',
   },
   {
     q: 'What is not in yet?',
-    a: 'We are honest about open seams. Onboarding seeds a native starter team (you build mixed-runtime teams yourself), the peer-chat room is read-only, and human participants on the board plus multi-tenant deployments are on the roadmap, not shipped yet.',
+    a: 'We are honest about open seams. Onboarding seeds a native starter team (you build mixed-runtime teams yourself), or you can pick one straight from the marketplace. Human participants on the board plus multi-tenant deployments are on the roadmap, not shipped yet.',
   },
   {
     q: 'Which platforms does it run on?',

--- a/website/src/sections/Features.astro
+++ b/website/src/sections/Features.astro
@@ -14,7 +14,7 @@ const cards = [
     icon: 'columns',
     accent: 'var(--primary)',
     title: 'A board you can trust',
-    body: 'A durable kanban fused with a live group chat. The board is the canonical source of truth, and chat is the narration. Tasks survive restarts, claims are race-free, and every delegation is a real board mutation.',
+    body: 'A durable kanban fused with a live group chat. The board is the canonical source of truth, and chat is the narration. Tasks survive restarts, claims are race-free, and every delegation is a real board mutation. You can create tasks, change their status, and drag them between columns yourself, alongside the agents.',
   },
   {
     icon: 'message',
@@ -38,7 +38,7 @@ const cards = [
     icon: 'shield',
     accent: 'var(--amber)',
     title: 'Verified and governed by default',
-    body: 'Built-in verification (the builder is not the judge), spend tracking and warnings, depth and fan-out caps, and approvals, plus OpenTelemetry traces and structured logs, all on by default. Hard spend caps that auto-pause are opt-in.',
+    body: 'Built-in verification (the builder is not the judge), spend tracking and warnings, depth and fan-out caps, and approvals, plus structured logs and a durable event trace, all on by default. OpenTelemetry export and hard spend caps that auto-pause are opt-in.',
   },
 ]
 

--- a/website/src/sections/HowItWorks.astro
+++ b/website/src/sections/HowItWorks.astro
@@ -19,7 +19,7 @@ const steps = [
   {
     num: '03',
     title: 'Your team is ready',
-    body: 'Clawboo seeds a starter team and drops you into the dashboard at http://localhost:18790. Your team is ready in about a minute.',
+    body: 'Pick a team template from the marketplace and Clawboo deploys it, then drops you into the dashboard at http://localhost:18790. Your team is ready in about a minute.',
   },
 ]
 ---

--- a/website/src/sections/Observability.astro
+++ b/website/src/sections/Observability.astro
@@ -8,7 +8,7 @@ const pillars = [
     icon: 'shield',
     accent: 'var(--mint)',
     title: 'Verified',
-    body: 'Built-in verification for autonomous work. The builder is not the judge, so a completion is reviewed before it counts as done.',
+    body: 'Built-in verification for autonomous work. The builder is not the judge, so a completion with a diff is reviewed before it counts as done.',
   },
   {
     icon: 'gauge',
@@ -20,7 +20,7 @@ const pillars = [
     icon: 'activity',
     accent: 'var(--category-data)',
     title: 'Observable',
-    body: 'OpenTelemetry traces, structured logs, and a clear error taxonomy, all on by default. You can see exactly what every agent did.',
+    body: 'Structured logs, a durable event trace, and a clear error taxonomy, all on by default. Point Clawboo at an OpenTelemetry collector when you want traces exported.',
   },
 ]
 ---
@@ -31,8 +31,9 @@ const pillars = [
       Autonomous, but never unaccountable.
     </h2>
     <p class="mt-4 text-[16px] leading-relaxed text-secondary">
-      Every autonomous completion is independently verified, spend is tracked with warnings, and
-      sensitive steps wait for approval. Traces, logs, and an error taxonomy are on from the start.
+      Work done in a task worktree is independently verified before it counts as done, spend is
+      tracked with warnings, and sensitive steps wait for approval. Traces, logs, and an error
+      taxonomy are on from the start.
     </p>
   </Reveal>
 

--- a/website/src/sections/Proof.astro
+++ b/website/src/sections/Proof.astro
@@ -7,7 +7,7 @@ import Icon from '../components/Icon.astro'
 const stats = [
   { icon: 'clock', text: 'Ready in about a minute' },
   { icon: 'terminal', text: 'Dashboard at localhost:18790' },
-  { icon: 'lock', text: 'Nothing leaves your machine' },
+  { icon: 'lock', text: 'No cloud account required' },
 ]
 ---
 <section id="proof" class="relative mx-auto max-w-7xl px-5 py-20 sm:px-8 sm:py-28">

--- a/website/src/sections/Runtimes.astro
+++ b/website/src/sections/Runtimes.astro
@@ -93,8 +93,8 @@ const runtimes = [
       >
         <span class="font-display text-[15px] font-bold text-foreground">Behind one interface</span>
         <p class="text-[13px] leading-relaxed text-secondary">
-          Every runtime executes board tasks isolated in its own git worktree, with a structured
-          handoff so work can move between runtimes.
+          Code tasks get their own git worktree on Native, Claude Code, Codex and Hermes; OpenClaw
+          runs over its own Gateway connection. A structured handoff moves work between runtimes.
         </p>
         <span class="mt-1 inline-flex items-center gap-1 text-[13px] font-semibold text-primary">
           See the Runtimes guide

--- a/website/src/sections/Surface.astro
+++ b/website/src/sections/Surface.astro
@@ -46,10 +46,10 @@ const stats = [
         <Icon name="check" size={16} class="mt-0.5 shrink-0 text-amber" />
         <p class="text-[13px] leading-relaxed text-secondary">
           <span class="font-semibold text-foreground/80">Honest about what is still landing.</span>{' '}
-          Onboarding seeds a native starter team (you build mixed-runtime teams yourself), the
-          peer-chat room is read-only, and human participants on the board plus multi-tenant
-          deployments are on the roadmap, not shipped. Our bar for "it works" is end-to-end tests,
-          not screenshots.
+          Onboarding seeds a native starter team (you build mixed-runtime teams yourself), or you
+          can pick one straight from the marketplace. Human participants on the board plus
+          multi-tenant deployments are on the roadmap, not shipped. Our bar for "it works" is
+          end-to-end tests, not screenshots.
         </p>
       </div>
     </Reveal>


### PR DESCRIPTION
## Summary

* Corrects inaccurate and outdated marketing copy to ensure public-facing claims accurately reflect Clawboo's current behavior and capabilities.
* Updates onboarding, provider, board management, and data residency messaging while removing references to deprecated features and overstated guarantees.
* Improves documentation accuracy without changing application behavior.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — website copy only, no product behavior changes)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding content to explain marketplace team selection and deployment.
  * Clarified support for additional OpenAI-compatible providers, local data storage, telemetry, API-key handling, and Ollama.
  * Expanded runtime guidance for Native, Claude Code, Codex, Hermes, and OpenClaw Gateway.
  * Clarified task verification, durable event traces, optional OpenTelemetry export, and worktree isolation.
  * Updated governance details for task collaboration and configurable spend-limit pausing.
  * Refreshed demo and roadmap messaging to reflect marketplace-based deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->