### PR TITLE
refactor(tests): unify database access and improve Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,25 +147,23 @@ jobs:
       # `--fail-if-no-match` so a mistyped filter can't yield a green leg that ran nothing.
       - run: pnpm --filter @clawboo/worktrees --fail-if-no-match exec vitest run
 
-      # apps/web/server platform surface (Windows leg): npm.cmd resolution, the
-      # which→where shim, and .exe candidate lookup — the DB-free slice of the server
-      # suite that runs green on Windows today, and the exact npm.cmd/shim regression
-      # surface #75 targets. Scoped to the FILE, not the dir: vitest's positional filter
-      # is a substring match, so `server/lib/runtimes/` would also pull in
-      # hermesDriver.test.ts, which fails on Windows.
-      - if: runner.os == 'Windows'
-        run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/lib/__tests__/platform.test.ts
-
-      # apps/web/server (full node server/ suite): macOS only for now — it already covers
-      # the platform test above. On Windows the suite fails two INDEPENDENT ways: (1) the
-      # SQLite-backed harness can't reset an open DB file between tests (better-sqlite3
-      # holds it → EBUSY on unlink), and (2) some suites override HOME but not
-      # USERPROFILE/CLAWBOO_HOME, so they resolve the real home rather than the sandbox
-      # (this PR fixes that class in executorRunner.test.ts; other suites still need it).
-      # Both are the "platform familiarity" follow-through the issue names — both, so the
-      # follow-up isn't mis-scoped as SQLite-only.
-      - if: runner.os != 'Windows'
-        run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/
+      # apps/web/server (full node `server/` suite): runtime CLI spawning, process-tree
+      # abort, the boot probe, npm.cmd resolution and the which→where shim, and path
+      # handling. The `server/` filter excludes the jsdom UI tests, which live in src/.
+      #
+      # Runs on BOTH legs as of issue #140. It was macOS-only before, because on Windows
+      # the suite failed two independent ways, both fixed there:
+      #   1. A HOME-only sandbox. os.homedir() reads %USERPROFILE% on Windows and
+      #      ignores $HOME, so every suite resolved the runner's REAL home instead of
+      #      its temp dir and they all shared one clawboo.db, which is what produced
+      #      the cascading UNIQUE-constraint failures. Fixed at one seam, the Vitest
+      #      setup file server/__vitest__/setupHomedir.ts, rather than per suite.
+      #   2. A leaked SQLite handle. better-sqlite3 holds the DB file open and Windows
+      #      refuses to unlink an open file, so teardown threw EBUSY. The suites now
+      #      open through getDb() and call resetDb() before removing the sandbox dir.
+      # The dedicated platform.test.ts step this replaces is redundant now, since that
+      # file runs as part of the full suite here.
+      - run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/
 
   build:
     name: Build

--- a/apps/web/server/__vitest__/setupHomedir.ts
+++ b/apps/web/server/__vitest__/setupHomedir.ts
@@ -1,0 +1,45 @@
+// Makes `$HOME` authoritative for `os.homedir()` on EVERY platform, for tests only.
+//
+// WHY THIS EXISTS (issue #140). Node resolves `os.homedir()` from `$HOME` on
+// POSIX but from `%USERPROFILE%` on Windows. Every sandboxing suite in this
+// server tree overrides `process.env.HOME` and nothing else, which is correct on
+// POSIX and silently wrong on Windows: `resolveClawbooDir`, `defaultDbPath` and
+// `userHermesHome` all route through `os.homedir()`, so on a Windows runner they
+// resolved the developer's REAL home instead of the per-test temp dir. Every
+// suite then shared one `C:\Users\<user>\.clawboo\clawboo.db`, which is what
+// produced the cascading UNIQUE-constraint failures on the first Windows run.
+//
+// WHY A SHIM RATHER THAN PER-SUITE ENV. The alternative was adding a second
+// override (USERPROFILE, or a per-resolver variable like CLAWBOO_HOME) to ~45
+// beforeEach blocks. That is 45 chances to get a save/restore pair wrong, it has
+// to be repeated in every suite added later, and it cannot fix
+// `hermesDriver.test.ts` at all: that suite DELIBERATELY deletes `HERMES_HOME`
+// (see its beforeEach) so it exercises the `~/.hermes` fallback, so the only way
+// to sandbox it is to move `os.homedir()` itself. One seam, applied uniformly,
+// is both smaller and harder to get wrong.
+//
+// SCOPE. This is a Vitest setup file. It is never bundled and never ships: the
+// server's own `os.homedir()` behavior is untouched in production. On POSIX it
+// is a no-op by construction, because `os.homedir()` already returns `$HOME`
+// there, so it changes results on Windows only.
+//
+// SAFETY. Patching the `node:os` module object works because every homedir
+// caller in this repo uses the `os.homedir()` member form rather than a named
+// `import { homedir }`, which would bind the original function and bypass this.
+// If you add a caller, use `os.homedir()`. The original is restored on exit so
+// nothing leaks between Vitest's module registries.
+
+import os from 'node:os'
+
+const realHomedir = os.homedir
+
+os.homedir = function sandboxedHomedir(): string {
+  // `$HOME` first on every platform, then Windows' own variable, then the real
+  // OS lookup. Falling through rather than returning '' matters: a suite that
+  // never sandboxes a home must still see a genuine home directory.
+  const home = process.env['HOME']?.trim()
+  if (home) return home
+  const profile = process.env['USERPROFILE']?.trim()
+  if (profile) return profile
+  return realHomedir()
+}

--- a/apps/web/server/api/__tests__/agents.rest.test.ts
+++ b/apps/web/server/api/__tests__/agents.rest.test.ts
@@ -8,11 +8,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, getSetting, teams } from '@clawboo/db'
+import { agents, getSetting, teams } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { runtimeAgentFileKey } from '../../lib/agentSource/runtimeAgentFileStore'
 import {
   agentsListGET,
@@ -61,7 +61,7 @@ describe('agents REST (registry disconnected → reads SQLite, writes 503)', () 
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     // Seed a synced agent row (as the sync would have produced).
-    const db = createDb(getDbPath())
+    const db = getDb()
     const now = Date.now()
     db.insert(teams)
       .values({ id: 't1', name: 'Team', icon: '👻', color: '#fff', createdAt: now, updatedAt: now })
@@ -82,6 +82,9 @@ describe('agents REST (registry disconnected → reads SQLite, writes 503)', () 
       .run()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']
@@ -214,7 +217,7 @@ describe('agents REST (registry disconnected → reads SQLite, writes 503)', () 
     expect(patch.status()).toBe(200)
     expect(patch.body()).toEqual({ ok: true, model: 'claude-haiku-4-5' })
     // The AgentConfig KV row carries the new primaryModel.
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(loadAgentConfig(db, id)?.primaryModel).toBe('claude-haiku-4-5')
 
     // The OpenClaw-seeded agent (a1) is not native → 404 (model change is native-only).
@@ -265,7 +268,7 @@ describe('agents REST (registry disconnected → reads SQLite, writes 503)', () 
       filePut.res,
     )
     expect(filePut.status()).toBe(200)
-    const db = createDb(getDbPath())
+    const db = getDb()
     const fileKey = runtimeAgentFileKey(created.id, 'SOUL.md')
     expect(getSetting(db, fileKey)).toBe('# coder')
 

--- a/apps/web/server/api/__tests__/board.deps.test.ts
+++ b/apps/web/server/api/__tests__/board.deps.test.ts
@@ -8,11 +8,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createDb, createTask, getDependents } from '@clawboo/db'
+import { createTask, getDependents } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { boardLinkDepPOST } from '../board'
 
 function mockRes(): { res: Response; statusCode: () => number; body: () => unknown } {
@@ -50,13 +50,16 @@ describe('POST /api/board/:taskId/deps — cycle rejection', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
   })
 
   it('a link that would close a cycle is 409, not 500, and no edge is written', () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const a = createTask(db, { title: 'A' })
     const b = createTask(db, { title: 'B' })
 
@@ -70,7 +73,7 @@ describe('POST /api/board/:taskId/deps — cycle rejection', () => {
   })
 
   it('a link to a task that does not exist is still 404', () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const a = createTask(db, { title: 'A' })
     expect(link(a.id, 'no-such-task').statusCode()).toBe(404)
   })

--- a/apps/web/server/api/__tests__/board.gate.test.ts
+++ b/apps/web/server/api/__tests__/board.gate.test.ts
@@ -7,18 +7,12 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import {
-  createDb,
-  createTask,
-  listGovernanceAudit,
-  setTaskVerification,
-  updateStatus,
-} from '@clawboo/db'
+import { createTask, listGovernanceAudit, setTaskVerification, updateStatus } from '@clawboo/db'
 import type { VerificationResult } from '@clawboo/governance'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { boardUpdatePATCH } from '../board'
 
 function mockRes(): { res: Response; statusCode: () => number; body: () => unknown } {
@@ -82,13 +76,16 @@ describe('board PATCH verification gate (intrinsic + audited override)', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
   })
 
   function redGatedTask(): string {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const t = createTask(db, { title: 'x' })
     updateStatus(db, t.id, 'in_progress')
     updateStatus(db, t.id, 'in_review')
@@ -112,7 +109,7 @@ describe('board PATCH verification gate (intrinsic + audited override)', () => {
       r.res,
     )
     expect(r.statusCode()).toBe(200)
-    const audit = listGovernanceAudit(createDb(getDbPath()), { eventType: 'verification' })
+    const audit = listGovernanceAudit(getDb(), { eventType: 'verification' })
     expect(audit.some((row) => String(row.summary).includes('override'))).toBe(true)
   })
 })

--- a/apps/web/server/api/__tests__/board.obs.test.ts
+++ b/apps/web/server/api/__tests__/board.obs.test.ts
@@ -7,11 +7,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createDb, listEvents, readRoom, resolveRoomForTeam } from '@clawboo/db'
+import { listEvents, readRoom, resolveRoomForTeam } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import {
   boardClaimPOST,
   boardCommentPOST,
@@ -41,7 +41,7 @@ const req = (body: unknown, params: Record<string, string> = {}): Request =>
   ({ body, query: {}, params }) as unknown as Request
 
 function kindsInLog(): string[] {
-  return listEvents(createDb(getDbPath()), { limit: 1000 }).map((e) => e.kind)
+  return listEvents(getDb(), { limit: 1000 }).map((e) => e.kind)
 }
 
 describe('board REST → observability emits', () => {
@@ -55,6 +55,9 @@ describe('board REST → observability emits', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -126,7 +129,7 @@ describe('board REST → observability emits', () => {
 
     // Each non-status board mutation now narrates a `kind:'system'` line into the
     // team room (before this fix only status changes reflected).
-    const room = readRoom(createDb(getDbPath()), { roomId: resolveRoomForTeam('team1') })
+    const room = readRoom(getDb(), { roomId: resolveRoomForTeam('team1') })
     expect(room.length).toBeGreaterThanOrEqual(3)
     expect(room.every((r) => r.kind === 'system' && r.authorAgentId === 'clawboo')).toBe(true)
     const bodies = room.map((r) => r.body)

--- a/apps/web/server/api/__tests__/booZeroOverride.test.ts
+++ b/apps/web/server/api/__tests__/booZeroOverride.test.ts
@@ -8,11 +8,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, getSetting, type ClawbooDb } from '@clawboo/db'
+import { agents, getSetting, type ClawbooDb } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { resolveBooZero, SETTING_BOO_ZERO_OVERRIDE } from '../../lib/teamChat/booZero'
 import { booZeroOverrideGET, booZeroOverridePOST } from '../booZeroOverride'
 
@@ -43,7 +43,7 @@ describe('Boo Zero override (runtime-neutral leader designation)', () => {
     await mkdir(path.join(home, '.clawboo'), { recursive: true })
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
     const now = Date.now()
     db.insert(agents)
       .values([
@@ -72,6 +72,9 @@ describe('Boo Zero override (runtime-neutral leader designation)', () => {
       .run()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})

--- a/apps/web/server/api/__tests__/budgets.test.ts
+++ b/apps/web/server/api/__tests__/budgets.test.ts
@@ -6,11 +6,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createApproval, createDb, recordSpend, resolveApproval } from '@clawboo/db'
+import { createApproval, recordSpend, resolveApproval } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { budgetsListGET, budgetsResumePOST, budgetsSetPOST } from '../budgets'
 import { delegationApprovalPOST } from '../delegationApproval'
 import { governanceAuditGET } from '../governanceAudit'
@@ -44,6 +44,9 @@ describe('governance REST', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -90,7 +93,7 @@ describe('governance REST', () => {
       req({ body: { scope: 'agent', scopeId: 'over', limitUsdCents: 100, mode: 'cap' } }),
       mockRes().res,
     )
-    const db = createDb(getDbPath())
+    const db = getDb()
     recordSpend(db, 'agent', 'over', 150) // spent 150 > 100 → paused
 
     const bare = mockRes()
@@ -115,7 +118,7 @@ describe('governance REST', () => {
 
     // A prior allow_always for (leader, delegate:code) makes the gate resolve
     // immediately — no blocking wait (proves the sticky-scope short-circuit).
-    const db = createDb(getDbPath())
+    const db = getDb()
     const a = createApproval(db, { toolName: 'delegate:code', agentId: 'leader1', args: {} })
     resolveApproval(db, a.id, 'allow_always')
     const sticky = mockRes()

--- a/apps/web/server/api/__tests__/capabilities.test.ts
+++ b/apps/web/server/api/__tests__/capabilities.test.ts
@@ -8,13 +8,13 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, getCapability, upsertCapabilities } from '@clawboo/db'
+import { agents, getCapability, upsertCapabilities } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { buildRecord } from '../../lib/capabilitySource/helpers'
 import { recordToInsert, rowToRecord } from '../../lib/capabilitySource/mapper'
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { capabilitiesActionPOST, capabilitiesListGET } from '../capabilities'
 
 function mockRes(): { res: Response; status: () => number; body: () => unknown } {
@@ -56,7 +56,7 @@ describe('capabilities REST', () => {
     prevHome = process.env['HOME']
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
-    const db = createDb(getDbPath())
+    const db = getDb()
     const now = Date.now()
     db.insert(agents)
       .values({
@@ -72,6 +72,9 @@ describe('capabilities REST', () => {
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']
@@ -114,7 +117,7 @@ describe('capabilities REST', () => {
   })
 
   it('enable/disable on an observe-only capability is 422', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const rec = buildRecord({
       sourceId: 'hermes',
       runtime: 'hermes',
@@ -146,7 +149,7 @@ describe('capabilities REST', () => {
     expect(r.status()).toBe(404)
   })
 
-  function seedOpenClawConnector(db: ReturnType<typeof createDb>): ReturnType<typeof buildRecord> {
+  function seedOpenClawConnector(db: ReturnType<typeof getDb>): ReturnType<typeof buildRecord> {
     const rec = buildRecord({
       sourceId: 'openclaw',
       runtime: 'openclaw',
@@ -165,7 +168,7 @@ describe('capabilities REST', () => {
   }
 
   it('rowToRecord re-derives writable:false for a runtime-of-record OpenClaw extension (degraded last-good DB keeps the gate)', () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const rec = seedOpenClawConnector(db)
     // The column does NOT persist `writable`; reading the row back + mapping must
     // RE-DERIVE writable:false so the dashboard's dead-button gate survives a
@@ -189,7 +192,7 @@ describe('capabilities REST', () => {
   })
 
   it('disable on a non-writable runtime-of-record connector is 422 at the REST gate (before any adapter write)', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const rec = seedOpenClawConnector(db)
     const r = mockRes()
     await capabilitiesActionPOST(

--- a/apps/web/server/api/__tests__/cliLogin.test.ts
+++ b/apps/web/server/api/__tests__/cliLogin.test.ts
@@ -246,45 +246,59 @@ describe('POST /api/auth/cli-login/:tool', () => {
     expect(m.events()).toContainEqual({ type: 'complete', success: true, loggedIn: true })
   })
 
-  it('openclaw: PTY-wrapped via `script`, browser-PKCE by default; the `Open:` line becomes auth-url', async () => {
-    const m = sseRes()
-    cliLoginPOST(req('openclaw'), m.res)
-    const call = spawnState.calls[0]!
-    expect(call.cmd).toBe('script') // the stdin.isTTY guard demands a PTY
-    // NO --device-code: the default oauth method is the ungated browser flow.
-    expect(call.args.join(' ')).toContain('models auth login --provider openai-codex')
-    expect(call.args.join(' ')).not.toContain('--device-code')
-    spawnState.children[0]!.emitStdout(
-      'Open: https://auth.openai.com/oauth/authorize?client_id=app_x&state=z\n',
-    )
-    expect(m.events()).toContainEqual({
-      type: 'auth-url',
-      url: 'https://auth.openai.com/oauth/authorize?client_id=app_x&state=z',
-    })
-    probeState.openclawProfile = true
-    spawnState.children[0]!.emitClose(0)
-    await flush()
-    expect(m.events()).toContainEqual({ type: 'complete', success: true, loggedIn: true })
-  })
-
-  it('the store WATCHER completes on the credential landing on disk — WITHOUT the child exiting', async () => {
-    // The slow-openclaw case: a >16s sign-in shows the CLI's paste-prompt, which
-    // holds the process open after the callback succeeds. Completion must come
-    // from the auth store, and the lingering child gets reaped.
-    vi.useFakeTimers()
-    try {
+  // POSIX-only by DESIGN, not merely untested on Windows: `buildCliLoginPlan`
+  // returns UNSUPPORTED_PLATFORM for openclaw on win32 (cliLoginPlans.ts), because
+  // `models auth login` has a hard stdin.isTTY guard and there is no `script` to
+  // wrap it in. So there is no spawn to assert on there. The Windows branch is
+  // covered portably by cliLoginPlans.test.ts, which injects 'win32' and therefore
+  // runs on every platform. (#140)
+  it.skipIf(process.platform === 'win32')(
+    'openclaw: PTY-wrapped via `script`, browser-PKCE by default; the `Open:` line becomes auth-url',
+    async () => {
       const m = sseRes()
       cliLoginPOST(req('openclaw'), m.res)
-      expect(m.events()).not.toContainEqual(expect.objectContaining({ type: 'complete' }))
-      probeState.openclawProfile = true // the profile lands on disk mid-flow
-      await vi.advanceTimersByTimeAsync(3_100)
+      const call = spawnState.calls[0]!
+      expect(call.cmd).toBe('script') // the stdin.isTTY guard demands a PTY
+      // NO --device-code: the default oauth method is the ungated browser flow.
+      expect(call.args.join(' ')).toContain('models auth login --provider openai-codex')
+      expect(call.args.join(' ')).not.toContain('--device-code')
+      spawnState.children[0]!.emitStdout(
+        'Open: https://auth.openai.com/oauth/authorize?client_id=app_x&state=z\n',
+      )
+      expect(m.events()).toContainEqual({
+        type: 'auth-url',
+        url: 'https://auth.openai.com/oauth/authorize?client_id=app_x&state=z',
+      })
+      probeState.openclawProfile = true
+      spawnState.children[0]!.emitClose(0)
+      await flush()
       expect(m.events()).toContainEqual({ type: 'complete', success: true, loggedIn: true })
-      expect(m.ended()).toBe(true)
-      expect(killState.killed).toHaveLength(1) // the lingering child is reaped
-    } finally {
-      vi.useRealTimers()
-    }
-  })
+    },
+  )
+
+  // POSIX-only for the same reason as the test above: on win32 the openclaw plan
+  // is UNSUPPORTED_PLATFORM, so no child is ever spawned to watch. (#140)
+  it.skipIf(process.platform === 'win32')(
+    'the store WATCHER completes on the credential landing on disk — WITHOUT the child exiting',
+    async () => {
+      // The slow-openclaw case: a >16s sign-in shows the CLI's paste-prompt, which
+      // holds the process open after the callback succeeds. Completion must come
+      // from the auth store, and the lingering child gets reaped.
+      vi.useFakeTimers()
+      try {
+        const m = sseRes()
+        cliLoginPOST(req('openclaw'), m.res)
+        expect(m.events()).not.toContainEqual(expect.objectContaining({ type: 'complete' }))
+        probeState.openclawProfile = true // the profile lands on disk mid-flow
+        await vi.advanceTimersByTimeAsync(3_100)
+        expect(m.events()).toContainEqual({ type: 'complete', success: true, loggedIn: true })
+        expect(m.ended()).toBe(true)
+        expect(killState.killed).toHaveLength(1) // the lingering child is reaped
+      } finally {
+        vi.useRealTimers()
+      }
+    },
+  )
 
   it('client disconnect (Cancel) kills the child TREE', () => {
     const m = sseRes()

--- a/apps/web/server/api/__tests__/governanceAudit.test.ts
+++ b/apps/web/server/api/__tests__/governanceAudit.test.ts
@@ -6,11 +6,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { appendAudit, createDb } from '@clawboo/db'
+import { appendAudit } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { governanceAuditGET } from '../governanceAudit'
 
 function mockRes(): { res: Response; status: () => number; body: () => unknown } {
@@ -45,13 +45,16 @@ describe('governance audit REST', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
   })
 
   it('filters by circuit_break event type and a future `since` cutoff', () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     appendAudit(db, { eventType: 'budget', agentId: 'a1', summary: { note: 'spend' } })
     appendAudit(db, {
       eventType: 'circuit_break',

--- a/apps/web/server/api/__tests__/obs.test.ts
+++ b/apps/web/server/api/__tests__/obs.test.ts
@@ -7,11 +7,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { appendEvent, createDb, listEvents } from '@clawboo/db'
+import { appendEvent, listEvents } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import {
   obsErrorsGET,
   obsEventsGET,
@@ -74,7 +74,7 @@ function mockSse(query: Record<string, string> = {}): {
 }
 
 function seed(): void {
-  const db = createDb(getDbPath())
+  const db = getDb()
   const now = Date.now()
   // A two-agent mission under trace tr1.
   appendEvent(db, {
@@ -178,6 +178,9 @@ describe('observability REST', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -317,5 +320,5 @@ describe('observability REST', () => {
 })
 
 function listEventsForTask(taskId: string): string[] {
-  return listEvents(createDb(getDbPath()), { taskId }).map((e) => e.kind)
+  return listEvents(getDb(), { taskId }).map((e) => e.kind)
 }

--- a/apps/web/server/api/__tests__/onboardingSeed.test.ts
+++ b/apps/web/server/api/__tests__/onboardingSeed.test.ts
@@ -12,14 +12,14 @@ import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { DEFAULT_AGENT_CONFIG } from '@clawboo/adapter-native'
-import { createDb, getSetting, setSetting, agents, teams } from '@clawboo/db'
+import { getSetting, setSetting, agents, teams } from '@clawboo/db'
 
 import {
   onboardingNativeLeaderModelGET,
   onboardingNativeLeaderModelPOST,
   onboardingSeedNativeTeamPOST,
 } from '../onboardingSeed'
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { loadAgentConfig, saveAgentConfig } from '../../lib/runtimes/native/agentConfigStore'
 import { SETTING_NATIVE_BOO_ZERO_ID, SETTING_NATIVE_LEADER_MODEL } from '../../lib/teamChat/booZero'
 
@@ -58,6 +58,9 @@ describe('onboarding seed-native-team REST', () => {
     process.env['OPENCLAW_STATE_DIR'] = mkdtempSync(path.join(os.tmpdir(), 'clawboo-seed-state-'))
   })
   afterEach(() => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     for (const k of SAVED) {
       if (prev[k] === undefined) delete process.env[k]
       else process.env[k] = prev[k]
@@ -75,7 +78,7 @@ describe('onboarding seed-native-team REST', () => {
     expect(out.specialistAgentId).toMatch(/^native-/)
     expect(out.leaderAgentId).not.toBe(out.specialistAgentId)
 
-    const db = createDb(getDbPath())
+    const db = getDb()
 
     // The team row exists with the leader recorded.
     const team = db.select().from(teams).where(eq(teams.id, out.teamId)).get()
@@ -128,6 +131,9 @@ describe('onboarding native-leader-model REST', () => {
     process.env['OPENCLAW_STATE_DIR'] = mkdtempSync(path.join(os.tmpdir(), 'clawboo-lm-state-'))
   })
   afterEach(() => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     for (const k of SAVED) {
       if (prev[k] === undefined) delete process.env[k]
       else process.env[k] = prev[k]
@@ -139,7 +145,7 @@ describe('onboarding native-leader-model REST', () => {
     const m = mockRes()
     onboardingNativeLeaderModelPOST(req({ provider: 'anthropic', model: 'claude-sonnet-5' }), m.res)
     expect(m.statusCode()).toBe(200)
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(JSON.parse(getSetting(db, SETTING_NATIVE_LEADER_MODEL) ?? '{}')).toEqual({
       provider: 'anthropic',
       model: 'claude-sonnet-5',
@@ -171,7 +177,7 @@ describe('onboarding native-leader-model REST', () => {
   })
 
   it('POST retro-applies the pick to an EXISTING native Boo Zero AgentConfig', () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     // Seed a native Boo Zero + its stored AgentConfig (the shape ensureNativeBooZero writes).
     setSetting(db, SETTING_NATIVE_BOO_ZERO_ID, 'native-bz-1')
     saveAgentConfig(db, {

--- a/apps/web/server/api/__tests__/onboardingState.test.ts
+++ b/apps/web/server/api/__tests__/onboardingState.test.ts
@@ -7,11 +7,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, teams } from '@clawboo/db'
+import { agents, teams } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { setRuntimeSecret } from '../../lib/secretsVault'
 import { onboardingStateGET } from '../onboardingState'
 
@@ -59,6 +59,9 @@ describe('GET /api/onboarding/state', () => {
     delete process.env['HERMES_HOME']
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     if (prevStateDir === undefined) delete process.env['OPENCLAW_STATE_DIR']
@@ -69,7 +72,7 @@ describe('GET /api/onboarding/state', () => {
 
   it('reports the fresh-install shape (all false)', async () => {
     // Touch the db so it exists (empty). No teams / native agents / vault keys.
-    createDb(getDbPath())
+    getDb()
     const r = mockRes()
     await onboardingStateGET(req(), r.res)
     expect(r.status()).toBe(200)
@@ -83,7 +86,7 @@ describe('GET /api/onboarding/state', () => {
   })
 
   it('flips hasTeam + hasNative once a native team is seeded', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const now = Date.now()
     db.insert(teams)
       .values({
@@ -120,7 +123,7 @@ describe('GET /api/onboarding/state', () => {
   })
 
   it('flips hasConnectedRuntime when a runtime key is stored in the vault', async () => {
-    createDb(getDbPath())
+    getDb()
     setRuntimeSecret('ANTHROPIC_API_KEY', 'sk-vault-test')
     const r = mockRes()
     await onboardingStateGET(req(), r.res)

--- a/apps/web/server/api/__tests__/runtimesInstallConnect.test.ts
+++ b/apps/web/server/api/__tests__/runtimesInstallConnect.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path'
 
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetDb } from '../../lib/db'
 
 // ── Mock platform: control which CLI bins are "installed". ───────────────────
 type PyResult = {
@@ -217,6 +218,10 @@ describe('runtimes install/connect REST', () => {
     process.env['HERMES_HOME'] = path.join(home, '.hermes')
   })
   afterEach(() => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. The suite never opens the handle itself,
+    // the server code under test does. (#140)
+    resetDb()
     for (const k of SAVED) {
       if (prev[k] === undefined) delete process.env[k]
       else process.env[k] = prev[k]

--- a/apps/web/server/api/__tests__/schedules.test.ts
+++ b/apps/web/server/api/__tests__/schedules.test.ts
@@ -7,11 +7,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, createTask, listScheduledRuns } from '@clawboo/db'
+import { agents, createTask, listScheduledRuns } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { resetScheduleMultiplexer } from '../../lib/scheduleSource/registry'
 import {
   schedulesCreatePOST,
@@ -58,7 +58,7 @@ describe('schedules REST (gateway disconnected)', () => {
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     resetScheduleMultiplexer()
-    const db = createDb(getDbPath())
+    const db = getDb()
     const now = Date.now()
     db.insert(agents)
       .values({
@@ -73,6 +73,9 @@ describe('schedules REST (gateway disconnected)', () => {
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']
@@ -108,7 +111,7 @@ describe('schedules REST (gateway disconnected)', () => {
   })
 
   it('a duplicate bound registration is a 409 (one firing-owner; never retried)', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const task = createTask(db, { title: 'Owned elsewhere', scheduledBy: 'openclaw' })
     const r = mockRes()
     // A bound routine must be one-shot (once@); the ownership conflict still applies.
@@ -123,7 +126,7 @@ describe('schedules REST (gateway disconnected)', () => {
   })
 
   it('a RECURRING schedule bound to a team task is a 400 (must be one-shot)', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const task = createTask(db, { title: 'Bound', status: 'todo' })
     const r = mockRes()
     await schedulesCreatePOST(req({ body: { ...CREATE_BODY, teamTaskId: task.id } }), r.res) // recurring + bound
@@ -194,6 +197,6 @@ describe('schedules REST (gateway disconnected)', () => {
     const run = mockRes()
     await schedulesRunPOST(req({ params: { id } }), run.res)
     expect(run.status()).toBe(202)
-    expect(listScheduledRuns(createDb(getDbPath()))[0]?.status).toBe('queued')
+    expect(listScheduledRuns(getDb())[0]?.status).toBe('queued')
   })
 })

--- a/apps/web/server/api/__tests__/skills.test.ts
+++ b/apps/web/server/api/__tests__/skills.test.ts
@@ -7,11 +7,11 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createDb, listGovernanceAudit, skills } from '@clawboo/db'
+import { listGovernanceAudit, skills } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { skillsPOST } from '../skills'
 
 function mockRes(): { res: Response; statusCode: () => number; body: () => unknown } {
@@ -42,6 +42,9 @@ describe('skills install — supply-chain injection scan', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -59,7 +62,7 @@ describe('skills install — supply-chain injection scan', () => {
       res.res,
     )
     expect(res.statusCode()).toBe(422)
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(
       listGovernanceAudit(db, { eventType: 'install' }).some((r) =>
         r.summary.includes('"blocked":true'),
@@ -72,7 +75,7 @@ describe('skills install — supply-chain injection scan', () => {
     const res = mockRes()
     skillsPOST(req({ id: 's2', name: 'Web Search', source: 'curated', agentId: 'a1' }), res.res)
     expect(res.statusCode()).toBe(200)
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(db.select().from(skills).all()).toHaveLength(1)
     expect(
       listGovernanceAudit(db, { eventType: 'install' }).some((r) =>
@@ -86,7 +89,7 @@ describe('skills install — supply-chain injection scan', () => {
     // agentId as an object is truthy but not a string — it must never persist.
     skillsPOST(req({ id: 's3', name: 'API Tester', source: 'curated', agentId: {} }), res.res)
     expect(res.statusCode()).toBe(400)
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(db.select().from(skills).all()).toHaveLength(0) // never recorded
   })
 })

--- a/apps/web/server/api/__tests__/teamAgentBooZero.test.ts
+++ b/apps/web/server/api/__tests__/teamAgentBooZero.test.ts
@@ -17,12 +17,12 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, setSetting, teams, type ClawbooDb } from '@clawboo/db'
+import { agents, setSetting, teams, type ClawbooDb } from '@clawboo/db'
 import { eq } from 'drizzle-orm'
 import type { Request, Response } from 'express'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { SETTING_DEFAULT_ID } from '../../lib/agentSource/openClawAgentSource'
 import { resolveBooZero, resolveNativeBooZero } from '../../lib/teamChat/booZero'
 import { agentsCreatePOST } from '../agents'
@@ -77,10 +77,13 @@ describe('teamAgentPOST → eager native Boo Zero', () => {
       delete process.env[v]
     }
     process.env['ANTHROPIC_API_KEY'] = 'sk-test-key'
-    db = createDb(getDbPath())
+    db = getDb()
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     for (const v of NATIVE_KEY_VARS) {

--- a/apps/web/server/api/__tests__/teamChatHostHeader.test.ts
+++ b/apps/web/server/api/__tests__/teamChatHostHeader.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../lib/teamChat/runTeamExchange', () => ({
 }))
 
 import { teamChatExchangePOST } from '../teamChat'
+import { resetDb } from '../../lib/db'
 
 function mockRes(): Response & { _status: number; _json?: unknown } {
   const res = {
@@ -54,6 +55,10 @@ describe('POST /api/team-chat/exchange — host-header injection', () => {
     captured.input = null
   })
   afterEach(() => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. The suite never opens the handle itself,
+    // the server code under test does. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['CLAWBOO_HOME']
     else process.env['CLAWBOO_HOME'] = prevHome
     rmSync(home, { recursive: true, force: true })

--- a/apps/web/server/api/__tests__/teamChatRest.test.ts
+++ b/apps/web/server/api/__tests__/teamChatRest.test.ts
@@ -7,11 +7,11 @@ import type { IncomingMessage } from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createDb, postToRoom, resolveRoomForTeam } from '@clawboo/db'
+import { postToRoom, resolveRoomForTeam } from '@clawboo/db'
 import type { Request, Response } from 'express'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 import { releaseRoom, tryAcquireRoom } from '../../lib/teamChat/roomLock'
 import { parseTeamChatBinding } from '../mcp'
 import { teamChatExchangePOST, teamChatGET } from '../teamChat'
@@ -68,6 +68,9 @@ describe('GET /api/team-chat', () => {
     process.env['CLAWBOO_HOME'] = dir
   })
   afterAll(() => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['CLAWBOO_HOME']
     else process.env['CLAWBOO_HOME'] = prevHome
     rmSync(dir, { recursive: true, force: true })
@@ -90,7 +93,7 @@ describe('GET /api/team-chat', () => {
 
   it('reads a team room (resolves roomId from teamId) in seq order', () => {
     // Seed the sandboxed DB the handler opens via getDbPath().
-    const db = createDb(getDbPath())
+    const db = getDb()
     postToRoom(db, {
       roomId: resolveRoomForTeam('tm-rest'),
       teamId: 'tm-rest',

--- a/apps/web/server/api/__tests__/teamChatStream.test.ts
+++ b/apps/web/server/api/__tests__/teamChatStream.test.ts
@@ -20,6 +20,7 @@ import {
 } from '@clawboo/db'
 import { buildTeamSessionKey } from '@clawboo/team-orchestration'
 
+import { resetDb } from '../../lib/db'
 import { resolveTeamSessionKeys } from '../teamChatStream'
 
 let dir: string
@@ -57,7 +58,13 @@ beforeEach(() => {
   db = createDb(path.join(dir, 'test.db'))
   seq = 0
 })
-afterEach(() => rmSync(dir, { recursive: true, force: true }))
+afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory that
+  // still holds an open file. The suite never opens the handle itself, the
+  // server code under test does. (#140)
+  resetDb()
+  rmSync(dir, { recursive: true, force: true })
+})
 
 describe('teamChatStream read path', () => {
   it('resolveTeamSessionKeys → the team members’ team-keys, excluding other teams', () => {

--- a/apps/web/server/api/__tests__/teamChatStream.test.ts
+++ b/apps/web/server/api/__tests__/teamChatStream.test.ts
@@ -20,7 +20,6 @@ import {
 } from '@clawboo/db'
 import { buildTeamSessionKey } from '@clawboo/team-orchestration'
 
-import { resetDb } from '../../lib/db'
 import { resolveTeamSessionKeys } from '../teamChatStream'
 
 let dir: string
@@ -59,10 +58,11 @@ beforeEach(() => {
   seq = 0
 })
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory that
-  // still holds an open file. The suite never opens the handle itself, the
-  // server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/api/__tests__/teamOnboarding.test.ts
+++ b/apps/web/server/api/__tests__/teamOnboarding.test.ts
@@ -8,11 +8,11 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { chatMessages, createDb, setSetting, type ClawbooDb } from '@clawboo/db'
+import { chatMessages, setSetting, type ClawbooDb } from '@clawboo/db'
 import type { Request, Response } from 'express'
 
 import { teamOnboardingGET } from '../teamOnboarding'
-import { getDbPath } from '../../lib/db'
+import { getDb, resetDb } from '../../lib/db'
 
 const TEAM = 'team-1'
 
@@ -44,10 +44,13 @@ describe('teamOnboardingGET — chat-history override', () => {
     prevHome = process.env['HOME']
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
-    db = createDb(getDbPath())
+    db = getDb()
     seq = 0
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']

--- a/apps/web/server/lib/__tests__/budget.test.ts
+++ b/apps/web/server/lib/__tests__/budget.test.ts
@@ -10,7 +10,6 @@ import path from 'node:path'
 import { promisify } from 'node:util'
 
 import {
-  createDb,
   createTask,
   getBudget,
   listGovernanceAudit,
@@ -28,7 +27,7 @@ import type {
 } from '@clawboo/executor'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 
 const execFileAsync = promisify(execFile)
@@ -111,6 +110,9 @@ describe('budget kill-switch (real board + real git worktree)', () => {
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -118,12 +120,11 @@ describe('budget kill-switch (real board + real git worktree)', () => {
   })
 
   function newTask(): string {
-    return createTask(createDb(getDbPath()), { title: 'spend', status: 'todo', teamId: 'team-1' })
-      .id
+    return createTask(getDb(), { title: 'spend', status: 'todo', teamId: 'team-1' }).id
   }
 
   it('auto-pauses + aborts the run when a cost event crosses the team budget', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     setBudgetLimit(db, { scope: 'team', scopeId: 'team-1', limitUsdCents: 10, mode: 'cap' }) // $0.10 hard cap
     const taskId = newTask()
     const fake = new FakeCostAdapter(0.5) // 50¢ ≫ 10¢
@@ -147,7 +148,7 @@ describe('budget kill-switch (real board + real git worktree)', () => {
   })
 
   it('a warn-mode budget does NOT pause — it tracks + warns, the run completes', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     // Track-and-warn: a warn budget far below the spend. The run must finish.
     setBudgetLimit(db, { scope: 'team', scopeId: 'team-1', limitUsdCents: 10, mode: 'warn' })
     const taskId = newTask()
@@ -172,7 +173,7 @@ describe('budget kill-switch (real board + real git worktree)', () => {
   })
 
   it('a human resume (raise the cap) lets a re-run proceed', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     setBudgetLimit(db, { scope: 'team', scopeId: 'team-1', limitUsdCents: 10, mode: 'cap' })
     const taskId = newTask()
     await runTaskOnRuntime({

--- a/apps/web/server/lib/__tests__/budgetPreflight.test.ts
+++ b/apps/web/server/lib/__tests__/budgetPreflight.test.ts
@@ -6,7 +6,6 @@ import { createDb, recordSpend, setBudgetLimit, type ClawbooDb } from '@clawboo/
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { budgetPreflight } from '../budgetPreflight'
-import { resetDb } from '../db'
 
 let dir: string
 let db: ClawbooDb
@@ -15,10 +14,11 @@ beforeEach(() => {
   db = createDb(path.join(dir, 'test.db'))
 })
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory that
-  // still holds an open file. The suite never opens the handle itself, the
-  // server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/__tests__/budgetPreflight.test.ts
+++ b/apps/web/server/lib/__tests__/budgetPreflight.test.ts
@@ -6,6 +6,7 @@ import { createDb, recordSpend, setBudgetLimit, type ClawbooDb } from '@clawboo/
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { budgetPreflight } from '../budgetPreflight'
+import { resetDb } from '../db'
 
 let dir: string
 let db: ClawbooDb
@@ -13,7 +14,13 @@ beforeEach(() => {
   dir = mkdtempSync(path.join(os.tmpdir(), 'clawboo-preflight-'))
   db = createDb(path.join(dir, 'test.db'))
 })
-afterEach(() => rmSync(dir, { recursive: true, force: true }))
+afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory that
+  // still holds an open file. The suite never opens the handle itself, the
+  // server code under test does. (#140)
+  resetDb()
+  rmSync(dir, { recursive: true, force: true })
+})
 
 describe('budgetPreflight', () => {
   it('does not block when no budget rows exist (uncapped)', () => {

--- a/apps/web/server/lib/__tests__/executorRunner.integration.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.integration.test.ts
@@ -29,7 +29,6 @@ import { promisify } from 'node:util'
 import type { Request, Response } from 'express'
 
 import {
-  createDb,
   createTask,
   getBudget,
   getComments,
@@ -50,7 +49,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { runtimesRunPOST } from '../../api/runtimes'
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 import type { RuntimeRunContext } from '../runtimes'
 import { getTaskWorkspace } from '../worktrees'
@@ -183,6 +182,9 @@ describe('executor runner — all-on integration (board + executors + worktrees 
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -190,7 +192,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
   })
 
   function newCodeTask(title = 'Implement the thing'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'do it',
       status: 'todo',
@@ -201,7 +203,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
   it('happy path: all six subsystems cooperate on one successful run', async () => {
     const taskId = newCodeTask()
     // A generous agent budget: spend is RECORDED (governance live) without pausing.
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'agent',
       scopeId: 'claude-1',
       limitUsdCents: 10_000,
@@ -214,7 +216,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
     const adapter = new ScriptedAdapter('claude-code', b.build())
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: (ctx: RuntimeRunContext) => {
         if (ctx.cwd) dirtyWorktree(ctx.cwd) // real call (worktree present) → leave a verifiable deliverable
         return adapter
@@ -234,7 +236,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
     expect(result.doneReason).toBe('success')
     expect(result.status).toBe('done') // verify gate passed → in_review → done
 
-    const db = createDb(getDbPath())
+    const db = getDb()
 
     // ── board ──────────────────────────────────────────────────────────────────
     expect(getTask(db, taskId)?.status).toBe('done')
@@ -277,7 +279,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
 
   it('all-on halt path: a budget trip cancels the run cleanly and SKIPS verify', async () => {
     const taskId = newCodeTask()
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'agent',
       scopeId: 'claude-1',
       limitUsdCents: 1,
@@ -291,7 +293,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
     const adapter = new ScriptedAdapter('claude-code', b.build())
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: (ctx: RuntimeRunContext) => {
         if (ctx.cwd) dirtyWorktree(ctx.cwd)
         return adapter
@@ -309,7 +311,7 @@ describe('executor runner — all-on integration (board + executors + worktrees 
     expect(result.summary).toBe('auto-paused (budget)') // budget, not the breaker
     expect(adapter.aborts).toBe(1) // exactly one abort — no double-abort
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo')
     expect(listGovernanceAudit(db, { eventType: 'budget' })).toHaveLength(1)
     expect(listGovernanceAudit(db, { eventType: 'circuit_break' })).toHaveLength(0) // breaker did NOT fire
@@ -345,12 +347,15 @@ describe.skipIf(process.env['CLAWBOO_LIVE_ACCEPTANCE'] !== '1')(
       repo = await initRepo()
     })
     afterEach(async () => {
+      // Close BEFORE removing the dir: Windows refuses to remove a directory
+      // that still holds an open file. (#140)
+      resetDb()
       if (prevHome !== undefined) process.env['HOME'] = prevHome
       await rm(repo, { recursive: true, force: true }).catch(() => {})
     })
 
     it('a real Claude Code run completes a board task with a worktree + verify + obs', async () => {
-      const taskId = createTask(createDb(getDbPath()), {
+      const taskId = createTask(getDb(), {
         title: 'Append a line to feature.txt and set VERIFY_CMD',
         description:
           "Create a file `feature.txt` with a single line of text in the working directory, then set `VERIFY_CMD='test -f feature.txt'` inside init.sh. Report a one-line summary when done.",
@@ -374,7 +379,7 @@ describe.skipIf(process.env['CLAWBOO_LIVE_ACCEPTANCE'] !== '1')(
       )
       expect(res.statusCode()).toBe(200)
 
-      const db = createDb(getDbPath())
+      const db = getDb()
       const task = getTask(db, taskId)
       expect(['done', 'in_review', 'in_progress']).toContain(task?.status)
       // the run left an obs trace + a board comment (report-up).

--- a/apps/web/server/lib/__tests__/executorRunner.nativeIntegration.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.nativeIntegration.test.ts
@@ -16,7 +16,6 @@ import { promisify } from 'node:util'
 import {
   chatMessages,
   claimTask,
-  createDb,
   createTask,
   getBudget,
   getComments,
@@ -39,7 +38,7 @@ import type {
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 import type { RuntimeRunContext } from '../runtimes'
 import { createNativeDriver } from '../runtimes/native'
@@ -99,8 +98,7 @@ const usage = (input: number, output: number): ProviderStreamEvent => ({
 function makeNativeFactory(client: RoutedProviderClient) {
   return (ctx: RuntimeRunContext): RuntimeAdapter =>
     new NativeAdapter(
-      (opts: StartOpts) =>
-        createNativeDriver(opts, ctx, { client, mcp: null, db: createDb(getDbPath()) }),
+      (opts: StartOpts) => createNativeDriver(opts, ctx, { client, mcp: null, db: getDb() }),
       async () => ({ ok: true }),
     )
 }
@@ -119,6 +117,9 @@ describe('executor runner — native runtime integration', () => {
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']
@@ -127,7 +128,7 @@ describe('executor runner — native runtime integration', () => {
   })
 
   function newCodeTask(title = 'Add GREETING.md'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'write it',
       status: 'todo',
@@ -137,7 +138,7 @@ describe('executor runner — native runtime integration', () => {
 
   it('happy path: claim → file-tool worktree mutation → verify gate → done + handoff nativeSessionId', async () => {
     const taskId = newCodeTask()
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'agent',
       scopeId: 'native-spec-1',
       limitUsdCents: 10_000,
@@ -169,7 +170,7 @@ describe('executor runner — native runtime integration', () => {
     ])
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: makeNativeFactory(client),
       taskId,
       assigneeAgentId: 'native-spec-1',
@@ -185,7 +186,7 @@ describe('executor runner — native runtime integration', () => {
     expect(result.status).toBe('done')
     expect(result.costUsd).toBeGreaterThan(0) // real priced turns, cumulative
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('done')
     expect(getComments(db, taskId).some((c) => c.body.includes('Wrote the greeting'))).toBe(true)
     expect(getTaskVerification(db, taskId)?.status).toBe('pass')
@@ -232,7 +233,7 @@ describe('executor runner — native runtime integration', () => {
 
   it('budget kill-switch aborts a native conversation mid-stream and releases the task', async () => {
     const taskId = newCodeTask('Expensive task')
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'agent',
       scopeId: 'native-spend-1',
       limitUsdCents: 1,
@@ -247,7 +248,7 @@ describe('executor runner — native runtime integration', () => {
     ])
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: makeNativeFactory(client),
       taskId,
       assigneeAgentId: 'native-spend-1',
@@ -261,19 +262,19 @@ describe('executor runner — native runtime integration', () => {
     expect(result.status).toBe('todo') // released — clean resumable state
     expect(result.summary).toBe('auto-paused (budget)')
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo')
     expect(listGovernanceAudit(db, { eventType: 'budget' })).toHaveLength(1)
     expect(getTaskVerification(db, taskId) ?? null).toBeNull() // verify never ran
   })
 
   it('coexistence: native + hermes-shaped + openclaw tasks complete on ONE board', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
 
     // 1) Native (real driver + scripted provider).
     const nativeTask = newCodeTask('Native leg')
     const nativeResult = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: makeNativeFactory(
         scriptedClient([
           [
@@ -344,7 +345,7 @@ describe('executor runner — native runtime integration', () => {
       async writeContext() {}
     }
     const hermesResult = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: (ctx: RuntimeRunContext) => {
         if (ctx.cwd) {
           writeFileSync(path.join(ctx.cwd, 'hermes.txt'), 'hermes\n', 'utf8')

--- a/apps/web/server/lib/__tests__/executorRunner.obs.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.obs.test.ts
@@ -10,7 +10,7 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { createDb, createTask, listEvents } from '@clawboo/db'
+import { createTask, listEvents } from '@clawboo/db'
 import type {
   Capabilities,
   RunHandle,
@@ -21,7 +21,7 @@ import type {
 } from '@clawboo/executor'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 import { spanIdFor } from '../obs'
 
@@ -80,14 +80,16 @@ describe('executor runner → observability', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
   })
 
   function newTask(): string {
-    return createTask(createDb(getDbPath()), { title: 'do it', status: 'todo', teamId: 'team-1' })
-      .id
+    return createTask(getDb(), { title: 'do it', status: 'todo', teamId: 'team-1' }).id
   }
 
   it('emits the full task trace under one traceId (AC1)', async () => {
@@ -120,22 +122,20 @@ describe('executor runner → observability', () => {
       { ...base(), kind: 'done', reason: 'success', summary: 'all done' },
     ])
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => adapter,
       taskId,
       assigneeAgentId: 'a1',
     })
     expect(result.ok).toBe(true)
 
-    const evs = listEvents(createDb(getDbPath()), { taskId, limit: 1000 })
-    const traceEvs = listEvents(createDb(getDbPath()), { limit: 1000 }).filter(
-      (e) => e.kind === 'span_start',
-    )
+    const evs = listEvents(getDb(), { taskId, limit: 1000 })
+    const traceEvs = listEvents(getDb(), { limit: 1000 }).filter((e) => e.kind === 'span_start')
     expect(traceEvs).toHaveLength(1)
     const traceId = traceEvs[0]!.traceId
     expect(traceId).toBeTruthy()
     // All run events share the one trace.
-    const all = listEvents(createDb(getDbPath()), { traceId: traceId!, limit: 1000 })
+    const all = listEvents(getDb(), { traceId: traceId!, limit: 1000 })
     const kinds = all.map((e) => e.kind)
     for (const k of [
       'span_start',
@@ -156,7 +156,7 @@ describe('executor runner → observability', () => {
   })
 
   it('nests a child run under its parent run via the board ancestor chain (cross-run traceparent)', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const parent = createTask(db, { title: 'parent', status: 'todo', teamId: 'team-1' })
     const child = createTask(db, {
       title: 'child',
@@ -169,19 +169,19 @@ describe('executor runner → observability', () => {
       base: () => { runId: string; sessionId: string | null; ts: number; seq: number },
     ): RuntimeEvent[] => [{ ...base(), kind: 'done', reason: 'success', summary: 'ok' }]
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => new ScriptedAdapter('cc', done),
       taskId: parent.id,
       assigneeAgentId: 'a1',
     })
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => new ScriptedAdapter('cc', done),
       taskId: child.id,
       assigneeAgentId: 'a2',
     })
 
-    const starts = listEvents(createDb(getDbPath()), { kinds: ['span_start'], limit: 100 })
+    const starts = listEvents(getDb(), { kinds: ['span_start'], limit: 100 })
     const parentStart = starts.find((e) => e.taskId === parent.id)!
     const childStart = starts.find((e) => e.taskId === child.id)!
     // One trace for the whole mission.
@@ -205,13 +205,13 @@ describe('executor runner → observability', () => {
       },
     ])
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => adapter,
       taskId,
       assigneeAgentId: 'a1',
     })
 
-    const errors = listEvents(createDb(getDbPath()), { kinds: ['error'], limit: 100 })
+    const errors = listEvents(getDb(), { kinds: ['error'], limit: 100 })
     expect(errors.length).toBeGreaterThanOrEqual(1)
     const data = JSON.parse(errors[0]!.data) as { errorClass: string; harnessBug: boolean }
     expect(data.errorClass).toBe('Unknown')
@@ -224,12 +224,12 @@ describe('executor runner → observability', () => {
       { ...base(), kind: 'done', reason: 'error', summary: 'request timed out after 600s' },
     ])
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => adapter,
       taskId,
       assigneeAgentId: 'a1',
     })
-    const data = JSON.parse(listEvents(createDb(getDbPath()), { kinds: ['error'] })[0]!.data) as {
+    const data = JSON.parse(listEvents(getDb(), { kinds: ['error'] })[0]!.data) as {
       errorClass: string
       harnessBug: boolean
     }

--- a/apps/web/server/lib/__tests__/executorRunner.rotation.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.rotation.test.ts
@@ -14,7 +14,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   SqliteMemoryStore,
-  createDb,
   createTask,
   getBudget,
   getSessionBySourceId,
@@ -32,7 +31,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 
 type Reason = 'success' | 'max_turns' | 'error'
@@ -127,6 +126,9 @@ describe('executor runner — session rotation + memory injection', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
@@ -136,7 +138,7 @@ describe('executor runner — session rotation + memory injection', () => {
     title = 'Implement payment processing',
     description = 'wire the Stripe path',
   ): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description,
       status: 'todo',
@@ -148,7 +150,7 @@ describe('executor runner — session rotation + memory injection', () => {
     const taskId = newTask()
     const fake = new RotatingAdapter('claude-code', ['max_turns', 'success'])
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -164,7 +166,7 @@ describe('executor runner — session rotation + memory injection', () => {
     expect(fake.startedContexts[1]).toContain('Session handoff (rotation)')
 
     // The session_rotated obs event was emitted under the run's trace.
-    const db = createDb(getDbPath())
+    const db = getDb()
     const rotated = listEvents(db, { taskId, kinds: ['session_rotated'] })
     expect(rotated).toHaveLength(1)
     const data = JSON.parse(rotated[0]!.data) as {
@@ -190,7 +192,7 @@ describe('executor runner — session rotation + memory injection', () => {
       'max_turns',
     ])
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -202,7 +204,7 @@ describe('executor runner — session rotation + memory injection', () => {
     expect(result.doneReason).toBe('max_turns')
     expect(result.status).toBe('todo') // chain exhausted → released, retryable
     expect(fake.startCount).toBe(3) // initial + 2 rotations
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(listEvents(db, { taskId, kinds: ['session_rotated'] })).toHaveLength(2)
   })
 
@@ -210,7 +212,7 @@ describe('executor runner — session rotation + memory injection', () => {
     const taskId = newTask()
     const fake = new RotatingAdapter('claude-code', ['success'])
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -219,18 +221,16 @@ describe('executor runner — session rotation + memory injection', () => {
     expect(result.ok && result.status).toBe('done')
     expect(fake.startCount).toBe(1)
     expect(fake.serializeCount).toBe(0)
-    expect(listEvents(createDb(getDbPath()), { taskId, kinds: ['session_rotated'] })).toHaveLength(
-      0,
-    )
+    expect(listEvents(getDb(), { taskId, kinds: ['session_rotated'] })).toHaveLength(0)
   })
 
   it('accumulates budget spend across rotations (cumulative, not per-run)', async () => {
     const taskId = newTask()
-    const db = createDb(getDbPath())
+    const db = getDb()
     setBudgetLimit(db, { scope: 'agent', scopeId: 'claude-1', limitUsdCents: 100 }) // high → never pauses
     const fake = new RotatingAdapter('claude-code', ['max_turns', 'success'], 0.05) // 5¢ per run
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -238,12 +238,12 @@ describe('executor runner — session rotation + memory injection', () => {
     })
     expect(result.ok).toBe(true)
     // Two runs × 5¢ = 10¢ recorded against the agent budget.
-    expect(getBudget(createDb(getDbPath()), 'agent', 'claude-1')?.spentUsdCents).toBe(10)
+    expect(getBudget(getDb(), 'agent', 'claude-1')?.spentUsdCents).toBe(10)
   })
 
   it('injects an <auto-memory> block at run start (and suppresses it when disabled)', async () => {
     // Seed a relevant fact into the SAME db the runner reads.
-    await new SqliteMemoryStore(createDb(getDbPath())).saveFact({
+    await new SqliteMemoryStore(getDb()).saveFact({
       title: 'Payments',
       content: 'payment processing uses the Stripe checkout API',
       scope: { teamId: 'team-1' },
@@ -252,7 +252,7 @@ describe('executor runner — session rotation + memory injection', () => {
     const taskOn = newTask()
     const fakeOn = new RotatingAdapter('claude-code', ['success'])
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fakeOn,
       taskId: taskOn,
       assigneeAgentId: 'claude-1',
@@ -263,7 +263,7 @@ describe('executor runner — session rotation + memory injection', () => {
     const taskOff = newTask()
     const fakeOff = new RotatingAdapter('claude-code', ['success'])
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fakeOff,
       taskId: taskOff,
       assigneeAgentId: 'claude-1',

--- a/apps/web/server/lib/__tests__/executorRunner.routing.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.routing.test.ts
@@ -17,7 +17,7 @@ import { promisify } from 'node:util'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { createDb, createTask, getTask, listEvents } from '@clawboo/db'
+import { createTask, getTask, listEvents } from '@clawboo/db'
 import type {
   Capabilities,
   RunHandle,
@@ -28,7 +28,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 import type { RuntimeRunContext } from '../runtimes'
 import { getTaskWorkspace } from '../worktrees'
@@ -158,13 +158,16 @@ describe('executor runner — native-preservation routing (by construction)', ()
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
   })
 
   function newTask(title = 'Implement the thing'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'do it',
       status: 'todo',
@@ -182,7 +185,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
       nativeScheduler: true,
     })
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'agent-1',
@@ -190,7 +193,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
     })
     expect(result).toEqual({ ok: false, reason: 'connected_substrate' })
     expect(fake.startCount).toBe(0) // the adapter was never started
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo') // never claimed
     expect(listEvents(db, { taskId, kinds: ['execution_started'] })).toHaveLength(0) // no exec row opened
   })
@@ -201,7 +204,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
     const first = new SeamAdapter('hermes', HERMES_SHAPED)
     const f1 = recordingFactory(first)
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f1.makeAdapter,
       taskId: newTask(),
       assigneeAgentId: 'hermes-1',
@@ -214,7 +217,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
     const second = new SeamAdapter('hermes', HERMES_SHAPED)
     const f2 = recordingFactory(second)
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f2.makeAdapter,
       taskId: newTask('Another task'),
       assigneeAgentId: 'hermes-1',
@@ -226,7 +229,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
     const third = new SeamAdapter('hermes', HERMES_SHAPED)
     const f3 = recordingFactory(third)
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f3.makeAdapter,
       taskId: newTask('Third task'),
       assigneeAgentId: 'hermes-2',
@@ -241,7 +244,7 @@ describe('executor runner — native-preservation routing (by construction)', ()
     const fake = new SeamAdapter('claude-code', FULL_CAPS)
     const f = recordingFactory(fake)
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f.makeAdapter,
       taskId: newTask(),
       assigneeAgentId: 'claude-1',
@@ -265,6 +268,9 @@ describe('executor runner — native session resume across dispatches', () => {
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
@@ -272,7 +278,7 @@ describe('executor runner — native session resume across dispatches', () => {
   })
 
   function newTask(): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title: 'Long task',
       description: 'spans dispatches',
       status: 'todo',
@@ -283,7 +289,7 @@ describe('executor runner — native session resume across dispatches', () => {
   /** Dispatch 1: pause-for-handoff so the worktree (and its handoff) survives. */
   async function pauseRun(taskId: string, adapter: SeamAdapter): Promise<void> {
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: recordingFactory(adapter).makeAdapter,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -308,7 +314,7 @@ describe('executor runner — native session resume across dispatches', () => {
     const second = new SeamAdapter('hermes', HERMES_SHAPED, ['success'], 'hsess-B')
     const f2 = recordingFactory(second)
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f2.makeAdapter,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -329,7 +335,7 @@ describe('executor runner — native session resume across dispatches', () => {
     const other = new SeamAdapter('codex', codexShaped, ['success'], 'thread-X')
     const f = recordingFactory(other)
     await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f.makeAdapter,
       taskId,
       assigneeAgentId: 'codex-1',
@@ -350,7 +356,7 @@ describe('executor runner — native session resume across dispatches', () => {
     const rotating = new SeamAdapter('hermes', HERMES_SHAPED, ['max_turns', 'success'], 'hsess-B')
     const f = recordingFactory(rotating)
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f.makeAdapter,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -384,7 +390,7 @@ describe('executor runner — native session resume across dispatches', () => {
     const failing = new SeamAdapter('hermes', HERMES_SHAPED, ['error'], null)
     const f = recordingFactory(failing)
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f.makeAdapter,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -405,7 +411,7 @@ describe('executor runner — native session resume across dispatches', () => {
     const third = new SeamAdapter('hermes', HERMES_SHAPED, ['success'], 'hsess-new')
     const f3 = recordingFactory(third)
     const ok = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: f3.makeAdapter,
       taskId,
       assigneeAgentId: 'hermes-1',

--- a/apps/web/server/lib/__tests__/executorRunner.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.test.ts
@@ -25,7 +25,6 @@ import { HermesAdapter, type HermesDriver, type HermesNativeEvent } from '@clawb
 import { resolveClawbooDir } from '@clawboo/config'
 import {
   claimTask,
-  createDb,
   createTask,
   getBudget,
   getComments,
@@ -43,7 +42,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { planDegradations } from '../degradation'
 import { runTaskOnRuntime } from '../executorRunner'
 import { runtimeIdentityHomePath } from '../runtimes/identityHome'
@@ -132,6 +131,9 @@ describe('executor runner (real board + real git worktree)', () => {
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
@@ -141,7 +143,7 @@ describe('executor runner (real board + real git worktree)', () => {
   })
 
   function newCodeTask(title = 'Implement the thing'): string {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const task = createTask(db, { title, description: 'do it', status: 'todo', teamId: 'team-1' })
     return task.id
   }
@@ -150,7 +152,7 @@ describe('executor runner (real board + real git worktree)', () => {
     const taskId = newCodeTask()
     const fake = new FakeRunnerAdapter('claude-code', FULL_CAPS, 'Implemented and verified.')
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -174,10 +176,10 @@ describe('executor runner (real board + real git worktree)', () => {
   it('refuses a second claim with 409 and never retries', async () => {
     const taskId = newCodeTask()
     // Someone else already owns it (in_progress).
-    claimTask(createDb(getDbPath()), taskId, 'other-agent', 'openclaw')
+    claimTask(getDb(), taskId, 'other-agent', 'openclaw')
     const fake = new FakeRunnerAdapter('codex', FULL_CAPS, 'should not run')
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'codex-1',
@@ -193,7 +195,7 @@ describe('executor runner (real board + real git worktree)', () => {
     const leak = 'crash: OPENROUTER_API_KEY=sk-or-SECRETKEY1234567890ABCDEF env dump'
     const fake = new FakeRunnerAdapter('hermes', FULL_CAPS, leak, 'error')
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -206,7 +208,7 @@ describe('executor runner (real board + real git worktree)', () => {
     expect(result.doneReason).toBe('error')
     expect(result.summary).not.toContain('sk-or-SECRETKEY')
     // The durable board comment + execution row carry the redacted text, not the key.
-    const comments = getComments(createDb(getDbPath()), taskId)
+    const comments = getComments(getDb(), taskId)
     expect(JSON.stringify(comments)).not.toContain('sk-or-SECRETKEY')
     expect(JSON.stringify(comments)).toContain('[REDACTED]')
   })
@@ -221,7 +223,7 @@ describe('executor runner (real board + real git worktree)', () => {
       'Wired the --json flag; NEXT: finish the SSE parser.',
     )
     const r1 = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => run1,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -240,7 +242,7 @@ describe('executor runner (real board + real git worktree)', () => {
     // prompt context must carry run 1's handoff, reconstructed from the worktree.
     const run2 = new FakeRunnerAdapter('codex', FULL_CAPS, 'Finished the parser. Done.')
     const r2 = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => run2,
       taskId,
       assigneeAgentId: 'codex-1',
@@ -251,7 +253,7 @@ describe('executor runner (real board + real git worktree)', () => {
   })
 
   it('refuses a task nested PAST MAX_SPAWN_DEPTH but dispatches one exactly at it', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const root = createTask(db, { title: 'root', status: 'todo' })
     const child = createTask(db, { title: 'child', status: 'todo', parentTaskId: root.id })
     const grandchild = createTask(db, {
@@ -265,7 +267,7 @@ describe('executor runner (real board + real git worktree)', () => {
     const tooDeep = new FakeRunnerAdapter('claude-code', FULL_CAPS, 'nope')
     expect(
       await runTaskOnRuntime({
-        db: createDb(getDbPath()),
+        db: getDb(),
         makeAdapter: () => tooDeep,
         taskId: great.id,
         assigneeAgentId: 'claude-1',
@@ -280,7 +282,7 @@ describe('executor runner (real board + real git worktree)', () => {
     // permanently undispatchable cards on the board.
     const atCeiling = new FakeRunnerAdapter('claude-code', FULL_CAPS, 'nope')
     const ok = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => atCeiling,
       taskId: grandchild.id,
       assigneeAgentId: 'claude-2',
@@ -303,7 +305,7 @@ describe('executor runner (real board + real git worktree)', () => {
     }
     const fake = new FakeRunnerAdapter('hermes', limited, 'done')
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'hermes-1',
@@ -469,6 +471,9 @@ describe('executor runner — circuit breakers', () => {
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
@@ -478,7 +483,7 @@ describe('executor runner — circuit breakers', () => {
   })
 
   function newCodeTask(title = 'Implement the thing'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'do it',
       status: 'todo',
@@ -488,7 +493,7 @@ describe('executor runner — circuit breakers', () => {
 
   async function run(taskId: string, fake: ScriptedAdapter, agentId = 'claude-1') {
     return runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: agentId,
@@ -499,7 +504,7 @@ describe('executor runner — circuit breakers', () => {
 
   /** Assert the full breaker teardown for a given halt reason. */
   function expectHalted(taskId: string, reason: string) {
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo') // released — clean resumable state
     expect(listGovernanceAudit(db, { eventType: 'circuit_break' }).length).toBe(1)
     expect(getComments(db, taskId).some((c) => c.body.includes(`[stopped: ${reason}]`))).toBe(true)
@@ -604,7 +609,7 @@ describe('executor runner — circuit breakers', () => {
     const ctl = new AbortController()
     ctl.abort()
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -615,7 +620,7 @@ describe('executor runner — circuit breakers', () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.reason).toBe('conflict')
     expect(fake.startedOpts).toBeNull() // never claimed → adapter never started
-    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo') // board untouched
+    expect(getTask(getDb(), taskId)?.status).toBe('todo') // board untouched
   })
 
   it('honors a per-run breakerConfig override (a tighter iteration cap trips early)', async () => {
@@ -625,7 +630,7 @@ describe('executor runner — circuit breakers', () => {
     b.done('success')
     const fake = new ScriptedAdapter('claude-code', b.build())
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -639,7 +644,7 @@ describe('executor runner — circuit breakers', () => {
 
   it('composes with the budget kill-switch — exactly one abort, budget wins the tie', async () => {
     const taskId = newCodeTask()
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'agent',
       scopeId: 'claude-1',
       limitUsdCents: 1,
@@ -655,7 +660,7 @@ describe('executor runner — circuit breakers', () => {
     if (!result.ok) return
     expect(result.summary).toBe('auto-paused (budget)') // budget, not the breaker
     expect(fake.aborts).toBe(1) // exactly one abort — no double-abort
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(listGovernanceAudit(db, { eventType: 'circuit_break' }).length).toBe(0) // breaker did NOT fire
     expect(listGovernanceAudit(db, { eventType: 'budget' }).length).toBe(1)
     expect(listEvents(db, { taskId, kinds: ['execution_completed'] }).length).toBe(1) // one terminal
@@ -707,6 +712,9 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
@@ -715,7 +723,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
   })
 
   function newTask(title = 'persistent task'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'do it',
       status: 'todo',
@@ -766,7 +774,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     const t2 = newTask('b')
     const run = (taskId: string) =>
       runTaskOnRuntime({
-        db: createDb(getDbPath()),
+        db: getDb(),
         makeAdapter: () => makeConcurrencyAdapter('clawboo-native', tracker),
         taskId,
         assigneeAgentId: 'agent-X', // SAME identity → same persistent home
@@ -783,7 +791,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     const t2 = newTask('b')
     const run = (taskId: string, agentId: string) =>
       runTaskOnRuntime({
-        db: createDb(getDbPath()),
+        db: getDb(),
         makeAdapter: () => makeConcurrencyAdapter('clawboo-native', tracker),
         taskId,
         assigneeAgentId: agentId,
@@ -836,7 +844,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     }
     const ctl = new AbortController()
     const p = runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => adapter,
       taskId,
       assigneeAgentId: 'agent-Z',
@@ -850,7 +858,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     if (!result.ok) return
     expect(result.doneReason).toBe('aborted')
     expect(result.status).toBe('todo') // released, retryable
-    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
+    expect(getTask(getDb(), taskId)?.status).toBe('todo')
   })
 
   // win32-skipped: this file is not Windows-runnable yet (SQLite reset + a
@@ -862,7 +870,7 @@ describe('executor runner — per-identity home serialization + cancellation + 0
     async () => {
       const taskId = newTask('perms')
       await runTaskOnRuntime({
-        db: createDb(getDbPath()),
+        db: getDb(),
         makeAdapter: () => makeConcurrencyAdapter('clawboo-native', { active: 0, max: 0 }),
         taskId,
         assigneeAgentId: 'agent-perms',
@@ -917,6 +925,9 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
@@ -926,7 +937,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
   })
 
   function newTeamTask(title = 'Do the thing'): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title,
       description: 'do it',
       status: 'todo',
@@ -936,7 +947,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
 
   it('estimates a CODEX run from reported usage so the cap engages (real adapter), then blocks the next dispatch', async () => {
     // A 1-cent team cap; Codex reports usage but NO USD → the executor must estimate.
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'team',
       scopeId: 'team-1',
       limitUsdCents: 1,
@@ -945,7 +956,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     const taskId = newTeamTask()
 
     const r1 = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () =>
         new CodexAdapter(
           () =>
@@ -968,7 +979,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     if (!r1.ok) return
     expect(r1.doneReason).toBe('aborted') // the kill-switch fired on the estimated spend
     expect(r1.status).toBe('todo')
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo') // released, retryable
     const b = getBudget(db, 'team', 'team-1')
     expect(b?.status).toBe('paused') // the cap engaged from estimated usage
@@ -977,7 +988,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     // The NEXT dispatch on the same (paused) team is refused pre-flight — never claimed.
     const taskId2 = newTeamTask('next')
     const r2 = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () =>
         new CodexAdapter(
           () =>
@@ -999,11 +1010,11 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     expect(r2.ok).toBe(false)
     if (r2.ok) return
     expect(r2.reason).toBe('budget_paused')
-    expect(getTask(createDb(getDbPath()), taskId2)?.status).toBe('todo') // never claimed
+    expect(getTask(getDb(), taskId2)?.status).toBe('todo') // never claimed
   })
 
   it('estimates a HERMES run from reported usage so the cap engages (real adapter)', async () => {
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'team',
       scopeId: 'team-1',
       limitUsdCents: 1,
@@ -1012,7 +1023,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     const taskId = newTeamTask()
 
     const r = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () =>
         new HermesAdapter(
           () =>
@@ -1034,14 +1045,14 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     expect(r.ok).toBe(true)
     if (!r.ok) return
     expect(r.doneReason).toBe('aborted')
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('todo')
     expect(getBudget(db, 'team', 'team-1')?.status).toBe('paused')
   })
 
   it('records a REAL costUsd exactly — the estimate never fires for an exact-cost runtime (no regression)', async () => {
     // A warn budget with plenty of headroom — it must record the EXACT cost, unpaused.
-    setBudgetLimit(createDb(getDbPath()), {
+    setBudgetLimit(getDb(), {
       scope: 'team',
       scopeId: 'team-1',
       limitUsdCents: 100_000,
@@ -1052,7 +1063,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
     b.costUsd(0.5) // a real reported costUsd (Claude Code / pinned-native shape) → exactly 50¢
     b.done('success')
     const r = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => new ScriptedAdapter('claude-code', b.build()),
       taskId,
       assigneeAgentId: 'claude-1',
@@ -1060,7 +1071,7 @@ describe('executor cost estimation across runtimes (the budget cap engages for e
       kind: 'code',
     })
     expect(r.ok).toBe(true)
-    const bud = getBudget(createDb(getDbPath()), 'team', 'team-1')
+    const bud = getBudget(getDb(), 'team', 'team-1')
     expect(bud?.spentUsdCents).toBe(50) // exact — the estimate path did not re-price it
     expect(bud?.status).not.toBe('paused') // a warn budget never pauses
   })

--- a/apps/web/server/lib/__tests__/executorRunner.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.test.ts
@@ -850,7 +850,13 @@ describe('executor runner — per-identity home serialization + cancellation + 0
       assigneeAgentId: 'agent-Z',
       abortSignal: ctl.signal,
     })
-    await new Promise((r) => setTimeout(r, 30)) // let the run reach the hang
+    // Wait until the run has ACTUALLY reached the hang, rather than guessing with
+    // a fixed sleep. `release` is only assigned once the generator is parked, and
+    // abort() resolves it. On a loaded runner (this is what timed out on Windows
+    // CI) 30ms can elapse before the generator gets there; aborting first leaves
+    // `release` null, so nothing ever unparks the generator and the run never
+    // settles. Polling the real signal makes it deterministic everywhere. (#140)
+    while (!release) await new Promise((r) => setTimeout(r, 5))
     ctl.abort()
     const result = await p
     expect(aborted).toBe(true) // the live run was aborted

--- a/apps/web/server/lib/__tests__/verification.test.ts
+++ b/apps/web/server/lib/__tests__/verification.test.ts
@@ -16,7 +16,6 @@ import { promisify } from 'node:util'
 
 import {
   claimTask,
-  createDb,
   createTask,
   getComments,
   getTask,
@@ -34,7 +33,7 @@ import type {
 import type { DiffStat, Worktree } from '@clawboo/worktrees'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { verifyTask } from '../verification'
 import { actOnTaskWorkspace, provisionTaskWorkspace } from '../worktrees'
 
@@ -100,7 +99,7 @@ async function provisionForTask(
   repoPath: string,
   verifyCmd: string,
 ): Promise<{ taskId: string; worktree: Worktree }> {
-  const db = createDb(getDbPath())
+  const db = getDb()
   const task = createTask(db, { title: 'do the thing', teamId: 'team1' })
   claimTask(db, task.id, 'agent1', 'openclaw') // → in_progress (a real run owns it before completion)
   const prov = await provisionTaskWorkspace(task.id, { repoPath, kind: 'code' })
@@ -128,6 +127,9 @@ describe('verification gate (real board + real git worktree)', () => {
     repo = await initRepo()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
@@ -138,15 +140,15 @@ describe('verification gate (real board + real git worktree)', () => {
     const { taskId } = await provisionForTask(repo, 'exit 0')
     const r = await actOnTaskWorkspace(taskId, 'complete')
     expect(r.ok && r.action === 'complete' ? r.verified : null).toBe('pass')
-    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('done')
-    expect(getTaskVerification(createDb(getDbPath()), taskId)?.status).toBe('pass')
+    expect(getTask(getDb(), taskId)?.status).toBe('done')
+    expect(getTaskVerification(getDb(), taskId)?.status).toBe('pass')
   })
 
   it('a failing gate blocks done and reverts to in_progress with a structured error', async () => {
     const { taskId } = await provisionForTask(repo, 'exit 1')
     const r = await actOnTaskWorkspace(taskId, 'complete')
     expect(r.ok && r.action === 'complete' ? r.verified : null).toBe('fail')
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('in_progress')
     const comments = getComments(db, taskId)
     expect(
@@ -156,7 +158,7 @@ describe('verification gate (real board + real git worktree)', () => {
 
   it('marks completed_with_debt at cycle exhaustion (never deadlocks)', async () => {
     const { taskId, worktree } = await provisionForTask(repo, 'exit 1')
-    const db = createDb(getDbPath())
+    const db = getDb()
     const verdict = await verifyTask({
       db,
       taskId,
@@ -172,7 +174,7 @@ describe('verification gate (real board + real git worktree)', () => {
 
   it('a completed_with_debt verdict over a RED gate routes to BLOCKED (never silently done)', async () => {
     const { taskId } = await provisionForTask(repo, 'exit 1') // gate always red
-    const db = createDb(getDbPath())
+    const db = getDb()
     // Pre-seed 2 prior failing attempts so the next cycle (default max 3) exhausts
     // the fix loop → completed_with_debt with a still-failing deterministic gate.
     const failAttempt = (n: number) => ({
@@ -217,7 +219,7 @@ describe('verification gate (real board + real git worktree)', () => {
 
   it('the read-only critic runs on a risky diff and a blocking finding fails the verdict', async () => {
     const { taskId, worktree } = await provisionForTask(repo, 'exit 0')
-    const db = createDb(getDbPath())
+    const db = getDb()
     const reviewRoot = path.join(home, 'reviews')
     const blocking = JSON.stringify({
       findings: [{ severity: 'security', title: 'hardcoded token', confidence: 0.9 }],
@@ -245,7 +247,7 @@ describe('verification gate (real board + real git worktree)', () => {
 
   it('skips the critic on a small, low-risk diff (passes on the gate alone)', async () => {
     const { taskId, worktree } = await provisionForTask(repo, 'exit 0')
-    const db = createDb(getDbPath())
+    const db = getDb()
     const verdict = await verifyTask({
       db,
       taskId,

--- a/apps/web/server/lib/__tests__/worktrees.test.ts
+++ b/apps/web/server/lib/__tests__/worktrees.test.ts
@@ -17,7 +17,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   claimTask,
-  createDb,
   createTask,
   getTask,
   getWorkspaceForTask,
@@ -28,7 +27,7 @@ import {
 } from '@clawboo/db'
 import { isWorktreeRegistered, SOR_FILES } from '@clawboo/worktrees'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import {
   actOnTaskWorkspace,
   gcTaskWorkspaces,
@@ -68,6 +67,9 @@ describe('server worktree orchestrator (real git + real board)', () => {
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
@@ -75,7 +77,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
   })
 
   function newClaimedCodeTask(): string {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const task = createTask(db, {
       title: 'Implement feature X',
       description: 'Wire feature X end to end.',
@@ -99,7 +101,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     // Worktree lives OUTSIDE the user's repo (under the sandbox HOME).
     expect(prov.worktree.worktreePath.startsWith(home)).toBe(true)
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     const ws = getWorkspaceForTask(db, taskId)
     expect(ws?.worktreePath).toBe(prov.worktree.worktreePath)
     expect(ws?.branch).toBe(prov.worktree.branch)
@@ -161,7 +163,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     expect(result.taskStatus).toBe('done')
     expect(existsSync(prov.worktree.worktreePath)).toBe(false)
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('done')
     expect(getWorkspaceForTask(db, taskId)?.status).toBe('archived')
   })
@@ -175,7 +177,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     // An earlier dirty attempt failed verification; the fix reduced the diff to
     // empty on this re-complete. The empty-diff terminal must not be blocked by the
     // stale failing verdict (an empty diff has no deliverable to verify).
-    const db = createDb(getDbPath())
+    const db = getDb()
     setTaskVerification(db, taskId, {
       status: 'fail',
       attempts: [
@@ -230,13 +232,13 @@ describe('server worktree orchestrator (real git + real board)', () => {
     expect(result.taskStatus).toBe('in_progress')
     expect(existsSync(prov.worktree.worktreePath)).toBe(true)
 
-    const db = createDb(getDbPath())
+    const db = getDb()
     expect(getTask(db, taskId)?.status).toBe('in_progress')
     expect(getWorkspaceForTask(db, taskId)?.status).toBe('active')
   })
 
   it('refuses to provision a worktree for read-only research work', async () => {
-    const db = createDb(getDbPath())
+    const db = getDb()
     const task = createTask(db, { title: 'Research the options', status: 'todo' })
     const prov = await provisionTaskWorkspace(task.id, { repoPath: repo, kind: 'research' })
     expect(prov.ok).toBe(false)
@@ -249,7 +251,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     expect(prov.ok).toBe(true)
     if (!prov.ok) return
     const wtPath = prov.worktree.worktreePath
-    const db = createDb(getDbPath())
+    const db = getDb()
     const wsId = getWorkspaceForTask(db, taskId)!.id
 
     // Simulate a GC reap: the worktree dir is gone (branch kept) + row marked stale.
@@ -275,7 +277,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     expect(a.ok && b.ok).toBe(true)
     if (!a.ok || !b.ok) return
     expect(b.workspaceId).toBe(a.workspaceId) // same row, not a duplicate
-    const db = createDb(getDbPath())
+    const db = getDb()
     const activeForTask = listActiveWorkspaces(db).filter((w) => w.taskId === taskId)
     expect(activeForTask).toHaveLength(1)
   })
@@ -285,7 +287,7 @@ describe('server worktree orchestrator (real git + real board)', () => {
     // snapshot, so a task that is active at reap time is genuinely protected. This
     // exercises the real gcTaskWorkspaces → gcWorktrees → live callback path and
     // locks the predicate to BOTH active statuses (in_progress AND in_review).
-    const db = createDb(getDbPath())
+    const db = getDb()
     const running = newClaimedCodeTask() // stays in_progress
     const reviewing = newClaimedCodeTask() // → in_review
     const released = newClaimedCodeTask() // → todo (no longer active)

--- a/apps/web/server/lib/agentChat/__tests__/driveAgentChat.test.ts
+++ b/apps/web/server/lib/agentChat/__tests__/driveAgentChat.test.ts
@@ -10,7 +10,7 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { agents, chatMessages, createDb, getSetting, setSetting, type ClawbooDb } from '@clawboo/db'
+import { agents, chatMessages, getSetting, setSetting, type ClawbooDb } from '@clawboo/db'
 import { eq } from 'drizzle-orm'
 import type {
   Capabilities,
@@ -21,7 +21,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { subscribeChatDelta } from '../../teamChat/chatDeltaBus'
 import { chatHistoryDELETE } from '../../../api/chatHistory'
 import {
@@ -84,9 +84,12 @@ describe('driveAgentChat (1:1 native conversational runner)', () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-agentchat-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
@@ -323,7 +326,7 @@ describe('driveAgentChat (1:1 native conversational runner)', () => {
     const key = nativeChatSessionSettingKey('native-x')
     setSetting(db, key, 'native-abc123')
     expect(getSetting(db, key)).toBe('native-abc123')
-    // chatHistoryDELETE opens its own createDb(getDbPath()) — the SAME sandbox file.
+    // chatHistoryDELETE opens its own getDb() — the SAME sandbox file.
     const req = {
       query: { sessionKey: nativeChatSessionKey('native-x') },
     } as unknown as Parameters<typeof chatHistoryDELETE>[0]

--- a/apps/web/server/lib/agentSource/__tests__/clawbooNativeAgentSource.test.ts
+++ b/apps/web/server/lib/agentSource/__tests__/clawbooNativeAgentSource.test.ts
@@ -11,9 +11,9 @@ import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { eq } from 'drizzle-orm'
 
-import { agents, createDb, getBudget, getSetting, type ClawbooDb } from '@clawboo/db'
+import { agents, getBudget, getSetting, type ClawbooDb } from '@clawboo/db'
 
-import { getDb, getDbPath, resetDb } from '../../db'
+import { getDb, resetDb } from '../../db'
 import {
   loadAgentConfig,
   nativeConfigKey,
@@ -35,9 +35,12 @@ describe('ClawbooNativeAgentSource (AgentSource contract + native specifics)', (
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     source = new ClawbooNativeAgentSource({ getDb })
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     // Drop the process-wide memo and this fixture's own handle before the
     // sandbox is removed — otherwise each test leaves a live SQLite handle
     // behind (and Windows refuses to rm a dir that still holds an open file).

--- a/apps/web/server/lib/agentSource/__tests__/openClawAgentSource.test.ts
+++ b/apps/web/server/lib/agentSource/__tests__/openClawAgentSource.test.ts
@@ -8,12 +8,12 @@ import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { agents, createDb, teams } from '@clawboo/db'
+import { agents, teams } from '@clawboo/db'
 import { GatewayResponseError } from '@clawboo/gateway-client'
 import { eq } from 'drizzle-orm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getDb, getDbPath, resetDb } from '../../db'
+import { getDb, resetDb } from '../../db'
 import {
   OpenClawAgentSource,
   type AgentListEntryLike,
@@ -129,6 +129,9 @@ describe('OpenClawAgentSource', () => {
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     // Drop the process-wide memo and this fixture's own handle before the
     // sandbox is removed — otherwise each test leaves a live SQLite handle
     // behind (and Windows refuses to rm a dir that still holds an open file).
@@ -171,7 +174,7 @@ describe('OpenClawAgentSource', () => {
 
     // Simulate clawboo-native edits (team assignment + personality) made by other
     // code paths AFTER the first sync.
-    const db = createDb(getDbPath())
+    const db = getDb()
     const now = Date.now()
     db.insert(teams)
       .values({
@@ -258,7 +261,7 @@ describe('OpenClawAgentSource', () => {
 
     // Seed the team the agent will join (agents.team_id has a real FK to teams).
     const now = Date.now()
-    createDb(getDbPath())
+    getDb()
       .insert(teams)
       .values({
         id: 'team-3',

--- a/apps/web/server/lib/agentSource/__tests__/runtimeAgentSource.test.ts
+++ b/apps/web/server/lib/agentSource/__tests__/runtimeAgentSource.test.ts
@@ -9,9 +9,9 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { createDb, getSetting, type ClawbooDb } from '@clawboo/db'
+import { getSetting, type ClawbooDb } from '@clawboo/db'
 
-import { getDb, getDbPath, resetDb } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { runtimeAgentFileKey } from '../runtimeAgentFileStore'
 import { RuntimeAgentSource } from '../runtimeAgentSource'
 
@@ -30,9 +30,12 @@ describe('RuntimeAgentSource (generic coding-runtime record source)', () => {
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
     source = new RuntimeAgentSource({ getDb, runtimeId: 'claude-code' })
     other = new RuntimeAgentSource({ getDb, runtimeId: 'hermes' })
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     // Drop the process-wide memo and this fixture's own handle before the
     // sandbox is removed — otherwise each test leaves a live SQLite handle
     // behind (and Windows refuses to rm a dir that still holds an open file).

--- a/apps/web/server/lib/capabilitySource/__tests__/adapters.test.ts
+++ b/apps/web/server/lib/capabilitySource/__tests__/adapters.test.ts
@@ -14,7 +14,6 @@ import {
 } from '@clawboo/db'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { resetDb } from '../../db'
 import { recordToInsert } from '../mapper'
 import { NativeCapabilitySource } from '../native'
 import { HermesCapabilitySource } from '../hermes'
@@ -32,10 +31,11 @@ beforeEach(() => {
   db = createDb(dbPath)
 })
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory that
-  // still holds an open file. The suite never opens the handle itself, the
-  // server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/capabilitySource/__tests__/adapters.test.ts
+++ b/apps/web/server/lib/capabilitySource/__tests__/adapters.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@clawboo/db'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { resetDb } from '../../db'
 import { recordToInsert } from '../mapper'
 import { NativeCapabilitySource } from '../native'
 import { HermesCapabilitySource } from '../hermes'
@@ -30,7 +31,13 @@ beforeEach(() => {
   dbPath = path.join(dir, 'test.db')
   db = createDb(dbPath)
 })
-afterEach(() => rmSync(dir, { recursive: true, force: true }))
+afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory that
+  // still holds an open file. The suite never opens the handle itself, the
+  // server code under test does. (#140)
+  resetDb()
+  rmSync(dir, { recursive: true, force: true })
+})
 
 function seedAgent(id: string, runtime: string, sourceId = 'openclaw'): void {
   const now = Date.now()

--- a/apps/web/server/lib/routines/__tests__/openclawDispatch.test.ts
+++ b/apps/web/server/lib/routines/__tests__/openclawDispatch.test.ts
@@ -33,7 +33,6 @@ import { createAsyncQueue } from '@clawboo/executor'
 import type { TaskTemplate } from '@clawboo/scheduler'
 
 import { dispatchConnectedSubstrate, type OperatorClientLike } from '../openclawDispatch'
-import { resetDb } from '../../db'
 
 // ── Local clone of the adapter package's unpublished FakeGatewayClient ──────
 class FakeOperatorClient {
@@ -137,10 +136,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory
-  // that still holds an open file. The suite never opens the handle itself,
-  // the server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/routines/__tests__/openclawDispatch.test.ts
+++ b/apps/web/server/lib/routines/__tests__/openclawDispatch.test.ts
@@ -33,6 +33,7 @@ import { createAsyncQueue } from '@clawboo/executor'
 import type { TaskTemplate } from '@clawboo/scheduler'
 
 import { dispatchConnectedSubstrate, type OperatorClientLike } from '../openclawDispatch'
+import { resetDb } from '../../db'
 
 // ── Local clone of the adapter package's unpublished FakeGatewayClient ──────
 class FakeOperatorClient {
@@ -136,6 +137,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory
+  // that still holds an open file. The suite never opens the handle itself,
+  // the server code under test does. (#140)
+  resetDb()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/routines/__tests__/routinesGovernance.test.ts
+++ b/apps/web/server/lib/routines/__tests__/routinesGovernance.test.ts
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   agents,
-  createDb,
   getBudget,
   getScheduledRun,
   listEvents,
@@ -30,7 +29,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { runTaskOnRuntime } from '../../executorRunner'
 import { createRoutinesTicker } from '../ticker'
 import { dispatchRoutine } from '../wakeBridge'
@@ -95,7 +94,7 @@ describe('routines × governance (real ledger + real executor runner)', () => {
     prevHome = process.env['HOME']
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
-    db = createDb(getDbPath())
+    db = getDb()
     const now = Date.now()
     db.insert(agents)
       .values({
@@ -110,6 +109,9 @@ describe('routines × governance (real ledger + real executor runner)', () => {
   })
 
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']

--- a/apps/web/server/lib/routines/__tests__/ticker.test.ts
+++ b/apps/web/server/lib/routines/__tests__/ticker.test.ts
@@ -24,6 +24,7 @@ import {
 } from '@clawboo/db'
 
 import { createRoutinesTicker, type RoutinesTickerDeps } from '../ticker'
+import { resetDb } from '../../db'
 
 let dir: string
 let db: ClawbooDb
@@ -60,6 +61,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory
+  // that still holds an open file. The suite never opens the handle itself,
+  // the server code under test does. (#140)
+  resetDb()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/routines/__tests__/ticker.test.ts
+++ b/apps/web/server/lib/routines/__tests__/ticker.test.ts
@@ -24,7 +24,6 @@ import {
 } from '@clawboo/db'
 
 import { createRoutinesTicker, type RoutinesTickerDeps } from '../ticker'
-import { resetDb } from '../../db'
 
 let dir: string
 let db: ClawbooDb
@@ -61,10 +60,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory
-  // that still holds an open file. The suite never opens the handle itself,
-  // the server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/routines/__tests__/wakeBridge.test.ts
+++ b/apps/web/server/lib/routines/__tests__/wakeBridge.test.ts
@@ -27,6 +27,7 @@ import { NotImplementedError } from '@clawboo/scheduler'
 import type { runTaskOnRuntime } from '../../executorRunner'
 import { dispatchRoutine } from '../wakeBridge'
 import type { dispatchConnectedSubstrate } from '../openclawDispatch'
+import { resetDb } from '../../db'
 
 type RunTaskInput = Parameters<typeof runTaskOnRuntime>[0]
 
@@ -74,6 +75,10 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // Close BEFORE removing the dir: Windows refuses to remove a directory
+  // that still holds an open file. The suite never opens the handle itself,
+  // the server code under test does. (#140)
+  resetDb()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/routines/__tests__/wakeBridge.test.ts
+++ b/apps/web/server/lib/routines/__tests__/wakeBridge.test.ts
@@ -27,7 +27,6 @@ import { NotImplementedError } from '@clawboo/scheduler'
 import type { runTaskOnRuntime } from '../../executorRunner'
 import { dispatchRoutine } from '../wakeBridge'
 import type { dispatchConnectedSubstrate } from '../openclawDispatch'
-import { resetDb } from '../../db'
 
 type RunTaskInput = Parameters<typeof runTaskOnRuntime>[0]
 
@@ -75,10 +74,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  // Close BEFORE removing the dir: Windows refuses to remove a directory
-  // that still holds an open file. The suite never opens the handle itself,
-  // the server code under test does. (#140)
-  resetDb()
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/hermesDriver.test.ts
@@ -86,7 +86,14 @@ describe('hermes driver (preserved runtime)', () => {
     const first = await provisionHermesHome(identityHome())
     expect(first.created).toBe(true)
     const st = await stat(first.home)
-    expect(st.mode & 0o777).toBe(0o700)
+    // The home is materialized on every platform; only the 0700 hardening is
+    // POSIX-only. Windows has no mode bits (the chmod is a no-op there and the
+    // stat reports 0666), and the source applies no ACL equivalent yet, so
+    // asserting 0700 there would assert something untrue rather than untested.
+    expect(st.isDirectory()).toBe(true)
+    if (process.platform !== 'win32') {
+      expect(st.mode & 0o777).toBe(0o700)
+    }
 
     const second = await provisionHermesHome(identityHome())
     expect(second.home).toBe(first.home)

--- a/apps/web/server/lib/runtimes/native/__tests__/conversation.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/conversation.test.ts
@@ -21,7 +21,6 @@ import { isContextOverflowMessage } from '../providers/types'
 import type { NeutralMessage, ProviderStreamEvent, ProviderTurnParams } from '../providers/types'
 import type { RoutedProviderClient } from '../routeCall'
 import { loadSessionTranscript } from '../sessionStore'
-import { resetDb } from '../../../db'
 
 const OPTS: StartOpts = {
   agentId: 'native-conv-1',
@@ -94,10 +93,11 @@ describe('Conversation turn loop', () => {
     events = []
   })
   afterEach(async () => {
-    // Close BEFORE removing the dir: Windows refuses to remove a directory
-    // that still holds an open file. The suite never opens the handle itself,
-    // the server code under test does. (#140)
-    resetDb()
+    // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+    // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+    // remove a directory that still holds an open file, so close it before the
+    // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+    db.$client.close()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/runtimes/native/__tests__/conversation.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/conversation.test.ts
@@ -21,6 +21,7 @@ import { isContextOverflowMessage } from '../providers/types'
 import type { NeutralMessage, ProviderStreamEvent, ProviderTurnParams } from '../providers/types'
 import type { RoutedProviderClient } from '../routeCall'
 import { loadSessionTranscript } from '../sessionStore'
+import { resetDb } from '../../../db'
 
 const OPTS: StartOpts = {
   agentId: 'native-conv-1',
@@ -93,6 +94,10 @@ describe('Conversation turn loop', () => {
     events = []
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. The suite never opens the handle itself,
+    // the server code under test does. (#140)
+    resetDb()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/runtimes/native/__tests__/nativeDriver.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/nativeDriver.test.ts
@@ -19,6 +19,7 @@ import type { RuntimeRunContext } from '../../types'
 import { createNativeDriver } from '../nativeDriver'
 import type { ProviderStreamEvent } from '../providers/types'
 import type { RoutedProviderClient } from '../routeCall'
+import { resetDb } from '../../../db'
 
 /** A scripted text-only provider client: one turn that emits `text` then usage. */
 function textClient(text: string): RoutedProviderClient {
@@ -48,6 +49,10 @@ describe('native driver — :native chat write de-double for team runs', () => {
     db = createDb(path.join(sandbox, 'test.db'))
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. The suite never opens the handle itself,
+    // the server code under test does. (#140)
+    resetDb()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/runtimes/native/__tests__/nativeDriver.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/nativeDriver.test.ts
@@ -19,7 +19,6 @@ import type { RuntimeRunContext } from '../../types'
 import { createNativeDriver } from '../nativeDriver'
 import type { ProviderStreamEvent } from '../providers/types'
 import type { RoutedProviderClient } from '../routeCall'
-import { resetDb } from '../../../db'
 
 /** A scripted text-only provider client: one turn that emits `text` then usage. */
 function textClient(text: string): RoutedProviderClient {
@@ -49,10 +48,11 @@ describe('native driver — :native chat write de-double for team runs', () => {
     db = createDb(path.join(sandbox, 'test.db'))
   })
   afterEach(async () => {
-    // Close BEFORE removing the dir: Windows refuses to remove a directory
-    // that still holds an open file. The suite never opens the handle itself,
-    // the server code under test does. (#140)
-    resetDb()
+    // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+    // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+    // remove a directory that still holds an open file, so close it before the
+    // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+    db.$client.close()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/runtimes/native/__tests__/stores.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/stores.test.ts
@@ -19,6 +19,7 @@ import {
   writeNativeAgentFile,
 } from '../agentConfigStore'
 import { priceTurn } from '../pricing'
+import { resetDb } from '../../../db'
 import {
   loadSessionTranscript,
   saveSessionTranscript,
@@ -34,6 +35,10 @@ describe('native stores', () => {
     db = createDb(path.join(sandbox, 'test.db'))
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. The suite never opens the handle itself,
+    // the server code under test does. (#140)
+    resetDb()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/runtimes/native/__tests__/stores.test.ts
+++ b/apps/web/server/lib/runtimes/native/__tests__/stores.test.ts
@@ -19,7 +19,6 @@ import {
   writeNativeAgentFile,
 } from '../agentConfigStore'
 import { priceTurn } from '../pricing'
-import { resetDb } from '../../../db'
 import {
   loadSessionTranscript,
   saveSessionTranscript,
@@ -35,10 +34,11 @@ describe('native stores', () => {
     db = createDb(path.join(sandbox, 'test.db'))
   })
   afterEach(async () => {
-    // Close BEFORE removing the dir: Windows refuses to remove a directory
-    // that still holds an open file. The suite never opens the handle itself,
-    // the server code under test does. (#140)
-    resetDb()
+    // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+    // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+    // remove a directory that still holds an open file, so close it before the
+    // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+    db.$client.close()
     await rm(sandbox, { recursive: true, force: true })
   })
 

--- a/apps/web/server/lib/scheduleSource/__tests__/clawbooRoutineScheduleSource.test.ts
+++ b/apps/web/server/lib/scheduleSource/__tests__/clawbooRoutineScheduleSource.test.ts
@@ -51,6 +51,11 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  // This suite OWNS its connection (createDb at a fixture path), so resetDb()
+  // cannot reach it: that only evicts the getDb() memo. Windows refuses to
+  // remove a directory that still holds an open file, so close it before the
+  // rm. Mirrors the ownership rule in lib/db.ts. (#140)
+  db.$client.close()
   rmSync(dir, { recursive: true, force: true })
 })
 

--- a/apps/web/server/lib/teamChat/__tests__/booZero.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/booZero.test.ts
@@ -11,10 +11,10 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { agents, createDb, getSetting, setSetting, teams, type ClawbooDb } from '@clawboo/db'
+import { agents, getSetting, setSetting, teams, type ClawbooDb } from '@clawboo/db'
 
 import { SETTING_DEFAULT_ID } from '../../agentSource/openClawAgentSource'
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import {
   booZeroForTeam,
   ensureNativeBooZero,
@@ -50,10 +50,13 @@ describe('booZero', () => {
       savedKeys[v] = process.env[v]
       delete process.env[v]
     }
-    db = createDb(getDbPath())
+    db = getDb()
     created = 0
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     for (const v of NATIVE_KEY_VARS) {

--- a/apps/web/server/lib/teamChat/__tests__/codexLeaderCascade.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/codexLeaderCascade.test.ts
@@ -27,7 +27,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   agents,
-  createDb,
   getComments,
   getSetting,
   listTasks,
@@ -52,7 +51,7 @@ import {
   type BoardOrchestrator,
 } from '@clawboo/team-orchestration'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { booZeroForTeam } from '../booZero'
 import { nativeTeamSessionSettingKey } from '../nativeTeamSession'
 import { createServerBoardClient } from '../serverBoardClient'
@@ -156,7 +155,7 @@ describe('Codex-led cascade (delegate MCP tool → board → report-up → synth
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-codex-lead-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
     const now = Date.now()
     db.insert(teams)
       .values({
@@ -195,6 +194,9 @@ describe('Codex-led cascade (delegate MCP tool → board → report-up → synth
       .run()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     vi.useRealTimers()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome

--- a/apps/web/server/lib/teamChat/__tests__/contextPreamble.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/contextPreamble.test.ts
@@ -15,9 +15,9 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { agents, createDb, setSetting, teams, type ClawbooDb } from '@clawboo/db'
+import { agents, setSetting, teams, type ClawbooDb } from '@clawboo/db'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { buildServerTeamContext } from '../contextPreamble'
 
 const LEADER_BLOCK = '[Leading this team' // shared framing (native AND coding leaders)
@@ -35,7 +35,7 @@ describe('buildServerTeamContext coordination blocks', () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-ctx-home-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
     const now = Date.now()
     db.insert(teams)
       .values({
@@ -96,6 +96,9 @@ describe('buildServerTeamContext coordination blocks', () => {
     )
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })

--- a/apps/web/server/lib/teamChat/__tests__/delegationApproval.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/delegationApproval.test.ts
@@ -13,16 +13,10 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  createApproval,
-  createDb,
-  listPendingApprovals,
-  resolveApproval,
-  type ClawbooDb,
-} from '@clawboo/db'
+import { createApproval, listPendingApprovals, resolveApproval, type ClawbooDb } from '@clawboo/db'
 
 import { resolveDelegationApproval } from '../../../api/delegationApproval'
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { isRiskyDelegation, RISKY_DELEGATION_RE } from '../riskyDelegation'
 
 describe('isRiskyDelegation', () => {
@@ -70,9 +64,12 @@ describe('resolveDelegationApproval', () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-delegapproval-home-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
@@ -107,7 +104,7 @@ describe('resolveDelegationApproval', () => {
   })
 
   it('is FAIL-CLOSED: a transport error resolves to timeout (never auto-run)', async () => {
-    const broken = createDb(getDbPath())
+    const broken = getDb()
     broken.$client.close() // any subsequent query throws
     const resolution = await resolveDelegationApproval(broken, {
       leaderAgentId: 'L',

--- a/apps/web/server/lib/teamChat/__tests__/persistTeamChatEntry.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/persistTeamChatEntry.test.ts
@@ -10,12 +10,12 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { chatMessages, createDb, type ClawbooDb } from '@clawboo/db'
+import { chatMessages, type ClawbooDb } from '@clawboo/db'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { buildTeamSessionKey } from '@clawboo/team-orchestration'
 import { eq } from 'drizzle-orm'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { persistTeamChatEntry } from '../persistTeamChatEntry'
 
 const TEAM = 'team-1'
@@ -29,9 +29,12 @@ describe('persistTeamChatEntry (the single team-chat writer)', () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-persist-home-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })

--- a/apps/web/server/lib/teamChat/__tests__/resolveServerOrchestrated.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/resolveServerOrchestrated.test.ts
@@ -8,9 +8,9 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { agents, createDb, setSetting, teams, type ClawbooDb } from '@clawboo/db'
+import { agents, setSetting, teams, type ClawbooDb } from '@clawboo/db'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import {
   resolveServerOrchestrated,
   serverOrchestratedSettingKey,
@@ -27,9 +27,12 @@ describe('resolveServerOrchestrated', () => {
     prevHome = process.env['HOME']
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']

--- a/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
@@ -10,16 +10,9 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import {
-  createDb,
-  getComments,
-  getTask,
-  listEvents,
-  listExecutions,
-  type ClawbooDb,
-} from '@clawboo/db'
+import { getComments, getTask, listEvents, listExecutions, type ClawbooDb } from '@clawboo/db'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { createServerBoardClient } from '../serverBoardClient'
 
 const TEAM = 'team-sbc'
@@ -33,9 +26,12 @@ describe('serverBoardClient (direct-DB BoardClient over the board repo)', () => 
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-sbc-home-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home // → getDbPath() lands in the sandbox
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })

--- a/apps/web/server/lib/teamChat/__tests__/serverDeliver.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/serverDeliver.test.ts
@@ -15,7 +15,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import {
   agents,
-  createDb,
   getBudget,
   listEvents,
   setBudgetLimit,
@@ -33,7 +32,7 @@ import type {
 } from '@clawboo/executor'
 import { createNudgeQueue, type NudgeQueue } from '@clawboo/team-orchestration'
 
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { createServerDeliver, type RunEntry } from '../serverDeliver'
 
 const CAPS: Capabilities = {
@@ -107,9 +106,12 @@ describe('serverDeliver (adapter run + event drain — NOT runTaskOnRuntime)', (
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-deliver-home-'))
     prevHome = process.env['HOME']
     process.env['HOME'] = home
-    db = createDb(getDbPath())
+    db = getDb()
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })

--- a/apps/web/server/lib/teamChat/__tests__/teamActivitySummary.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/teamActivitySummary.test.ts
@@ -13,7 +13,6 @@ import {
   agents,
   booZeroTeamBriefs,
   chatMessages,
-  createDb,
   createTask,
   SqliteMemoryStore,
   teams,
@@ -23,7 +22,7 @@ import { buildTeamSessionKey } from '@clawboo/team-orchestration'
 import type { Request, Response } from 'express'
 
 import { teamActivitySummaryGET } from '../../../api/teamActivity'
-import { getDbPath } from '../../db'
+import { getDb, resetDb } from '../../db'
 import { buildTeamActivitySummary } from '../teamActivitySummary'
 
 const TEAM = 'team-1'
@@ -40,10 +39,13 @@ describe('buildTeamActivitySummary', () => {
     prevHome = process.env['HOME']
     process.env['HOME'] = home
     process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
-    db = createDb(getDbPath())
+    db = getDb()
     seq = 0
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     delete process.env['CLAWBOO_HOME']

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
           include: ['src/**/*.test.ts', 'server/**/*.test.ts'],
           environment: 'node',
           globals: true,
+          // Makes `$HOME` authoritative for `os.homedir()` on every platform, so the
+          // suites that sandbox `process.env.HOME` actually land in their temp dir on
+          // Windows too (Node reads %USERPROFILE% there). A no-op on POSIX. See the
+          // file's header for why this is one seam rather than an env var per suite.
+          setupFiles: ['./server/__vitest__/setupHomedir.ts'],
           // The server suite has real-git + real-sqlite integration tests that run
           // a few seconds each in isolation. When the jsdom project's heavier
           // component transforms run concurrently in the same `vitest run`, those


### PR DESCRIPTION
## Summary

* Fixes cross-platform test sandboxing so the `apps/web/server` test suite runs reliably on both Windows and POSIX environments.
* Unifies database lifecycle management by reusing the shared `getDb()`/`resetDb()` seams, eliminating leaked SQLite handles and Windows file-lock failures during teardown.
* Expands CI coverage to execute the full server test suite on Windows, replacing the previous platform-specific subset.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [x] Test

## Changeset

* [ ] Added changeset (not needed — test infrastructure and CI improvements)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff

Closes #140


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded server test coverage to run consistently across Windows and macOS.
  * Improved test isolation and cleanup to prevent temporary-file and database-lock failures.
  * Standardized sandbox home-directory behavior across supported platforms.
  * Preserved validation for APIs, agent workflows, governance, observability, budgets, routing, and task execution.
  * Added platform-appropriate handling for CLI login and filesystem permission checks.

* **Chores**
  * Improved CI reliability and cross-platform test consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->