### PR TITLE
fix(obs): read the most recent event window on the dashboards

### DIFF
--- a/apps/web/server/api/__tests__/board.obs.test.ts
+++ b/apps/web/server/api/__tests__/board.obs.test.ts
@@ -137,4 +137,17 @@ describe('board REST → observability emits', () => {
     expect(bodies.some((b) => /report up/.test(b))).toBe(true)
     expect(bodies.some((b) => /depends on/.test(b))).toBe(true)
   })
+
+  it('PATCH executions/:execId with an unknown id → 404, and appends no event', () => {
+    const res = mockRes()
+    // `execId` is a raw path param, so an unknown one reaches the handler. It
+    // closes nothing, so reporting success would be a lie, and appending a
+    // completion would strand an uncorrelated lifecycle event in the log.
+    boardExecutionCompletePATCH(
+      req({ status: 'succeeded', costUsd: 0.01 }, { execId: 'no-such-exec' }),
+      res.res,
+    )
+    expect(res.statusCode()).toBe(404)
+    expect(kindsInLog().filter((k) => k === 'execution_completed')).toHaveLength(0)
+  })
 })

--- a/apps/web/server/api/__tests__/obs.test.ts
+++ b/apps/web/server/api/__tests__/obs.test.ts
@@ -328,6 +328,23 @@ describe('observability REST', () => {
     expect(s.writes()).not.toContain('data:')
   })
 
+  it('GET /api/obs/events clamps limit (a negative one must not drain the table)', () => {
+    seed()
+    const res = mockRes()
+    // SQLite reads a NEGATIVE limit as UNBOUNDED, so forwarding this raw let one
+    // request pull every row of a never-pruned table on the synchronous
+    // connection that also serves the event loop.
+    obsEventsGET(req({ limit: '-1' }), res.res)
+    expect(res.statusCode()).toBe(200)
+    const body = res.body() as { events: unknown[] }
+    expect(body.events.length).toBeGreaterThan(0)
+    expect(body.events.length).toBeLessThanOrEqual(DASHBOARD_EVENT_WINDOW)
+
+    const capped = mockRes()
+    obsEventsGET(req({ limit: '2' }), capped.res)
+    expect((capped.body() as { events: unknown[] }).events).toHaveLength(2)
+  })
+
   // ── The dashboard read window ─────────────────────────────────────────────
   // Both dashboards fold a WINDOW of an append-only, never-pruned log. Two
   // independent things have to hold, so they get independent tests:

--- a/apps/web/server/api/__tests__/obs.test.ts
+++ b/apps/web/server/api/__tests__/obs.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { getDb, resetDb } from '../../lib/db'
 import {
+  DASHBOARD_EVENT_WINDOW,
   obsErrorsGET,
   obsEventsGET,
   obsGraphGET,
@@ -170,12 +171,19 @@ function seed(): void {
 describe('observability REST', () => {
   let home: string
   let prevHome: string | undefined
+  let prevClawbooHome: string | undefined
 
   beforeEach(async () => {
     home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-obs-rest-'))
     await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
+    await mkdir(path.join(home, '.clawboo'), { recursive: true })
     prevHome = process.env['HOME']
+    // `resolveClawbooDir` reads CLAWBOO_HOME BEFORE falling back to $HOME, so
+    // sandboxing $HOME alone leaves the suite writing into a developer's real
+    // database whenever that supported override happens to be exported.
+    prevClawbooHome = process.env['CLAWBOO_HOME']
     process.env['HOME'] = home
+    process.env['CLAWBOO_HOME'] = path.join(home, '.clawboo')
   })
   afterEach(async () => {
     // Close BEFORE removing the dir: Windows refuses to remove a directory
@@ -183,6 +191,8 @@ describe('observability REST', () => {
     resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
+    if (prevClawbooHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevClawbooHome
     await rm(home, { recursive: true, force: true }).catch(() => {})
   })
 
@@ -316,6 +326,157 @@ describe('observability REST', () => {
     obsStreamGET(s.req, s.res)
     s.close()
     expect(s.writes()).not.toContain('data:')
+  })
+
+  // ── The dashboard read window ─────────────────────────────────────────────
+  // Both dashboards fold a WINDOW of an append-only, never-pruned log. Two
+  // independent things have to hold, so they get independent tests:
+  //   • the window is the NEWEST rows (an ASC `limit` silently pins both views
+  //     to the oldest N events forever, the bug these guard against), and
+  //   • the window is folded CHRONOLOGICALLY (the reducers are order-sensitive,
+  //     so the descending read has to be reversed before projecting).
+  describe('dashboard read window', () => {
+    /** Fill the window with old events so a later one falls outside an ASC read. */
+    function seedFiller(count: number, teamId: string): void {
+      const db = getDb()
+      for (let i = 0; i < count; i += 1) {
+        appendEvent(db, {
+          kind: 'tool_call',
+          teamId,
+          taskId: 'ancient-task',
+          agentId: 'ancient-agent',
+          data: { toolCallId: `tc-${i}`, name: 'noop' },
+        })
+      }
+    }
+
+    it('GET /api/obs/health reflects activity past the window (never freezes)', () => {
+      // Oldest: far enough back that the newest-N window must evict it.
+      appendEvent(getDb(), {
+        kind: 'execution_started',
+        teamId: 'teamW',
+        taskId: 'ancient-task',
+        agentId: 'evicted-agent',
+        data: { execId: 'x-ancient' },
+      })
+      seedFiller(DASHBOARD_EVENT_WINDOW, 'teamW')
+      // Newest: fresh activity arriving AFTER the window is already full. An ASC
+      // read cannot see it, so fleet health would report the fleet as it was.
+      appendEvent(getDb(), {
+        kind: 'execution_started',
+        teamId: 'teamW',
+        taskId: 'fresh-task',
+        agentId: 'fresh-agent',
+        ts: Date.now(),
+        data: { execId: 'x-fresh' },
+      })
+
+      const res = mockRes()
+      obsHealthGET(req({ teamId: 'teamW' }), res.res)
+      const body = res.body() as { agents: { agentId: string; status: string }[] }
+      const ids = body.agents.map((a) => a.agentId)
+      expect(ids, 'the newest agent must fall inside the window').toContain('fresh-agent')
+      // Pins the FAR edge too. Without this the assertions above hold for any
+      // limit >= 2, so DASHBOARD_EVENT_WINDOW would not actually be constrained.
+      expect(ids, 'an agent older than the window must be evicted').not.toContain('evicted-agent')
+      expect(body.agents.find((a) => a.agentId === 'fresh-agent')!.status).toBe('working')
+    })
+
+    it('GET /api/obs/graph reflects tasks created past the window (never freezes)', () => {
+      seedFiller(DASHBOARD_EVENT_WINDOW, 'teamW')
+      const db = getDb()
+      appendEvent(db, {
+        kind: 'task_created',
+        teamId: 'teamW',
+        taskId: 'fresh-task',
+        data: { title: 'fresh', status: 'todo' },
+      })
+      appendEvent(db, {
+        kind: 'task_claimed',
+        teamId: 'teamW',
+        taskId: 'fresh-task',
+        agentId: 'fresh-agent',
+        data: { assigneeAgentId: 'fresh-agent' },
+      })
+
+      const res = mockRes()
+      obsGraphGET(req({ teamId: 'teamW' }), res.res)
+      const g = res.body() as { tasks: { id: string; title: string | null; status: string }[] }
+      const fresh = g.tasks.find((t) => t.id === 'fresh-task')
+      expect(fresh, 'the newest task must fall inside the window').toBeTruthy()
+      expect(fresh!.title).toBe('fresh')
+      expect(fresh!.status).toBe('in_progress')
+    })
+
+    it('GET /api/obs/graph folds chronologically and stays scoped to the team', () => {
+      const db = getDb()
+      // A task on ANOTHER team must never leak in. Without this, dropping the
+      // teamId filter from the shared helper would pass every other test here,
+      // because each one seeds a single team.
+      appendEvent(db, {
+        kind: 'task_created',
+        teamId: 'teamOther',
+        taskId: 'foreign',
+        data: { title: 'foreign', status: 'todo' },
+      })
+      appendEvent(db, {
+        kind: 'task_created',
+        teamId: 'teamO',
+        taskId: 't1',
+        data: { title: 'ordered', status: 'todo' },
+      })
+      appendEvent(db, {
+        kind: 'task_claimed',
+        teamId: 'teamO',
+        taskId: 't1',
+        agentId: 'a1',
+        data: { assigneeAgentId: 'a1' },
+      })
+      appendEvent(db, {
+        kind: 'status_changed',
+        teamId: 'teamO',
+        taskId: 't1',
+        data: { from: 'in_progress', to: 'done' },
+      })
+
+      const res = mockRes()
+      obsGraphGET(req({ teamId: 'teamO' }), res.res)
+      const g = res.body() as { tasks: { id: string; status: string }[] }
+      expect(
+        g.tasks.map((t) => t.id),
+        'another team must not leak in',
+      ).not.toContain('foreign')
+      // Status is last-write-wins, so the fold direction is directly observable:
+      // chronological ends at `done`; a newest-first fold would end at `todo`
+      // (the earliest event applied last).
+      expect(g.tasks.find((t) => t.id === 't1')!.status).toBe('done')
+    })
+
+    it('GET /api/obs/health pairs execution start/complete in chronological order', () => {
+      const db = getDb()
+      appendEvent(db, {
+        kind: 'execution_started',
+        teamId: 'teamO',
+        taskId: 't1',
+        agentId: 'a1',
+        data: { execId: 'x1' },
+      })
+      appendEvent(db, {
+        kind: 'execution_completed',
+        teamId: 'teamO',
+        taskId: 't1',
+        agentId: 'a1',
+        data: { execId: 'x1', status: 'succeeded' },
+      })
+
+      const res = mockRes()
+      obsHealthGET(req({ teamId: 'teamO' }), res.res)
+      const body = res.body() as { agents: { agentId: string; status: string }[] }
+      // The execution closed, so the agent is idle. Folded newest-first the
+      // completion would be seen first (clamped to 0) and the start would leave
+      // the counter open, reporting a finished agent as still `working`.
+      expect(body.agents.find((a) => a.agentId === 'a1')!.status).toBe('idle')
+    })
   })
 })
 

--- a/apps/web/server/api/__tests__/obs.test.ts
+++ b/apps/web/server/api/__tests__/obs.test.ts
@@ -328,6 +328,61 @@ describe('observability REST', () => {
     expect(s.writes()).not.toContain('data:')
   })
 
+  it('POST /api/obs/ingest clamps a forged ts (it must not mask a zombie)', () => {
+    const res = mockRes()
+    const far = Date.now() + 10 * 365 * 24 * 60 * 60_000 // a decade ahead
+    const r = {
+      query: {},
+      params: {},
+      body: { events: [{ kind: 'tool_call', taskId: 'sub', agentId: 'a2', ts: far, data: {} }] },
+    } as unknown as Request
+    obsIngestPOST(r, res.res)
+    expect((res.body() as { count: number }).count).toBe(1)
+
+    // Stored at server time, not the forged one. projectFleetHealth derives
+    // staleness from `now - lastEventTs` (a MAX over the window), so a future ts
+    // makes `quiet` negative and pins an agent at `working` forever.
+    const stored = listEvents(getDb(), { taskId: 'sub' })
+    expect(stored).toHaveLength(1)
+    expect(stored[0]!.ts).toBeLessThanOrEqual(Date.now() + 60_000)
+
+    // A plausible recent ts is still honoured (a mirror reports what it saw).
+    const recent = Date.now() - 5_000
+    const res2 = mockRes()
+    obsIngestPOST(
+      {
+        query: {},
+        params: {},
+        body: {
+          events: [{ kind: 'tool_call', taskId: 'ok', agentId: 'a2', ts: recent, data: {} }],
+        },
+      } as unknown as Request,
+      res2.res,
+    )
+    expect(listEvents(getDb(), { taskId: 'ok' })[0]!.ts).toBe(recent)
+  })
+
+  it('GET /api/obs/errors orders by ts (index-backed) and still reads newest-first', () => {
+    const db = getDb()
+    for (const [taskId, ts] of [
+      ['old', 1_000],
+      ['newest', 9_000],
+      ['mid', 5_000],
+    ] as const) {
+      appendEvent(db, {
+        kind: 'error',
+        taskId,
+        agentId: 'a1',
+        ts,
+        data: { message: taskId, errorClass: 'Timeout', harnessBug: false },
+      })
+    }
+    const res = mockRes()
+    obsErrorsGET(req({}), res.res)
+    const body = res.body() as { errors: { taskId: string }[] }
+    expect(body.errors.map((e) => e.taskId)).toEqual(['newest', 'mid', 'old'])
+  })
+
   it('GET /api/obs/events clamps limit (a negative one must not drain the table)', () => {
     seed()
     const res = mockRes()

--- a/apps/web/server/api/board.ts
+++ b/apps/web/server/api/board.ts
@@ -297,13 +297,20 @@ export function boardExecutionCompletePATCH(req: Request, res: Response): void {
     // so the open-run counter never decremented and a finished agent read as a
     // permanent zombie. "Correlate by execId" was never implemented downstream.
     const exec = completeExecutionProcess(db, execId, parsed.data)
-    const task = exec ? getTask(db, exec.taskId) : null
+    // `execId` is a raw path param, so an unknown one reaches here. Nothing was
+    // closed, so answer 404 rather than reporting success, and above all do not
+    // append a completion for a run that never ended.
+    if (!exec) {
+      res.status(404).json({ error: 'execution not found' })
+      return
+    }
+    const task = getTask(db, exec.taskId)
     emitEvent(db, {
       kind: 'execution_completed',
-      taskId: exec?.taskId ?? null,
+      taskId: exec.taskId,
       teamId: task?.teamId ?? null,
       agentId: task?.assigneeAgentId ?? null,
-      runtime: exec?.executorType ?? null,
+      runtime: exec.executorType,
       data: {
         execId,
         status: parsed.data.status,

--- a/apps/web/server/api/board.ts
+++ b/apps/web/server/api/board.ts
@@ -291,12 +291,19 @@ export function boardExecutionCompletePATCH(req: Request, res: Response): void {
     }
     const db = getDb()
     const execId = (req.params['execId'] as string | undefined) ?? ''
-    completeExecutionProcess(db, execId, parsed.data)
-    // taskId/agentId aren't in scope on this REST path (only execId) — the
-    // execution_started event carries them; correlate by execId. The runner path
-    // (T5) emits a fully-correlated execution_completed.
+    // The request carries only an execId, but the closed row carries its taskId,
+    // so the correlation columns ARE recoverable here. Emitting without them
+    // stranded this event: `projectFleetHealth` skips any event with no agentId,
+    // so the open-run counter never decremented and a finished agent read as a
+    // permanent zombie. "Correlate by execId" was never implemented downstream.
+    const exec = completeExecutionProcess(db, execId, parsed.data)
+    const task = exec ? getTask(db, exec.taskId) : null
     emitEvent(db, {
       kind: 'execution_completed',
+      taskId: exec?.taskId ?? null,
+      teamId: task?.teamId ?? null,
+      agentId: task?.assigneeAgentId ?? null,
+      runtime: exec?.executorType ?? null,
       data: {
         execId,
         status: parsed.data.status,

--- a/apps/web/server/api/obs.ts
+++ b/apps/web/server/api/obs.ts
@@ -54,6 +54,52 @@ function strOrNull(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? v : null
 }
 
+// ─── The dashboard read window ───────────────────────────────────────────────
+// Fleet health and the graph projection fold a WINDOW of the log, not the whole
+// log: `orchestration_events` is append-only and nothing prunes it, so an
+// unbounded read is not an option. The window must be the most RECENT rows.
+//
+// `listEvents` defaults to `seq ASC`, the causal replay order the reducers need,
+// so a `limit` with no `order` silently selects the OLDEST N rows. That is a
+// freeze, not an error: past N events both dashboards would pin themselves to
+// the first N events the database ever recorded and never reflect current state
+// again. Read `desc` to select the recent window, then reverse it so
+// `projectFleetHealth` / `projectGraph` still fold chronologically (they are
+// order-sensitive: fed newest-first, an `execution_completed` would be seen
+// before its `execution_started` and every agent would read as `working`).
+//
+// The direction also decides which way a CUT pair can lie, and the two are not
+// symmetric. A completion always carries a higher `seq` than its start, so a
+// trailing window can only ever drop the START, which `Math.max(0, open - 1)`
+// clamps to `idle`: it can under-report a still-open execution but never invent
+// one. A leading window drops the COMPLETION instead, leaving `open` stuck at 1
+// with a stale `lastEventTs`, which is why the old read did not merely freeze,
+// it reported healthy agents as permanent zombies. A missed zombie is the safe
+// way to be wrong here, and the stuck execution behind it is still reaped by the
+// board's orphan reconciliation regardless of what this view shows.
+export const DASHBOARD_EVENT_WINDOW = 5000
+
+/**
+ * The most recent `DASHBOARD_EVENT_WINDOW` events for the requested scope, in
+ * chronological (`seq ASC`) order. Shared by both dashboard handlers so the two
+ * cannot drift apart on ordering again. Query: `teamId?`.
+ *
+ * A `since` (ms) narrowing filter is deliberately NOT offered here, unlike on
+ * `/api/obs/events`: no index leads with `ts`, so a window matching fewer rows
+ * than the limit must scan the whole never-pruned table to prove none remain,
+ * and this read sits on a synchronous 5-second poll. `teamId` rides
+ * `idx_orch_events_team_seq`, so scoping by team stays an index seek.
+ */
+function readRecentEvents(req: Request): OrchestrationEvent[] {
+  return listEvents(getDb(), {
+    teamId: strParam(req.query['teamId']),
+    order: 'desc',
+    limit: DASHBOARD_EVENT_WINDOW,
+  })
+    .reverse()
+    .map(toEvent)
+}
+
 // ─── POST /api/obs/ingest ────────────────────────────────────────────────────
 // Mirror client-observed runtime events (the OpenClaw in-browser path, which the
 // server never sees) into the durable log so the activity terminal is uniform
@@ -196,6 +242,11 @@ export function obsEventsGET(req: Request, res: Response): void {
 // ─── GET /api/obs/traces/:traceId ────────────────────────────────────────────
 // One trace = all events sharing the traceId, ordered seq ASC (causal). Renders
 // the full multi-agent task (leader → specialists → tools).
+//
+// The ASC window here is DELIBERATE. Do not "fix" it to `desc` by analogy with
+// the dashboard handlers below. A trace is a bounded tree, not a growing stream:
+// if one ever exceeded the limit, the head (root span first) is the half that
+// still reconstructs, whereas the tail would be orphan child spans with no parent.
 export function obsTraceGET(req: Request, res: Response): void {
   try {
     const traceId = (req.params['traceId'] as string | undefined) ?? ''
@@ -257,10 +308,7 @@ export function obsErrorsGET(req: Request, res: Response): void {
 // Fleet-health triage (working / idle / stalled / zombie). Query: teamId?
 export function obsHealthGET(req: Request, res: Response): void {
   try {
-    const events = listEvents(getDb(), {
-      teamId: strParam(req.query['teamId']),
-      limit: 5000,
-    }).map(toEvent)
+    const events = readRecentEvents(req)
     const health = projectFleetHealth(events, Date.now())
     res.json({ agents: [...health.entries()].map(([id, h]) => ({ agentId: id, ...h })) })
   } catch (err) {
@@ -272,11 +320,7 @@ export function obsHealthGET(req: Request, res: Response): void {
 // The event-sourced delegation/status/cost graph projection. Query: teamId?
 export function obsGraphGET(req: Request, res: Response): void {
   try {
-    const events = listEvents(getDb(), {
-      teamId: strParam(req.query['teamId']),
-      limit: 5000,
-    }).map(toEvent)
-    res.json(projectGraph(events))
+    res.json(projectGraph(readRecentEvents(req)))
   } catch (err) {
     res.status(500).json({ error: redactValue(String(err)) })
   }

--- a/apps/web/server/api/obs.ts
+++ b/apps/web/server/api/obs.ts
@@ -54,6 +54,22 @@ function strOrNull(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? v : null
 }
 
+/**
+ * Clamp a caller-supplied row cap to `[1, DASHBOARD_EVENT_WINDOW]`, or undefined
+ * to take the data layer's default. Forwarding the raw value let a single
+ * request drain a table nothing prunes: SQLite reads a NEGATIVE limit as
+ * unbounded, so `?limit=-1` returned every row (measured: 1M rows in ~2.9s) on
+ * the synchronous connection that also serves the event loop, then redacted all
+ * of them on the way out.
+ */
+function parseLimit(v: unknown): number | undefined {
+  const raw = strParam(v)
+  if (!raw) return undefined
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return undefined
+  return Math.min(Math.max(Math.trunc(n), 1), DASHBOARD_EVENT_WINDOW)
+}
+
 // ─── The dashboard read window ───────────────────────────────────────────────
 // Fleet health and the graph projection fold a WINDOW of the log, not the whole
 // log: `orchestration_events` is append-only and nothing prunes it, so an
@@ -217,7 +233,6 @@ export function obsEventsGET(req: Request, res: Response): void {
       .map((k) => k.trim())
       .filter(Boolean) as OrchestrationEventKind[] | undefined
     const sinceRaw = strParam(req.query['since'])
-    const limitRaw = strParam(req.query['limit'])
     const afterSeqRaw = strParam(req.query['afterSeq'])
     const rows = listEvents(db, {
       teamId: strParam(req.query['teamId']),
@@ -227,7 +242,7 @@ export function obsEventsGET(req: Request, res: Response): void {
       kinds: kinds && kinds.length ? kinds : undefined,
       since: sinceRaw ? Number(sinceRaw) : undefined,
       afterSeq: afterSeqRaw ? Number(afterSeqRaw) : undefined,
-      limit: limitRaw ? Number(limitRaw) : undefined,
+      limit: parseLimit(req.query['limit']),
       order: req.query['order'] === 'desc' ? 'desc' : 'asc',
     })
     // Redact-on-display: mask any credential-shaped key/value in each event's JSON

--- a/apps/web/server/api/obs.ts
+++ b/apps/web/server/api/obs.ts
@@ -125,12 +125,34 @@ function readRecentEvents(req: Request): OrchestrationEvent[] {
 // fails the batch).
 const INGEST_KINDS = new Set<OrchestrationEventKind>(['tool_call', 'tool_result', 'error'])
 const MAX_INGEST_BATCH = 200
+/** Tolerated clock skew ahead of the server for a mirrored event. */
+const INGEST_MAX_AHEAD_MS = 60_000
+/** How far back a mirrored event may be dated (a mirror is near-real-time). */
+const INGEST_MAX_BEHIND_MS = 24 * 60 * 60_000
+
+/**
+ * Accept a caller-supplied `ts` only within a sane band around server time,
+ * falling back to server `now` otherwise.
+ *
+ * `ts` is not just metadata: `projectFleetHealth` derives staleness from
+ * `now - lastEventTs`, and `lastEventTs` is a MAX over the window. A future
+ * timestamp therefore makes `quiet` negative, pinning an agent with an open
+ * execution at `working` permanently and masking a genuine `zombie`. Since this
+ * route exists to mirror what a browser observed, a timestamp far from now is
+ * wrong regardless of intent.
+ */
+function ingestTs(v: unknown, now: number): number | undefined {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return undefined
+  if (v > now + INGEST_MAX_AHEAD_MS || v < now - INGEST_MAX_BEHIND_MS) return undefined
+  return v
+}
 
 export function obsIngestPOST(req: Request, res: Response): void {
   try {
     const body = req.body as { events?: unknown } | undefined
     const raw = Array.isArray(body?.events) ? body.events : []
     const db = getDb()
+    const now = Date.now()
     let count = 0
     for (const e of raw.slice(0, MAX_INGEST_BATCH)) {
       if (!e || typeof e !== 'object') continue
@@ -139,7 +161,7 @@ export function obsIngestPOST(req: Request, res: Response): void {
       if (typeof kind !== 'string' || !INGEST_KINDS.has(kind as OrchestrationEventKind)) continue
       emitEvent(db, {
         kind: kind as OrchestrationEventKind,
-        ts: typeof ev['ts'] === 'number' ? (ev['ts'] as number) : undefined,
+        ts: ingestTs(ev['ts'], now),
         teamId: strOrNull(ev['teamId']),
         taskId: strOrNull(ev['taskId']),
         agentId: strOrNull(ev['agentId']),
@@ -282,9 +304,17 @@ export function obsTraceGET(req: Request, res: Response): void {
 export function obsErrorsGET(req: Request, res: Response): void {
   try {
     const sinceRaw = strParam(req.query['since'])
+    // Order by `ts`, not `seq`. This is a human-facing "most recent errors"
+    // feed on a 5-second poll, and `(kind, ts)` is the only index over `kind`:
+    // sorting it by `seq` cannot use that index, so SQLite pushes every error
+    // row in the table through a temp B-tree before applying the limit. The
+    // cost then grows with accumulated errors rather than with the 500 returned
+    // (measured at 100k errors: 57.3 ms sorted by seq, 0.9 ms by ts), which
+    // means the error dashboard got slowest exactly when it had most to show.
     const rows = listEvents(getDb(), {
       kinds: ['error'],
       since: sinceRaw ? Number(sinceRaw) : undefined,
+      orderBy: 'ts',
       order: 'desc',
       limit: 500,
     })

--- a/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
@@ -10,10 +10,34 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { getComments, getTask, listEvents, listExecutions, type ClawbooDb } from '@clawboo/db'
+import {
+  getComments,
+  getTask,
+  listEvents,
+  listExecutions,
+  type ClawbooDb,
+  type DbOrchestrationEvent,
+} from '@clawboo/db'
+import {
+  projectFleetHealth,
+  projectGraph,
+  type OrchestrationEvent,
+  type OrchestrationEventKind,
+} from '@clawboo/obs'
 
 import { getDb, resetDb } from '../../db'
 import { createServerBoardClient } from '../serverBoardClient'
+
+/** Rehydrate a stored row into the reducer shape (mirrors api/obs.ts `toEvent`). */
+function toObsEvent(row: DbOrchestrationEvent): OrchestrationEvent {
+  let data: Record<string, unknown> = {}
+  try {
+    data = JSON.parse(row.data) as Record<string, unknown>
+  } catch {
+    data = {}
+  }
+  return { ...row, kind: row.kind as OrchestrationEventKind, data }
+}
 
 const TEAM = 'team-sbc'
 
@@ -37,9 +61,11 @@ describe('serverBoardClient (direct-DB BoardClient over the board repo)', () => 
     await rm(home, { recursive: true, force: true })
   })
 
-  // Query ALL events (fresh sandbox DB per test). Note: like api/board.ts, the
-  // comment_added / dep_linked / execution_completed events carry no teamId, so a
-  // teamId-filtered query would miss them — the unfiltered list is the parity check.
+  // Query ALL events (fresh sandbox DB per test). `comment_added` / `dep_linked`
+  // still carry no teamId, so a teamId-filtered query would miss those and the
+  // unfiltered list stays the parity check. `execution_completed` no longer
+  // belongs on that list: it is now correlated like `execution_started`, which
+  // the two tests below pin.
   const kinds = (): string[] => listEvents(db).map((e) => e.kind)
 
   it('createTask → row + task_created obs', async () => {
@@ -74,6 +100,44 @@ describe('serverBoardClient (direct-DB BoardClient over the board repo)', () => 
     await client.completeExecution(exec!.id, { status: 'succeeded', summary: 'ok', costUsd: 0.01 })
     expect(listExecutions(db, task!.id)[0]?.status).toBe('succeeded')
     expect(kinds()).toContain('execution_completed')
+  })
+
+  it('execution_completed carries the same correlation columns as execution_started', async () => {
+    const client = createServerBoardClient(db)
+    const task = await client.createTask({ title: 't', teamId: TEAM })
+    await client.claim(task!.id, 'a1')
+    const exec = await client.createExecution(task!.id, 'clawboo-native')
+    await client.completeExecution(exec!.id, { status: 'succeeded', costUsd: 0.01 })
+
+    // The request only carries an execId, but the closed row carries its taskId,
+    // so these are recoverable. Uncorrelated, `projectFleetHealth` skips the
+    // completion (it drops any event with no agentId) and the agent reads as a
+    // permanent zombie; a teamId-scoped read drops it too, since SQL equality
+    // never matches NULL.
+    const done = listEvents(db, { kinds: ['execution_completed'] })
+    expect(done).toHaveLength(1)
+    expect(done[0]!.taskId).toBe(task!.id)
+    expect(done[0]!.teamId).toBe(TEAM)
+    expect(done[0]!.agentId).toBe('a1')
+    // The team-scoped read the dashboards actually issue must see it.
+    expect(listEvents(db, { teamId: TEAM, kinds: ['execution_completed'] })).toHaveLength(1)
+  })
+
+  it('a finished run reads idle, not a phantom zombie', async () => {
+    const client = createServerBoardClient(db)
+    const task = await client.createTask({ title: 't', teamId: TEAM })
+    await client.claim(task!.id, 'a1')
+    const exec = await client.createExecution(task!.id, 'clawboo-native')
+    await client.completeExecution(exec!.id, { status: 'succeeded', costUsd: 0.42 })
+
+    const events = listEvents(db, { teamId: TEAM }).map(toObsEvent)
+    // 31 min later: an undecremented open counter would have gone working →
+    // stalled → zombie by now, so this pins the decrement, not just the columns.
+    const health = projectFleetHealth(events, Date.now() + 31 * 60_000)
+    expect(health.get('a1')?.status).toBe('idle')
+    expect(health.get('a1')?.openExecutions).toBe(0)
+    // And the authoritative run cost lands on the task instead of being skipped.
+    expect(projectGraph(events).tasks.find((t) => t.id === task!.id)?.costUsd).toBe(0.42)
   })
 
   it('updateStatus(done) on an unverified task → true + done + status_changed; an illegal/unknown transition → false (no throw)', async () => {

--- a/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
+++ b/apps/web/server/lib/teamChat/__tests__/serverBoardClient.test.ts
@@ -123,6 +123,21 @@ describe('serverBoardClient (direct-DB BoardClient over the board repo)', () => 
     expect(listEvents(db, { teamId: TEAM, kinds: ['execution_completed'] })).toHaveLength(1)
   })
 
+  it('an unknown execId closes nothing and emits nothing', async () => {
+    const client = createServerBoardClient(db)
+    const task = await client.createTask({ title: 't', teamId: TEAM })
+    await client.claim(task!.id, 'a1')
+    await client.createExecution(task!.id, 'clawboo-native')
+
+    await client.completeExecution('no-such-exec', { status: 'succeeded' })
+
+    // A completion for a run that never ended would be uncorrelated by
+    // construction (there is no row to recover a taskId from), reintroducing the
+    // very event shape the correlation fix removes.
+    expect(listEvents(db, { kinds: ['execution_completed'] })).toHaveLength(0)
+    expect(listExecutions(db, task!.id)[0]?.status).toBe('running')
+  })
+
   it('a finished run reads idle, not a phantom zombie', async () => {
     const client = createServerBoardClient(db)
     const task = await client.createTask({ title: 't', teamId: TEAM })

--- a/apps/web/server/lib/teamChat/serverBoardClient.ts
+++ b/apps/web/server/lib/teamChat/serverBoardClient.ts
@@ -160,9 +160,23 @@ export function createServerBoardClient(db: ClawbooDb): BoardClient {
 
     async completeExecution(execId, outcome: CompleteExecutionOutcome): Promise<void> {
       try {
-        completeExecutionProcess(db, execId, outcome)
+        // Carry the same correlation columns `createExecution` puts on
+        // `execution_started`. Without them `projectFleetHealth` drops the
+        // completion (it skips any event with no `agentId`), so the open-run
+        // counter never decrements and a finished agent reads working → stalled
+        // → zombie forever; `projectGraph` likewise skips the authoritative
+        // cost on `if (!taskId)`. `teamId` matters just as much: it is the
+        // column the team-scoped dashboard read filters on, and SQL equality
+        // never matches NULL, so an uncorrelated completion is invisible to the
+        // Ghost Graph overlay even once the other two are populated.
+        const exec = completeExecutionProcess(db, execId, outcome)
+        const task = exec ? getTask(db, exec.taskId) : null
         emitEvent(db, {
           kind: 'execution_completed',
+          taskId: exec?.taskId ?? null,
+          teamId: task?.teamId ?? null,
+          agentId: task?.assigneeAgentId ?? null,
+          runtime: exec?.executorType ?? null,
           data: {
             execId,
             status: outcome.status,

--- a/apps/web/server/lib/teamChat/serverBoardClient.ts
+++ b/apps/web/server/lib/teamChat/serverBoardClient.ts
@@ -170,13 +170,17 @@ export function createServerBoardClient(db: ClawbooDb): BoardClient {
         // never matches NULL, so an uncorrelated completion is invisible to the
         // Ghost Graph overlay even once the other two are populated.
         const exec = completeExecutionProcess(db, execId, outcome)
-        const task = exec ? getTask(db, exec.taskId) : null
+        // No row matched, so nothing was closed. Emitting anyway would append
+        // exactly the uncorrelated event this block exists to prevent, for a run
+        // that never ended.
+        if (!exec) return
+        const task = getTask(db, exec.taskId)
         emitEvent(db, {
           kind: 'execution_completed',
-          taskId: exec?.taskId ?? null,
+          taskId: exec.taskId,
           teamId: task?.teamId ?? null,
           agentId: task?.assigneeAgentId ?? null,
-          runtime: exec?.executorType ?? null,
+          runtime: exec.executorType,
           data: {
             execId,
             status: outcome.status,

--- a/apps/web/src/features/obs/__tests__/ActivityTerminal.test.tsx
+++ b/apps/web/src/features/obs/__tests__/ActivityTerminal.test.tsx
@@ -90,6 +90,31 @@ describe('ActivityTerminal', () => {
     expect(screen.getByText('error')).toBeInTheDocument()
   })
 
+  it('backfills the RECENT window (order=desc) and still renders chronologically', async () => {
+    let requestedOrder: string | null = null
+    server.use(
+      http.get('/api/obs/events', ({ request }) => {
+        requestedOrder = new URL(request.url).searchParams.get('order')
+        // A desc feed: newest first, the way the server returns it.
+        return HttpResponse.json({
+          events: [
+            wire(2, 'tool_call', { name: 'newer_call', input: {} }),
+            wire(1, 'tool_call', { name: 'older_call', input: {} }),
+          ],
+        })
+      }),
+    )
+    render(<ActivityTerminal scope={{ taskId: 't1' }} />)
+    expect(await screen.findByText('older_call')).toBeInTheDocument()
+    // `asc` would backfill the FIRST N events ever recorded for this scope, on a
+    // log nothing prunes, and seed the SSE cursor from them so the tail replays
+    // the whole log forward.
+    expect(requestedOrder).toBe('desc')
+    // The hook reverses the window, so the terminal still reads oldest → newest.
+    const shown = screen.getAllByText(/older_call|newer_call/).map((n) => n.textContent)
+    expect(shown).toEqual(['older_call', 'newer_call'])
+  })
+
   it('shows the branded empty state when there is no activity', async () => {
     server.use(http.get('/api/obs/events', () => HttpResponse.json({ events: [] })))
     render(<ActivityTerminal scope={{ taskId: 't1' }} />)

--- a/apps/web/src/features/obs/useObsStream.ts
+++ b/apps/web/src/features/obs/useObsStream.ts
@@ -134,12 +134,19 @@ export function useObsStream(
     void (async () => {
       try {
         const bp = new URLSearchParams(base)
-        bp.set('order', 'asc')
+        // Backfill the RECENT window, not the oldest one. `/api/obs/events`
+        // orders `seq ASC` by default, so `asc` + `limit` returns the FIRST N
+        // events ever recorded for this scope, on a log nothing prunes. That
+        // strands the terminal on ancient rows AND seeds `maxSeq` from them, so
+        // the SSE tail below then replays the whole log forward from that
+        // cursor, 500 rows per poll. Ask newest-first and reverse, so the
+        // terminal still renders chronologically and the cursor starts live.
+        bp.set('order', 'desc')
         bp.set('limit', String(limit))
         const r = await fetch(`/api/obs/events?${bp.toString()}`, { signal: backfillAbort.signal })
         if (!cancelled && r.ok) {
           const body = (await r.json()) as { events?: Record<string, unknown>[] }
-          const rows = (body.events ?? []).map(parseRow)
+          const rows = (body.events ?? []).map(parseRow).reverse()
           for (const row of rows) {
             seen.add(row.seq)
             if (row.seq > maxSeq) maxSeq = row.seq

--- a/docs/reference/rest-api/board.md
+++ b/docs/reference/rest-api/board.md
@@ -483,7 +483,7 @@ curl -X POST http://localhost:18790/api/board/<task-id>/executions \
 
 ## `PATCH /api/board/executions/:execId`
 
-Closes out an execution row with its outcome and an optional token/cost ledger. The handler emits an `execution_completed` event; `taskId`/`agentId` are not in scope on this REST path (only `execId`), so correlate via the `execution_started` event by `execId`.
+Closes out an execution row with its outcome and an optional token/cost ledger. The handler emits an `execution_completed` event carrying the run's `taskId`, `teamId`, `agentId` and `runtime`, recovered from the closed row, so the event correlates with the `execution_started` it pairs with. An unknown `execId` closes nothing and returns `404` without appending an event.
 
 - **Path params**: `execId`.
 - **Request body** (validated by `completeExecutionBody`):
@@ -514,6 +514,12 @@ Closes out an execution row with its outcome and an optional token/cost ledger. 
 
 ```json
 { "ok": true }
+```
+
+**`404 Not Found`**: no execution row matched `execId`; nothing was closed and no event was appended:
+
+```json
+{ "error": "execution not found" }
 ```
 
 **`500 Internal Server Error`**:

--- a/docs/reference/rest-api/observability.md
+++ b/docs/reference/rest-api/observability.md
@@ -149,7 +149,7 @@ The error-taxonomy feed: every `error` event, recent-first, projected to a compa
 
 - **Request body**: none.
 
-The read is fixed to `kinds: ['error']`, `order: 'desc'`, `limit: 500`. The `harnessBug` filter is applied after projection.
+The read is fixed to `kinds: ['error']`, `limit: 500`, newest-first **by `ts`**. Wall-clock order is what a display feed wants, and it is the order the only index over `kind` can serve, so the cost stays proportional to the 500 rows returned rather than to every error ever recorded. The `harnessBug` filter is applied after projection.
 
 ### Responses
 
@@ -365,7 +365,7 @@ Mirrors client-observed runtime events into the durable log. The OpenClaw runtim
 {
   events?: Array<{
     kind: 'tool_call' | 'tool_result' | 'error'  // any other kind is dropped
-    ts?: number
+    ts?: number              // must be within [now - 24h, now + 60s], else server time is used
     teamId?: string | null
     taskId?: string | null
     agentId?: string | null
@@ -376,6 +376,8 @@ Mirrors client-observed runtime events into the durable log. The OpenClaw runtim
 ```
 
 A non-array `events` is treated as empty. At most 200 events are accepted per call (the rest are sliced off). Any event whose `kind` is missing or not in the whitelist is skipped.
+
+A supplied `ts` is clamped to a band around server time (60 s ahead for clock skew, 24 h behind) and replaced with server time when it falls outside. `ts` is not just metadata: fleet health derives staleness from it, so a future timestamp would pin an agent at `working` and mask a genuine `zombie`. A mirror reports what a browser just observed, so a timestamp far from now is wrong regardless of intent.
 
 ### Responses
 

--- a/docs/reference/rest-api/observability.md
+++ b/docs/reference/rest-api/observability.md
@@ -196,7 +196,7 @@ Fleet-health triage, a per-agent state folded from the event log, time-sensitive
 - **Query params**: `teamId` (string), scope to one team.
 - **Request body**: none.
 
-The read is capped at 5000 events.
+The read is capped at the **most recent 5000 events** for the requested scope. `orchestration_events` is append-only and is never pruned, so the triage folds a trailing window rather than the whole history: rows are selected newest-first, then folded in causal order. An agent whose activity has scrolled out of that window stops appearing.
 
 ### Responses
 
@@ -237,7 +237,7 @@ Folds the ordered event stream into a delegation/status/cost graph projection. T
 - **Query params**: `teamId` (string), scope to one team.
 - **Request body**: none.
 
-The read is capped at 5000 events.
+The read is capped at the **most recent 5000 events** for the requested scope. `orchestration_events` is append-only and is never pruned, so the projection folds a trailing window rather than the whole history: rows are selected newest-first, then folded in causal order. A task whose events have all scrolled out of that window stops appearing, and one only partly inside it projects from the events that remain.
 
 ### Responses
 

--- a/docs/reference/rest-api/observability.md
+++ b/docs/reference/rest-api/observability.md
@@ -42,7 +42,7 @@ Returns rows from the event log filtered by the query params, ordered by the mon
 | `kinds`    | string          | Comma-separated list of event kinds; empty/blank values dropped. |
 | `since`    | number          | `ts >=` (wall-clock ms), a recent-window read.                   |
 | `afterSeq` | number          | `seq >` cursor (strictly monotonic, collision-free).             |
-| `limit`    | number          | Row cap (defaults to 500 in the data layer when omitted).        |
+| `limit`    | number          | Row cap, clamped to 1-5000 (defaults to 500 when omitted).       |
 | `order`    | `asc` \| `desc` | `desc` only when literally `"desc"`; anything else is `asc`.     |
 
 - **Request body**: none.

--- a/docs/using/observability-dashboard.md
+++ b/docs/using/observability-dashboard.md
@@ -134,6 +134,8 @@ The read endpoints share a query vocabulary:
 | `order=asc\|desc` | `events`                              | Causal (`asc`) or newest-first (`desc`)                    |
 | `harnessBug=true` | `errors`                              | Only harness bugs (`Unknown` class)                        |
 
+`health` and `graph` fold the most recent 5000 events for the requested scope, so both surfaces keep tracking current activity however long the log has been accumulating. An agent or task whose events have scrolled out of that window stops appearing.
+
 The SSE stream (`GET /api/obs/stream`) is a short-interval DB-tail on the `seq` cursor. `EventSource` reconnects automatically and resumes from the last `seq` via its `Last-Event-ID` header (or `?since=`). Each event's `data` is redacted before it reaches the browser; credential-shaped keys and values are masked, while numeric cost and token fields survive.
 
 ## Verify it worked

--- a/packages/db/src/board/repository.ts
+++ b/packages/db/src/board/repository.ts
@@ -796,13 +796,20 @@ export interface CompleteExecOutcome {
   costUsd?: number | null
 }
 
+/**
+ * Close an execution row. Returns the updated row (null when `execId` matched
+ * nothing) so a caller holding only an `execId` can recover its `taskId`. The
+ * obs `execution_completed` emitters need it to stay correlated with the
+ * `execution_started` they pair with. Mirrors `createExecutionProcess`, which
+ * has always returned its row.
+ */
 export function completeExecutionProcess(
   db: ClawbooDb,
   execId: string,
   outcome: CompleteExecOutcome,
-): void {
+): DbExecutionProcess | null {
   const now = Date.now()
-  withWriteRetry(() =>
+  const row = withWriteRetry(() =>
     db
       .update(executionProcesses)
       .set({
@@ -818,8 +825,10 @@ export function completeExecutionProcess(
         costUsd: outcome.costUsd ?? null,
       })
       .where(eq(executionProcesses.id, execId))
-      .run(),
+      .returning()
+      .get(),
   )
+  return (row as DbExecutionProcess | undefined) ?? null
 }
 
 /** List a task's execution-process rows (the run ledger), oldest first. */

--- a/packages/db/src/events/listEvents.ts
+++ b/packages/db/src/events/listEvents.ts
@@ -29,6 +29,16 @@ export interface ListEventsFilter {
   afterSeq?: number
   limit?: number
   order?: 'asc' | 'desc'
+  /**
+   * Which column the `order` applies to. Defaults to `seq`, the causal key a
+   * replay needs. Pass `'ts'` for a kind-filtered DISPLAY feed: the only index
+   * over `kind` is `(kind, ts)`, so ordering such a read by `seq` cannot use it
+   * and SQLite sorts every matching row through a temp B-tree first, at a cost
+   * that grows with how many of that kind have accumulated. Wall-clock order is
+   * what a human-facing feed wants anyway. Do NOT use it to feed a reducer: `ts`
+   * is caller-suppliable and therefore not strictly monotonic.
+   */
+  orderBy?: 'seq' | 'ts'
 }
 
 export function listEvents(db: ClawbooDb, filter: ListEventsFilter = {}): DbOrchestrationEvent[] {
@@ -41,8 +51,8 @@ export function listEvents(db: ClawbooDb, filter: ListEventsFilter = {}): DbOrch
     conds.push(inArray(orchestrationEvents.kind, filter.kinds))
   if (filter.since) conds.push(gte(orchestrationEvents.ts, filter.since))
   if (filter.afterSeq != null) conds.push(gt(orchestrationEvents.seq, filter.afterSeq))
-  const ordering =
-    filter.order === 'desc' ? desc(orchestrationEvents.seq) : asc(orchestrationEvents.seq)
+  const col = filter.orderBy === 'ts' ? orchestrationEvents.ts : orchestrationEvents.seq
+  const ordering = filter.order === 'desc' ? desc(col) : asc(col)
   return db
     .select()
     .from(orchestrationEvents)

--- a/packages/db/src/events/listEvents.ts
+++ b/packages/db/src/events/listEvents.ts
@@ -2,6 +2,12 @@
 // a trace/graph replay reproduces state deterministically (a deliberate deviation
 // from governance/audit's `desc(createdAt)`, which suits a "most-recent" lineage
 // feed). Pass `order: 'desc'` for a recent-first events feed.
+//
+// ⚠ `limit` composes with `order`, and the log is append-only and never pruned.
+// A `limit` with no `order` therefore selects the OLDEST N rows, not the newest.
+// A caller reading a WINDOW of a live stream must pass `order: 'desc'` and
+// reverse the result if its consumer needs chronological order. Getting this
+// wrong is silent: the read keeps succeeding while pinned to ancient rows.
 
 import { and, asc, desc, eq, gt, gte, inArray, type SQL } from 'drizzle-orm'
 

--- a/packages/obs/src/project/__tests__/graph.test.ts
+++ b/packages/obs/src/project/__tests__/graph.test.ts
@@ -160,6 +160,14 @@ describe('projectGraph', () => {
     const ids = g.tasks.map((t) => t.id)
     expect(ids).toContain('child')
     expect(ids, 'every edge endpoint must resolve to a node').toContain('evicted-parent')
+    // The edge itself must still be emitted; materialising the parent is only
+    // useful if the edge that referenced it is there to resolve.
+    expect(g.taskEdges).toContainEqual({
+      id: 'delegation:evicted-parent->child',
+      source: 'evicted-parent',
+      target: 'child',
+      kind: 'delegation',
+    })
     // A placeholder, not invented detail.
     const parent = g.tasks.find((t) => t.id === 'evicted-parent')!
     expect(parent.title).toBeNull()

--- a/packages/obs/src/project/__tests__/graph.test.ts
+++ b/packages/obs/src/project/__tests__/graph.test.ts
@@ -136,6 +136,38 @@ describe('projectGraph', () => {
     expect(a3.costUsd).toBeCloseTo(0.05)
   })
 
+  it('materialises a parent that scrolled out of the window, so no edge dangles', () => {
+    // A read of the log is a WINDOW, so a child's `task_created` can be inside
+    // it while its parent's has already scrolled out. Only the child is fed here.
+    const g = projectGraph([
+      {
+        id: 'e1',
+        seq: 1,
+        ts: 1000,
+        kind: 'task_created',
+        teamId: 'team1',
+        taskId: 'child',
+        agentId: null,
+        runtime: null,
+        traceId: null,
+        spanId: null,
+        parentSpanId: null,
+        correlationId: null,
+        tenantId: null,
+        data: { title: 'child', status: 'todo', parentTaskId: 'evicted-parent' },
+      },
+    ])
+    const ids = g.tasks.map((t) => t.id)
+    expect(ids).toContain('child')
+    expect(ids, 'every edge endpoint must resolve to a node').toContain('evicted-parent')
+    // A placeholder, not invented detail.
+    const parent = g.tasks.find((t) => t.id === 'evicted-parent')!
+    expect(parent.title).toBeNull()
+    expect(parent.status).toBe('unknown')
+    // It has no assignee, so no phantom agent edge is derived from it.
+    expect(g.agentEdges).toHaveLength(0)
+  })
+
   it('REPLAY reproduces the graph state (the surface cannot drift)', () => {
     const log = buildLog()
     const a = projectGraph(log)

--- a/packages/obs/src/project/graph.ts
+++ b/packages/obs/src/project/graph.ts
@@ -108,6 +108,12 @@ export function projectGraph(events: readonly OrchestrationEvent[]): ProjectedGr
         t.teamId = ev.teamId ?? t.teamId
         if (d.parentTaskId) {
           t.parentTaskId = d.parentTaskId
+          // Materialise the parent too, the way the `dep_linked` branch below
+          // does for both of its endpoints, so every edge resolves to a node.
+          // A read of this log is a WINDOW, so a child's `task_created` can sit
+          // inside it while its parent's has already scrolled out; without this
+          // the projection emits an edge whose `source` is absent from `tasks`.
+          ensureTask(d.parentTaskId)
           addTaskEdge(d.parentTaskId, taskId, 'delegation')
         }
         break


### PR DESCRIPTION
## Summary

* Fixes observability dashboards to read the most recent event window instead of the oldest records from the append-only event log.
* Introduces a shared `readRecentEvents` helper so dashboard views use a consistent event-selection strategy while preserving causal event ordering.
* Updates documentation and adds safeguards to clarify event window semantics and prevent regressions caused by unordered limited reads.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff

Closes #145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Observability dashboards now use the latest 5,000 team-scoped events for health and delegation views.
  * Events are displayed chronologically while preserving accurate live updates.
  * Event queries support limits up to 5,000 rows, with errors shown newest first.
  * Completion events now include task, team, agent, and runtime details for improved activity and cost reporting.
  * Invalid or out-of-range event timestamps are safely adjusted.
* **Documentation**
  * Updated observability API and dashboard guidance for event windows and partial visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->