### PR TITLE
chore(deps): update Node and better-sqlite3 versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,11 @@ on:
 
 concurrency:
   group: publish-${{ github.ref }}
-  cancel-in-progress: true
+  # NEVER cancel a release mid-flight. `changeset publish` pushes to npm and then
+  # creates the git tags; cancelling between those steps leaves a version live on
+  # npm with no tag behind it, which cannot be undone. Queue the next run instead --
+  # a superseded release is cheap, a desynced one is not.
+  cancel-in-progress: false
 
 # Least-privilege default, matching ci.yml and evals.yml. Any job added here
 # without its own `permissions:` block would otherwise inherit whatever the

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ coverage
 
 # Astro generated cache + types (website/) — regenerated on build, must never be committed.
 website/.astro/
+
+# Package tarballs. `pnpm pack` (used by test:clean-install, and by `changeset
+# publish` at release time) writes one into the package directory; it is a build
+# artifact, never a source file.
+*.tgz

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   A <strong>TypeScript orchestrator for heterogeneous AI agent runtimes</strong>. Native agents are built in: paste a key and go.
   <br/>
-  Claude Code, Codex, Hermes, and OpenClaw join as <strong>peer teammates in one chat</strong>, sharing one board, one memory, and one capability dashboard, all governed, with autonomous work independently verified.
+  Claude Code, Codex, Hermes, and OpenClaw join as <strong>peer teammates in one chat</strong>, sharing one board, one memory, and one capability dashboard, all governed, with autonomous file-mutating work independently verified before it counts as done.
 </p>
 
 <p align="center">
@@ -77,7 +77,7 @@ The server keeps running after the CLI exits, so `clawboo stop` and `clawboo res
 - **Mixed-runtime peer chat.** Native, Claude Code, Codex, Hermes, and OpenClaw agents are all named peers in one room, and any runtime can lead. Coordination flows over structured lifecycle events and MCP calls, never terminal-output scraping.
 - **Native agents built in, external runtimes one click away.** Paste a provider key and Clawboo runs agents itself, or install and connect a coding-agent CLI from the Runtimes panel. Each runtime keeps its own native powers (OpenClaw keeps its channels and always-on heartbeat; Hermes keeps its self-improvement and skills).
 - **One shared memory, one capability dashboard.** Every runtime reads and writes the same tiered memory store and shows up in one unified skills and connectors inventory, while its private self-model stays its own.
-- **Verified, governed, observable.** Built-in verification for autonomous completions (builder is not the judge), spend tracking and warnings, depth and fan-out caps, and approvals, plus OpenTelemetry traces, structured logs, and an error taxonomy, all on by default. Hard spend caps that auto-pause a run are opt-in.
+- **Verified, governed, observable.** Built-in verification for autonomous file-mutating completions (builder is not the judge: a deterministic gate always, plus an independent read-only critic on a risky or large diff; read-only research carries no verdict), spend tracking and warnings, and depth and fan-out caps, plus OpenTelemetry traces, structured logs, and an error taxonomy, all on by default. Interactive tool approvals apply to the connected OpenClaw path; the spawned runtimes execute board tasks non-interactively inside a per-task worktree. Hard spend caps that auto-pause a run are opt-in.
 
 ---
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -68,6 +68,7 @@ These are used to build and test Clawboo and are not shipped in the npm package:
 **Ingested commit**: `64eee9f8e04f69b04e78e150d771a443c64720be`
 **Content location**: `apps/web/src/features/marketplace/agents/agency/`
 **Files ingested**: 179 agent `.md` files across 13 domain folders
+**License verified**: MIT, confirmed at the pinned commit on 2026-07-28 (GitHub license API, `spdx_id: MIT`). Because the ingest is commit-pinned, a later upstream relicense does not affect the grant that applied at this commit; re-verify when the pin is next moved.
 
 MIT License
 
@@ -97,6 +98,7 @@ SOFTWARE.
 **Ingested commit**: `659895e58e2105c6db8fbef39f446c8a786a480c`
 **Content location**: `apps/web/src/features/marketplace/agents/awesome-openclaw/`
 **Files ingested**: 42 usecase `.md` files transformed into 110 agent catalog entries
+**License verified**: MIT, confirmed at the pinned commit on 2026-07-28 (GitHub license API, `spdx_id: MIT`). Because the ingest is commit-pinned, a later upstream relicense does not affect the grant that applied at this commit; re-verify when the pin is next moved.
 
 Each generated catalog entry stores the full, verbatim usecase body in its
 `identityTemplate` field (zero-loss ingestion), with a source URL pointing back to the

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -38,11 +38,11 @@
     "test": "vitest run"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "dependencies": {
     "@clack/prompts": "^0.9.0",
-    "better-sqlite3": "11.10.0",
+    "better-sqlite3": "13.0.1",
     "chalk": "^5.4.0",
     "commander": "^12.1.0",
     "ora": "^8.1.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -22,7 +22,7 @@
     "mission-control"
   ],
   "bin": {
-    "clawboo": "dist/index.js",
+    "clawboo": "dist/bootstrap.js",
     "clawboo-mcp-tasks": "dist/bin/tasks.js",
     "clawboo-mcp-memory": "dist/bin/memory.js",
     "clawboo-mcp-tools": "dist/bin/tools.js",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.0",
-    "better-sqlite3": "13.0.1",
+    "better-sqlite3": "12.11.1",
     "chalk": "^5.4.0",
     "commander": "^12.1.0",
     "ora": "^8.1.0",

--- a/apps/cli/src/__tests__/node-version.test.ts
+++ b/apps/cli/src/__tests__/node-version.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  MIN_NODE_MAJOR,
+  MIN_NODE_MINOR,
+  isSupportedNodeVersion,
+  nodeVersionError,
+  parseNodeVersion,
+} from '../node-version'
+
+describe('node-version preflight', () => {
+  it('parses a process.version-shaped string', () => {
+    expect(parseNodeVersion('v22.12.0')).toEqual({ major: 22, minor: 12 })
+    expect(parseNodeVersion('24.3.1')).toEqual({ major: 24, minor: 3 })
+    expect(parseNodeVersion('not-a-version')).toBeNull()
+  })
+
+  it('accepts the floor and anything newer', () => {
+    expect(isSupportedNodeVersion(`v${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}.0`)).toBe(true)
+    expect(isSupportedNodeVersion('v22.20.0')).toBe(true)
+    expect(isSupportedNodeVersion('v24.0.0')).toBe(true)
+  })
+
+  it('rejects the versions that actually break the bundled CJS launcher', () => {
+    // 22.0–22.11 predate `require(esm)`, so requiring ESM-only chalk/ora throws.
+    expect(isSupportedNodeVersion('v22.0.0')).toBe(false)
+    expect(isSupportedNodeVersion('v22.11.0')).toBe(false)
+    expect(isSupportedNodeVersion('v20.18.0')).toBe(false)
+  })
+
+  it('fails open on an unrecognised runtime rather than blocking a launch', () => {
+    expect(isSupportedNodeVersion('weird-build')).toBe(true)
+    expect(nodeVersionError('weird-build')).toBeNull()
+  })
+
+  it('returns an actionable message below the floor, null at or above it', () => {
+    const msg = nodeVersionError('v20.18.0')
+    expect(msg).toContain('requires Node.js')
+    expect(msg).toContain('v20.18.0')
+    expect(msg).toContain('nodejs.org')
+    expect(nodeVersionError('v22.12.0')).toBeNull()
+  })
+})

--- a/apps/cli/src/__tests__/server-log.test.ts
+++ b/apps/cli/src/__tests__/server-log.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  SERVER_LOG_MAX_BYTES,
+  openServerLog,
+  resolveServerLogPath,
+  tailServerLog,
+} from '../server-log'
+
+describe('server-log', () => {
+  let home: string
+  let prevHome: string | undefined
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'clawboo-log-'))
+    prevHome = process.env['CLAWBOO_HOME']
+    process.env['CLAWBOO_HOME'] = home
+  })
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env['CLAWBOO_HOME']
+    else process.env['CLAWBOO_HOME'] = prevHome
+    fs.rmSync(home, { recursive: true, force: true })
+  })
+
+  it('opens an appendable log under the Clawboo home and writes the header', () => {
+    const log = openServerLog('--- header ---\n')
+    expect(log).not.toBeNull()
+    expect(log!.path).toBe(resolveServerLogPath())
+    fs.writeSync(log!.fd, 'boot line\n')
+    fs.closeSync(log!.fd)
+    expect(fs.readFileSync(log!.path, 'utf8')).toContain('--- header ---')
+    expect(fs.readFileSync(log!.path, 'utf8')).toContain('boot line')
+  })
+
+  it('rotates a log that has grown past the cap', () => {
+    const logPath = resolveServerLogPath()
+    fs.mkdirSync(path.dirname(logPath), { recursive: true })
+    fs.writeFileSync(logPath, 'x'.repeat(SERVER_LOG_MAX_BYTES + 1))
+
+    const log = openServerLog()
+    expect(log).not.toBeNull()
+    fs.closeSync(log!.fd)
+
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true) // previous log preserved
+    expect(fs.statSync(logPath).size).toBeLessThan(SERVER_LOG_MAX_BYTES) // fresh log
+  })
+
+  it('tails only the last non-blank lines', () => {
+    const log = openServerLog()!
+    fs.writeSync(log.fd, 'one\n\ntwo\nthree\n')
+    fs.closeSync(log.fd)
+    expect(tailServerLog(log.path, 2)).toEqual(['two', 'three'])
+  })
+
+  it('degrades quietly when the log is missing', () => {
+    expect(tailServerLog(path.join(home, 'nope.log'))).toEqual([])
+  })
+})

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -1,0 +1,32 @@
+// The published `clawboo` bin entry.
+//
+// This file exists for ONE reason: the Node-version check has to happen before
+// any dependency is loaded. `dist/index.js` `require()`s externalized packages
+// at module scope, and at least one of them (`ora`) is ESM-only with no CJS
+// entry. On Node 22.0-22.11, which predates `require(esm)`, that throws a raw
+// `ERR_REQUIRE_ESM` the moment the file is loaded, long before Commander could
+// register a `preAction` hook. A guard living inside the CLI can therefore never
+// fire on the exact versions it exists to catch.
+//
+// So the bin points here instead. This module imports NOTHING but the local,
+// dependency-free version check (tsup inlines it), runs on any Node that can
+// parse it, and only then hands off to the real CLI.
+
+import { nodeVersionError } from './node-version'
+
+const versionError = nodeVersionError(process.version)
+if (versionError) {
+  // No chalk: it is a dependency, and loading one here would defeat the purpose.
+  process.stderr.write(`[31m✖ [39m${versionError}\n`)
+  process.exit(1)
+}
+
+// Hand off to the real CLI.
+//
+// The specifier is assembled at runtime so the bundler cannot resolve it
+// statically. A literal `require('./index')` is inlined by tsup, which would
+// pull every dependency back into this file and reinstate the exact failure
+// this bootstrap prevents. `dist/index.js` is emitted as its own entry and sits
+// next to this file.
+const cliEntry = ['.', 'index.js'].join('/')
+module.require(cliEntry)

--- a/apps/cli/src/bootstrap.ts
+++ b/apps/cli/src/bootstrap.ts
@@ -1,22 +1,21 @@
 // The published `clawboo` bin entry.
 //
-// This file exists for ONE reason: the Node-version check has to happen before
-// any dependency is loaded. `dist/index.js` `require()`s externalized packages
-// at module scope, and at least one of them (`ora`) is ESM-only with no CJS
-// entry. On Node 22.0-22.11, which predates `require(esm)`, that throws a raw
-// `ERR_REQUIRE_ESM` the moment the file is loaded, long before Commander could
-// register a `preAction` hook. A guard living inside the CLI can therefore never
-// fire on the exact versions it exists to catch.
+// The Node-version check must run before any dependency loads. `dist/index.js`
+// requires externalized packages at module scope, and one of them (`ora`) is
+// ESM-only with no CJS entry, so on Node 22.0-22.11 — which predates
+// `require(esm)` — loading it throws `ERR_REQUIRE_ESM` before Commander can
+// register a `preAction` hook. A check inside the CLI cannot run on the versions
+// it needs to catch.
 //
-// So the bin points here instead. This module imports NOTHING but the local,
-// dependency-free version check (tsup inlines it), runs on any Node that can
-// parse it, and only then hands off to the real CLI.
+// This module therefore imports nothing but the local, dependency-free version
+// check (tsup inlines it) and hands off to the real CLI once the runtime is
+// supported.
 
 import { nodeVersionError } from './node-version'
 
 const versionError = nodeVersionError(process.version)
 if (versionError) {
-  // No chalk: it is a dependency, and loading one here would defeat the purpose.
+  // Written with a raw escape rather than chalk: this path must load no dependency.
   process.stderr.write(`[31m✖ [39m${versionError}\n`)
   process.exit(1)
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -26,6 +26,8 @@ import fs from 'fs'
 import { resolveClawbooDir } from '@clawboo/config'
 
 import { VERSION } from './version'
+import { nodeVersionError } from './node-version'
+import { tailServerLog } from './server-log'
 import { shouldOfferRestart } from './versionCheck'
 import {
   discoverDashboard,
@@ -113,6 +115,18 @@ async function startAndReport(opts: {
           chalk.white(`cd ${outcome.monorepoRoot} && pnpm dev`)
         : chalk.yellow('Dashboard is taking too long to start.')
     ui.spinner?.fail(hint)
+    // Show WHY. The server is detached, so without this a failed boot is invisible
+    // and the only signal is the timeout itself.
+    if (outcome.logPath) {
+      const lines = tailServerLog(outcome.logPath)
+      if (lines.length > 0) {
+        console.log()
+        console.log(chalk.bold('Last lines from the server log:'))
+        for (const line of lines) console.log(chalk.gray('  ' + line))
+      }
+      console.log()
+      console.log(chalk.gray('Full log: ') + chalk.white(outcome.logPath))
+    }
     return null
   }
 
@@ -569,6 +583,17 @@ program
   .option('--no-version-check', 'Skip comparing a running server against this launcher.')
   .option('-y, --yes', 'Restart an older running server without prompting.')
   .showHelpAfterError()
+  // Node preflight for EVERY command, not just the default launch. This binary is
+  // bundled as CJS and require()s ESM-only deps, so an unsupported Node fails with a
+  // raw ERR_REQUIRE_ESM before any of our code runs. A hook here means `stop`,
+  // `restart`, `backup` — and any future subcommand — inherit it automatically.
+  .hook('preAction', () => {
+    const versionError = nodeVersionError(process.version)
+    if (versionError) {
+      console.error(chalk.red('✖ ') + versionError)
+      process.exit(1)
+    }
+  })
 
 program.action((opts: LaunchOptions, command: Command) => {
   // Commander dispatches registered subcommands before reaching here and does

--- a/apps/cli/src/lifecycle.ts
+++ b/apps/cli/src/lifecycle.ts
@@ -379,6 +379,12 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
   const childStdio: 'ignore' | ['ignore', number, number] = serverLog
     ? ['ignore', serverLog.fd, serverLog.fd]
     : 'ignore'
+  // `fork()` only auto-attaches its required IPC channel for the 'ignore'
+  // SHORTHAND; an explicit stdio array must carry 'ipc' itself or fork() throws
+  // "Forked processes must have an IPC channel". `spawn()` must NOT have it.
+  const forkStdio: 'ignore' | ['ignore', number, number, 'ipc'] = serverLog
+    ? ['ignore', serverLog.fd, serverLog.fd, 'ipc']
+    : 'ignore'
 
   // Strategy 1: Bundled mode — server.js sits next to this CLI entry
   const bundledServerPath = path.join(__dirname, 'server.js')
@@ -419,7 +425,7 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
         ...pinned,
       },
       detached: true,
-      stdio: childStdio,
+      stdio: forkStdio,
     })
     child.unref()
     // `fork()` ALWAYS attaches an IPC channel, even under `stdio: 'ignore'`, and

--- a/apps/cli/src/lifecycle.ts
+++ b/apps/cli/src/lifecycle.ts
@@ -23,6 +23,8 @@ import fs from 'fs'
 
 import { resolveClawbooDir } from '@clawboo/config'
 
+import { openServerLog } from './server-log'
+
 import { VERSION } from './version'
 import { findListenerPid } from '@clawboo/process-lookup'
 
@@ -358,7 +360,7 @@ export interface StartOptions {
 export type StartOutcome =
   | { status: 'started'; port: number; mode: LaunchMode }
   | { status: 'no-server' }
-  | { status: 'timeout'; mode: LaunchMode; monorepoRoot: string | null }
+  | { status: 'timeout'; mode: LaunchMode; monorepoRoot: string | null; logPath: string | null }
 
 /**
  * Start a detached dashboard server and wait for it to answer.
@@ -369,6 +371,15 @@ export type StartOutcome =
  * while the server keeps running.
  */
 export async function startDashboard(opts: StartOptions = {}): Promise<StartOutcome> {
+  // The server is detached with `stdio: 'ignore'`, so a boot failure leaves no
+  // trace and the launcher can only report an unexplained timeout. Capture the
+  // child's output to a rolling log instead; `startAndReport` tails it on timeout.
+  // A null log (unwritable home) degrades to the previous ignore-everything path.
+  const serverLog = openServerLog(`\n--- clawboo v${VERSION} · pid ${process.pid} ---\n`)
+  const childStdio: 'ignore' | ['ignore', number, number] = serverLog
+    ? ['ignore', serverLog.fd, serverLog.fd]
+    : 'ignore'
+
   // Strategy 1: Bundled mode — server.js sits next to this CLI entry
   const bundledServerPath = path.join(__dirname, 'server.js')
 
@@ -408,7 +419,7 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
         ...pinned,
       },
       detached: true,
-      stdio: 'ignore',
+      stdio: childStdio,
     })
     child.unref()
     // `fork()` ALWAYS attaches an IPC channel, even under `stdio: 'ignore'`, and
@@ -430,7 +441,7 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
           cwd: monorepoRoot!,
           env: { ...process.env, NODE_ENV: 'production', CLAWBOO_VERSION: VERSION, ...pinned },
           detached: true,
-          stdio: 'ignore',
+          stdio: childStdio,
           shell: true,
           windowsHide: true,
         })
@@ -438,7 +449,7 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
           cwd: monorepoRoot!,
           env: { ...process.env, NODE_ENV: 'production', CLAWBOO_VERSION: VERSION, ...pinned },
           detached: true,
-          stdio: 'ignore',
+          stdio: childStdio,
         })
     // Without a listener a failed spawn emits an unhandled 'error' event, which
     // takes the launcher down with an opaque stack instead of the readiness
@@ -470,7 +481,7 @@ export async function startDashboard(opts: StartOptions = {}): Promise<StartOutc
     if (found !== null) return { status: 'started', port: found, mode }
   }
 
-  return { status: 'timeout', mode, monorepoRoot }
+  return { status: 'timeout', mode, monorepoRoot, logPath: serverLog?.path ?? null }
 }
 
 /** Test seams — every side effect `stopDashboard` performs is injectable. */

--- a/apps/cli/src/node-version.ts
+++ b/apps/cli/src/node-version.ts
@@ -1,0 +1,46 @@
+/**
+ * Runtime Node-version guard for the launcher.
+ *
+ * `engines.node` is advisory only — npm's EBADENGINE warning never blocks and
+ * `npx` ignores it entirely. On an unsupported Node the launcher itself often
+ * starts fine and the DETACHED server dies during boot, so the user just sees a
+ * spinner time out with no reason. Fail fast, in the terminal, before we fork.
+ *
+ * The floor is 22.12 rather than 22.0 because the CLI is bundled as CJS and
+ * `require()`s ESM-only dependencies (chalk 5, ora 8, @clack/prompts); Node
+ * enabled `require(esm)` by default in 22.12, so 22.0–22.11 throw ERR_REQUIRE_ESM.
+ */
+
+export const MIN_NODE_MAJOR = 22
+export const MIN_NODE_MINOR = 12
+
+/** Parse `major.minor` from a `process.version`-shaped string ('v22.11.0'). */
+export function parseNodeVersion(version: string): { major: number; minor: number } | null {
+  const match = version.trim().match(/^v?(\d+)\.(\d+)/)
+  if (!match) return null
+  const major = Number(match[1])
+  const minor = Number(match[2])
+  if (!Number.isInteger(major) || !Number.isInteger(minor)) return null
+  return { major, minor }
+}
+
+/** True when `version` meets the supported floor. */
+export function isSupportedNodeVersion(version: string): boolean {
+  const parsed = parseNodeVersion(version)
+  // An unrecognised runtime must never block a launch — fail open, not closed.
+  if (parsed === null) return true
+  if (parsed.major > MIN_NODE_MAJOR) return true
+  if (parsed.major < MIN_NODE_MAJOR) return false
+  return parsed.minor >= MIN_NODE_MINOR
+}
+
+/** An actionable message when `version` is below the floor, else null. */
+export function nodeVersionError(version: string): string | null {
+  if (isSupportedNodeVersion(version)) return null
+  const floor = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`
+  return (
+    `Clawboo requires Node.js ${floor} or newer — this is ${version}.\n` +
+    `Install a current Node from https://nodejs.org, or switch with a version manager ` +
+    `(\`nvm install ${MIN_NODE_MAJOR}\` / \`fnm use ${MIN_NODE_MAJOR}\`), then run \`clawboo\` again.`
+  )
+}

--- a/apps/cli/src/server-log.ts
+++ b/apps/cli/src/server-log.ts
@@ -1,0 +1,81 @@
+/**
+ * Rolling log for the DETACHED dashboard server.
+ *
+ * The server is forked with `detached: true` and its stdio was previously
+ * discarded, so a boot failure left no trace anywhere — the launcher just timed
+ * out with a generic hint. Pointing the child's stdout/stderr at this file makes
+ * a failed first run diagnosable after the fact.
+ *
+ * Every function here is best-effort and NEVER throws: a log we cannot open must
+ * degrade to the previous behaviour (discarded output), never fail a launch.
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+import { resolveClawbooDir } from '@clawboo/config'
+
+/** Rotate past this size so the log can't grow without bound. */
+export const SERVER_LOG_MAX_BYTES = 5 * 1024 * 1024
+
+export interface ServerLog {
+  fd: number
+  path: string
+}
+
+export function resolveServerLogPath(): string {
+  return path.join(resolveClawbooDir(), 'server.log')
+}
+
+/**
+ * Open (append) the rolling server log, rotating it first if oversized.
+ * Returns null when it cannot be opened (read-only home, permissions).
+ */
+export function openServerLog(header?: string): ServerLog | null {
+  const logPath = resolveServerLogPath()
+  try {
+    fs.mkdirSync(path.dirname(logPath), { recursive: true })
+    try {
+      if (fs.statSync(logPath).size > SERVER_LOG_MAX_BYTES) {
+        fs.renameSync(logPath, `${logPath}.1`)
+      }
+    } catch {
+      // No existing log (or an unstattable one) — nothing to rotate.
+    }
+    const fd = fs.openSync(logPath, 'a')
+    if (header) {
+      try {
+        fs.writeSync(fd, header)
+      } catch {
+        // Header is a nicety; an unwritable log is handled by the caller.
+      }
+    }
+    return { fd, path: logPath }
+  } catch {
+    return null
+  }
+}
+
+/** The last `maxLines` non-blank lines, reading at most `maxBytes` from the tail. */
+export function tailServerLog(logPath: string, maxLines = 12, maxBytes = 8_192): string[] {
+  try {
+    const size = fs.statSync(logPath).size
+    const start = Math.max(0, size - maxBytes)
+    const fd = fs.openSync(logPath, 'r')
+    try {
+      const length = size - start
+      const buf = Buffer.alloc(length)
+      fs.readSync(fd, buf, 0, length, start)
+      return buf
+        .toString('utf8')
+        .split(/\r?\n/)
+        .map((l) => l.trimEnd())
+        .filter((l) => l.length > 0)
+        .slice(-maxLines)
+    } finally {
+      fs.closeSync(fd)
+    }
+  } catch {
+    return []
+  }
+}

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 import pkg from './package.json'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/bootstrap.ts'],
   format: ['cjs'],
   dts: false,
   clean: true,

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -12,7 +12,7 @@ import { reconcileOrphans, reconcileStaleInProgress, seedBuiltinTools } from '@c
 import { apiRouter } from './api/index'
 import { attachIdentity } from './lib/auth'
 import { closeDb, getDb } from './lib/db'
-import { killLiveSubprocesses } from './lib/runtimes/subprocess'
+import { killLiveSubprocesses, shutdownLiveSubprocesses } from './lib/runtimes/subprocess'
 import { gcTaskWorkspaces } from './lib/worktrees'
 import { startMcpSupervisor } from './lib/mcpSupervisor'
 import { startApprovalReaper } from './lib/approvalReaper'
@@ -457,14 +457,31 @@ async function main() {
       log.warn({ err }, 'WAL checkpoint on shutdown failed (non-fatal)')
     }
   }
-  process.once('SIGINT', () => {
+  // A signal shutdown WAITS for the children to actually die before exiting.
+  // `cleanup()`'s reap only sends SIGTERM; killTree then schedules a SIGKILL
+  // escalation on a timer, and `process.exit(0)` would kill that timer with the
+  // process — so a child ignoring SIGTERM used to outlive the server. The wait is
+  // bounded (SHUTDOWN_WAIT_MS) so a hung child can never block the exit, and it
+  // never throws.
+  const gracefulExit = async (): Promise<void> => {
+    try {
+      const { signalled, exited } = await shutdownLiveSubprocesses()
+      if (signalled > 0) {
+        log.info({ signalled, exited }, 'Terminated running runtime subprocesses on shutdown')
+      }
+    } catch (err) {
+      log.warn({ err }, 'Failed to terminate runtime subprocesses on shutdown (non-fatal)')
+    }
     cleanup()
-    process.exit(0)
+  }
+  process.once('SIGINT', () => {
+    void gracefulExit().finally(() => process.exit(0))
   })
   process.once('SIGTERM', () => {
-    cleanup()
-    process.exit(0)
+    void gracefulExit().finally(() => process.exit(0))
   })
+  // Last-resort synchronous path (a `process.exit` from anywhere else): it cannot
+  // await, so it falls back to signalling without waiting.
   process.once('exit', cleanup)
 
   // Defensive graceful degradation: a background subsystem that rejects without a

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -12,6 +12,7 @@ import { reconcileOrphans, reconcileStaleInProgress, seedBuiltinTools } from '@c
 import { apiRouter } from './api/index'
 import { attachIdentity } from './lib/auth'
 import { closeDb, getDb } from './lib/db'
+import { killLiveSubprocesses } from './lib/runtimes/subprocess'
 import { gcTaskWorkspaces } from './lib/worktrees'
 import { startMcpSupervisor } from './lib/mcpSupervisor'
 import { startApprovalReaper } from './lib/approvalReaper'
@@ -436,6 +437,16 @@ async function main() {
   const cleanup = (): void => {
     if (shutDown) return
     shutDown = true
+    // Reap spawned runtime children BEFORE we go. They are detached process-group
+    // leaders and are deliberately never unref'd, so they outlive this process —
+    // still spending against the provider while boot-time reconciliation hands
+    // their task to another runner (two live runs on one worktree).
+    try {
+      const reaped = killLiveSubprocesses()
+      if (reaped > 0) log.info({ reaped }, 'Terminated running runtime subprocesses on shutdown')
+    } catch (err) {
+      log.warn({ err }, 'Failed to terminate runtime subprocesses on shutdown (non-fatal)')
+    }
     // Only if the file still names OUR port: a second instance (auto-scan
     // fallback, or a restart successor that has already rebound) may have
     // rewritten it, and deleting that would strand a server that is still up.

--- a/apps/web/server/lib/__tests__/executorRunner.isolation.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.isolation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Isolation + claim-safety guards on the per-task runner.
+ *
+ * Two invariants, both about what happens when something goes wrong AFTER the
+ * atomic claim:
+ *
+ *  1. A file-mutating task with no provisionable worktree is REFUSED. Running it
+ *     with a null cwd would execute the agent in the server's own working
+ *     directory — and the drivers run with their permission gates bypassed on the
+ *     strength of worktree isolation, so that combination must never happen.
+ *  2. An unexpected throw releases the claim. Otherwise the task sits
+ *     `in_progress` with no runner behind it until the stale sweep.
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createDb, createTask, getTask } from '@clawboo/db'
+import type {
+  Capabilities,
+  RunHandle,
+  RuntimeAdapter,
+  RuntimeEvent,
+  StartOpts,
+  TaskHandle,
+} from '@clawboo/executor'
+
+import { getDbPath } from '../db'
+import { runTaskOnRuntime } from '../executorRunner'
+
+const CAPS: Capabilities = {
+  streaming: true,
+  mcp: true,
+  worktrees: true,
+  resume: true,
+  toolApproval: true,
+  models: [],
+  contextWindowTokens: 200_000,
+}
+
+/** Records whether it was ever started, and can be scripted to throw. */
+class ProbeAdapter implements RuntimeAdapter {
+  readonly participantKind = 'agent' as const
+  startCount = 0
+
+  constructor(
+    readonly id: string,
+    private readonly throwOnStart = false,
+  ) {}
+
+  capabilities(): Capabilities {
+    return CAPS
+  }
+  async health() {
+    return { ok: true }
+  }
+  async start(_t: TaskHandle, opts: StartOpts): Promise<RunHandle> {
+    this.startCount += 1
+    if (this.throwOnStart) throw new Error('driver exploded mid-start')
+    return { adapterId: this.id, sessionKey: opts.sessionKey, runId: 'rid-0' }
+  }
+  events(run: RunHandle): AsyncIterable<RuntimeEvent> {
+    const base = { runId: run.runId ?? run.sessionKey, sessionId: run.sessionKey, ts: 1, seq: 1 }
+    return (async function* () {
+      yield { ...base, kind: 'done', reason: 'success', summary: 'ok' } as RuntimeEvent
+    })()
+  }
+  async abort() {}
+  async setModel() {}
+  async writeContext() {}
+}
+
+describe('executor runner — isolation + claim safety', () => {
+  let home: string
+  let prevHome: string | undefined
+
+  beforeEach(async () => {
+    home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-iso-home-'))
+    await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
+    prevHome = process.env['HOME']
+    process.env['HOME'] = home
+  })
+  afterEach(async () => {
+    if (prevHome === undefined) delete process.env['HOME']
+    else process.env['HOME'] = prevHome
+    await rm(home, { recursive: true, force: true })
+  })
+
+  function newTask(): string {
+    return createTask(createDb(getDbPath()), {
+      title: 'Change some files',
+      description: 'file-mutating work',
+      status: 'todo',
+      teamId: 'team-1',
+    }).id
+  }
+
+  it('refuses a file-mutating task that has no worktree instead of running in the server cwd', async () => {
+    const taskId = newTask()
+    const fake = new ProbeAdapter('claude-code')
+
+    const result = await runTaskOnRuntime({
+      db: createDb(getDbPath()),
+      makeAdapter: () => fake,
+      taskId,
+      assigneeAgentId: 'claude-1',
+      disableMemoryAutoInject: true,
+      // kind defaults to 'code' (file-mutating) and no repoPath is supplied,
+      // so isolation is required but cannot be provisioned.
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('workspace_unavailable')
+    // The agent must never have been started.
+    expect(fake.startCount).toBe(0)
+    // And the task goes back to the queue rather than being stranded.
+    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
+  })
+
+  it('still runs read-only work without a worktree', async () => {
+    const taskId = newTask()
+    const fake = new ProbeAdapter('claude-code')
+
+    const result = await runTaskOnRuntime({
+      db: createDb(getDbPath()),
+      makeAdapter: () => fake,
+      taskId,
+      assigneeAgentId: 'claude-1',
+      disableMemoryAutoInject: true,
+      kind: 'research', // mutates no files — legitimately needs no isolation
+    })
+
+    expect(result.ok).toBe(true)
+    expect(fake.startCount).toBe(1)
+  })
+
+  it('releases the claim when the driver throws unexpectedly', async () => {
+    const taskId = newTask()
+    const fake = new ProbeAdapter('claude-code', true)
+
+    await expect(
+      runTaskOnRuntime({
+        db: createDb(getDbPath()),
+        makeAdapter: () => fake,
+        taskId,
+        assigneeAgentId: 'claude-1',
+        disableMemoryAutoInject: true,
+        kind: 'research',
+      }),
+    ).rejects.toThrow(/driver exploded/)
+
+    // The throw propagates, but the task must not be left wedged in_progress.
+    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
+  })
+})

--- a/apps/web/server/lib/__tests__/executorRunner.isolation.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.isolation.test.ts
@@ -18,7 +18,7 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-import { createDb, createTask, getTask } from '@clawboo/db'
+import { createTask, getTask } from '@clawboo/db'
 import type {
   Capabilities,
   RunHandle,
@@ -28,7 +28,7 @@ import type {
   TaskHandle,
 } from '@clawboo/executor'
 
-import { getDbPath } from '../db'
+import { getDb, resetDb } from '../db'
 import { runTaskOnRuntime } from '../executorRunner'
 
 const CAPS: Capabilities = {
@@ -84,13 +84,16 @@ describe('executor runner — isolation + claim safety', () => {
     process.env['HOME'] = home
   })
   afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
     if (prevHome === undefined) delete process.env['HOME']
     else process.env['HOME'] = prevHome
     await rm(home, { recursive: true, force: true })
   })
 
   function newTask(): string {
-    return createTask(createDb(getDbPath()), {
+    return createTask(getDb(), {
       title: 'Change some files',
       description: 'file-mutating work',
       status: 'todo',
@@ -103,7 +106,7 @@ describe('executor runner — isolation + claim safety', () => {
     const fake = new ProbeAdapter('claude-code')
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -118,7 +121,7 @@ describe('executor runner — isolation + claim safety', () => {
     // The agent must never have been started.
     expect(fake.startCount).toBe(0)
     // And the task goes back to the queue rather than being stranded.
-    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
+    expect(getTask(getDb(), taskId)?.status).toBe('todo')
   })
 
   it('still runs read-only work without a worktree', async () => {
@@ -126,7 +129,7 @@ describe('executor runner — isolation + claim safety', () => {
     const fake = new ProbeAdapter('claude-code')
 
     const result = await runTaskOnRuntime({
-      db: createDb(getDbPath()),
+      db: getDb(),
       makeAdapter: () => fake,
       taskId,
       assigneeAgentId: 'claude-1',
@@ -144,7 +147,7 @@ describe('executor runner — isolation + claim safety', () => {
 
     await expect(
       runTaskOnRuntime({
-        db: createDb(getDbPath()),
+        db: getDb(),
         makeAdapter: () => fake,
         taskId,
         assigneeAgentId: 'claude-1',
@@ -154,6 +157,6 @@ describe('executor runner — isolation + claim safety', () => {
     ).rejects.toThrow(/driver exploded/)
 
     // The throw propagates, but the task must not be left wedged in_progress.
-    expect(getTask(createDb(getDbPath()), taskId)?.status).toBe('todo')
+    expect(getTask(getDb(), taskId)?.status).toBe('todo')
   })
 })

--- a/apps/web/server/lib/__tests__/executorRunner.rotation.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.rotation.test.ts
@@ -155,6 +155,9 @@ describe('executor runner — session rotation + memory injection', () => {
       taskId,
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(result.ok).toBe(true)
     if (!result.ok) return
@@ -197,6 +200,9 @@ describe('executor runner — session rotation + memory injection', () => {
       taskId,
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
       maxRotations: 2,
     })
     expect(result.ok).toBe(true)
@@ -217,6 +223,9 @@ describe('executor runner — session rotation + memory injection', () => {
       taskId,
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(result.ok && result.status).toBe('done')
     expect(fake.startCount).toBe(1)
@@ -235,6 +244,9 @@ describe('executor runner — session rotation + memory injection', () => {
       taskId,
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(result.ok).toBe(true)
     // Two runs × 5¢ = 10¢ recorded against the agent budget.
@@ -256,6 +268,9 @@ describe('executor runner — session rotation + memory injection', () => {
       makeAdapter: () => fakeOn,
       taskId: taskOn,
       assigneeAgentId: 'claude-1',
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(fakeOn.startedContexts[0]).toContain('<auto-memory')
     expect(fakeOn.startedContexts[0]).toContain('Stripe checkout')
@@ -268,6 +283,9 @@ describe('executor runner — session rotation + memory injection', () => {
       taskId: taskOff,
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this suite exercises rotation mechanics, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(fakeOff.startedContexts[0]).not.toContain('<auto-memory')
   })

--- a/apps/web/server/lib/__tests__/executorRunner.routing.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.routing.test.ts
@@ -190,6 +190,9 @@ describe('executor runner — native-preservation routing (by construction)', ()
       taskId,
       assigneeAgentId: 'agent-1',
       disableMemoryAutoInject: true,
+      // Read-only: this case exercises homeDir routing, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(result).toEqual({ ok: false, reason: 'connected_substrate' })
     expect(fake.startCount).toBe(0) // the adapter was never started
@@ -209,6 +212,9 @@ describe('executor runner — native-preservation routing (by construction)', ()
       taskId: newTask(),
       assigneeAgentId: 'hermes-1',
       disableMemoryAutoInject: true,
+      // Read-only: this case exercises homeDir routing, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(f1.liveCtx()?.homeDir).toBe(expected)
 
@@ -222,6 +228,9 @@ describe('executor runner — native-preservation routing (by construction)', ()
       taskId: newTask('Another task'),
       assigneeAgentId: 'hermes-1',
       disableMemoryAutoInject: true,
+      // Read-only: this case exercises homeDir routing, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(f2.liveCtx()?.homeDir).toBe(expected)
 
@@ -234,6 +243,9 @@ describe('executor runner — native-preservation routing (by construction)', ()
       taskId: newTask('Third task'),
       assigneeAgentId: 'hermes-2',
       disableMemoryAutoInject: true,
+      // Read-only: this case exercises homeDir routing, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(f3.liveCtx()?.homeDir).toBe(
       path.join(home, '.clawboo', 'runtimes', 'hermes', 'hermes-2'),
@@ -249,6 +261,9 @@ describe('executor runner — native-preservation routing (by construction)', ()
       taskId: newTask(),
       assigneeAgentId: 'claude-1',
       disableMemoryAutoInject: true,
+      // Read-only: this case exercises homeDir routing, not file mutation, so it
+      // opts out of worktree isolation explicitly (see isolationForTask).
+      kind: 'research',
     })
     expect(f.liveCtx()).not.toBeNull()
     expect(f.liveCtx()?.homeDir).toBeNull()

--- a/apps/web/server/lib/__tests__/executorRunner.spend.test.ts
+++ b/apps/web/server/lib/__tests__/executorRunner.spend.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unreported-spend visibility.
+ *
+ * Codex and Hermes only emit a cost event `if (ev.usage)`, so a change in a CLI's
+ * output format stops spend reaching the budget ledger without failing anything:
+ * budgets and caps quietly under-count real money. The runner therefore warns when
+ * a pass finishes without reporting any usage or cost.
+ */
+
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTask } from '@clawboo/db'
+import type {
+  Capabilities,
+  RunHandle,
+  RuntimeAdapter,
+  RuntimeEvent,
+  StartOpts,
+  TaskHandle,
+} from '@clawboo/executor'
+
+// Narrow mock: keep every other obs export real, spy only on the structured logger.
+const logStructured = vi.fn()
+vi.mock('../obs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../obs')>()),
+  logStructured: (entry: unknown) => logStructured(entry),
+}))
+
+const { getDb, resetDb } = await import('../db')
+const { runTaskOnRuntime } = await import('../executorRunner')
+
+const CAPS: Capabilities = {
+  streaming: true,
+  mcp: true,
+  worktrees: true,
+  resume: true,
+  toolApproval: true,
+  models: [],
+  contextWindowTokens: 200_000,
+}
+
+/** Emits a terminal, optionally preceded by a cost event. */
+class SpendAdapter implements RuntimeAdapter {
+  readonly participantKind = 'agent' as const
+  constructor(
+    readonly id: string,
+    private readonly reportsCost: boolean,
+  ) {}
+  capabilities(): Capabilities {
+    return CAPS
+  }
+  async health() {
+    return { ok: true }
+  }
+  async start(_t: TaskHandle, opts: StartOpts): Promise<RunHandle> {
+    return { adapterId: this.id, sessionKey: opts.sessionKey, runId: 'rid-0' }
+  }
+  events(run: RunHandle): AsyncIterable<RuntimeEvent> {
+    const reports = this.reportsCost
+    let seq = 0
+    const base = () => ({
+      runId: run.runId ?? run.sessionKey,
+      sessionId: run.sessionKey,
+      ts: 1,
+      seq: (seq += 1),
+    })
+    return (async function* () {
+      if (reports) {
+        yield {
+          ...base(),
+          kind: 'cost',
+          costUsd: 0.01,
+          usage: { inputTokens: 10, outputTokens: 5 },
+          model: 'm',
+        } as RuntimeEvent
+      }
+      yield { ...base(), kind: 'done', reason: 'success', summary: 'ok' } as RuntimeEvent
+    })()
+  }
+  async abort() {}
+  async setModel() {}
+  async writeContext() {}
+}
+
+const spendWarnings = (): unknown[] =>
+  logStructured.mock.calls
+    .map((c) => c[0] as { action?: string })
+    .filter((e) => e?.action === 'spend_unreported')
+
+describe('executor runner — unreported spend is visible', () => {
+  let home: string
+  let prevHome: string | undefined
+
+  beforeEach(async () => {
+    logStructured.mockClear()
+    home = await mkdtemp(path.join(os.tmpdir(), 'clawboo-spend-home-'))
+    await mkdir(path.join(home, '.openclaw', 'clawboo'), { recursive: true })
+    prevHome = process.env['HOME']
+    process.env['HOME'] = home
+  })
+  afterEach(async () => {
+    // Close BEFORE removing the dir: Windows refuses to remove a directory
+    // that still holds an open file. (#140)
+    resetDb()
+    if (prevHome === undefined) delete process.env['HOME']
+    else process.env['HOME'] = prevHome
+    await rm(home, { recursive: true, force: true })
+  })
+
+  function newTask(): string {
+    return createTask(getDb(), {
+      title: 'Look something up',
+      description: 'read-only',
+      status: 'todo',
+      teamId: 'team-1',
+    }).id
+  }
+
+  it('warns when a run reports no usage or cost at all', async () => {
+    const result = await runTaskOnRuntime({
+      db: getDb(),
+      makeAdapter: () => new SpendAdapter('codex', false),
+      taskId: newTask(),
+      assigneeAgentId: 'codex-1',
+      disableMemoryAutoInject: true,
+      kind: 'research',
+    })
+
+    expect(result.ok).toBe(true)
+    const warned = spendWarnings()
+    expect(warned).toHaveLength(1)
+    expect(warned[0]).toMatchObject({ level: 'warn', runtime: 'codex' })
+  })
+
+  it('stays quiet when the runtime does report cost', async () => {
+    const result = await runTaskOnRuntime({
+      db: getDb(),
+      makeAdapter: () => new SpendAdapter('codex', true),
+      taskId: newTask(),
+      assigneeAgentId: 'codex-1',
+      disableMemoryAutoInject: true,
+      kind: 'research',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(spendWarnings()).toHaveLength(0)
+  })
+})

--- a/apps/web/server/lib/executorRunner.ts
+++ b/apps/web/server/lib/executorRunner.ts
@@ -157,7 +157,15 @@ export interface RunTaskInput {
 export type RunTaskResult =
   | {
       ok: false
-      reason: 'not_found' | 'conflict' | 'too_deep' | 'connected_substrate' | 'budget_paused'
+      reason:
+        | 'not_found'
+        | 'conflict'
+        | 'too_deep'
+        | 'connected_substrate'
+        | 'budget_paused'
+        // Isolation was required for a file-mutating task but could not be
+        // provisioned; the run is refused rather than executed un-isolated.
+        | 'workspace_unavailable'
     }
   | {
       ok: true
@@ -198,14 +206,26 @@ function formatResumeContext(r: ResumeState): string {
   return parts.join('\n\n')
 }
 
+/**
+ * Outcome of acquiring a workspace.
+ *
+ * `cwd: null` with `ok: true` is a LEGITIMATE no-worktree run (a runtime that
+ * doesn't do worktrees, or read-only research/review work that mutates no files).
+ * `ok: false` means isolation was REQUIRED for this task but could not be
+ * provided — the caller must fail the run rather than fall back to the server's
+ * own working directory, which is what the drivers inherit when `cwd` is null.
+ */
+type WorkspaceOutcome =
+  { ok: true; cwd: string | null; resume: ResumeState | null } | { ok: false; reason: string }
+
 /** Acquire a worktree for the run — reuse an existing one (cross-runtime resume) or provision fresh. */
 async function acquireWorkspace(
   taskId: string,
   caps: Capabilities,
   repoPath: string | null | undefined,
   kind: string,
-): Promise<{ cwd: string | null; resume: ResumeState | null }> {
-  if (!caps.worktrees) return { cwd: null, resume: null }
+): Promise<WorkspaceOutcome> {
+  if (!caps.worktrees) return { ok: true, cwd: null, resume: null }
 
   const existing = await getTaskWorkspace(taskId)
   if (existing.ok && existing.workspace?.worktreePath) {
@@ -219,7 +239,7 @@ async function acquireWorkspace(
       existing.workspace.status === 'stale' ||
       !existsSync(wtPath) ||
       (repoPath ? !(await isWorktreeRegistered(repoPath, wtPath)) : false)
-    if (!reaped) return { cwd: wtPath, resume: existing.resume }
+    if (!reaped) return { ok: true, cwd: wtPath, resume: existing.resume }
     if (repoPath) {
       const resumed = await resumeTaskWorkspace(taskId, { repoPath })
       if (resumed.ok) {
@@ -229,21 +249,39 @@ async function acquireWorkspace(
         } catch {
           resume = null
         }
-        return { cwd: resumed.worktree.worktreePath, resume }
+        return { ok: true, cwd: resumed.worktree.worktreePath, resume }
       }
     }
   }
 
-  if (!repoPath || isolationForTask(kind) !== 'worktree') return { cwd: null, resume: null }
+  // Read-only work (research / review) mutates no files, so it legitimately runs
+  // without a worktree.
+  if (isolationForTask(kind) !== 'worktree') return { ok: true, cwd: null, resume: null }
+
+  // From here the task DOES mutate files, so isolation is mandatory. Returning a
+  // null cwd here would hand the driver the server's own working directory —
+  // which the drivers run in with permission gates bypassed. Fail instead.
+  if (!repoPath) {
+    return {
+      ok: false,
+      reason:
+        'This task changes files, so it needs an isolated git worktree, but no repository path was provided for it.',
+    }
+  }
   const prov = await provisionTaskWorkspace(taskId, { repoPath, kind })
-  if (!prov.ok) return { cwd: null, resume: null }
+  if (!prov.ok) {
+    return {
+      ok: false,
+      reason: `Could not provision an isolated git worktree for this task at ${repoPath}.`,
+    }
+  }
   let resume: ResumeState | null = null
   try {
     resume = await reconstructState(prov.worktree.worktreePath)
   } catch {
     resume = null
   }
-  return { cwd: prov.worktree.worktreePath, resume }
+  return { ok: true, cwd: prov.worktree.worktreePath, resume }
 }
 
 /**
@@ -262,6 +300,10 @@ export async function runTaskOnRuntime(input: RunTaskInput): Promise<RunTaskResu
   const parentTaskId = !input.parentTraceparent
     ? (getTask(input.db, input.taskId)?.parentTaskId ?? null)
     : null
+  // Tracks whether the atomic claim landed, so an UNEXPECTED throw below can put
+  // the task back instead of leaving it wedged in `in_progress` until the stale
+  // sweep. Every expected outcome already releases on its own path.
+  const claimState: ClaimState = { claimed: false }
   const run = (): Promise<RunTaskResult> =>
     withTaskSpan(
       {
@@ -273,7 +315,7 @@ export async function runTaskOnRuntime(input: RunTaskInput): Promise<RunTaskResu
         parentTraceparent: input.parentTraceparent ?? null,
         parentSpanId: parentTaskId ? spanIdFor(parentTaskId) : null,
       },
-      (span) => runTaskInner(input, span),
+      (span) => runTaskInner(input, span, claimState),
     )
 
   // Probe capabilities once (constructing the adapter is side-effect-free — no
@@ -287,10 +329,40 @@ export async function runTaskOnRuntime(input: RunTaskInput): Promise<RunTaskResu
     resolveRuntimeIntegration(probe.capabilities()).home.kind === 'persistent'
       ? runtimeIdentityHomePath(probe.id, input.assigneeAgentId)
       : null
-  return homeKey ? homeDispatchMutex.run(homeKey, run) : run()
+  try {
+    return await (homeKey ? homeDispatchMutex.run(homeKey, run) : run())
+  } catch (err) {
+    // Safety net for an UNEXPECTED throw (a driver blowing up, a disk error mid-run):
+    // without this the task keeps its claim and sits `in_progress` with no runner
+    // behind it until the stale sweep. Release so it is retryable, then rethrow —
+    // the failure itself is still the caller's to handle.
+    if (claimState.claimed) {
+      try {
+        // ONLY release a task that is still mid-run. A throw can also happen after
+        // the run reached a terminal state (e.g. writing the handoff on the success
+        // path); releasing then would resurrect a finished task and clear its
+        // verification verdict, which is worse than the stranded claim we're fixing.
+        if (input.db && getTask(input.db, input.taskId)?.status === 'in_progress') {
+          releaseTask(input.db, input.taskId)
+        }
+      } catch {
+        // Best effort — never mask the original error with a cleanup failure.
+      }
+    }
+    throw err
+  }
 }
 
-async function runTaskInner(input: RunTaskInput, span: SpanCtx): Promise<RunTaskResult> {
+/** Mutable claim flag shared with `runTaskInner` (see the safety net above). */
+interface ClaimState {
+  claimed: boolean
+}
+
+async function runTaskInner(
+  input: RunTaskInput,
+  span: SpanCtx,
+  claimState: ClaimState = { claimed: false },
+): Promise<RunTaskResult> {
   const { db, taskId, assigneeAgentId } = input
   const compact = input.compact ?? defaultCompact
   const maxDepth = input.maxSpawnDepth ?? MAX_SPAWN_DEPTH
@@ -341,6 +413,9 @@ async function runTaskInner(input: RunTaskInput, span: SpanCtx): Promise<RunTask
   // Atomic claim — a lost claim is a conflict and is NEVER retried.
   const claim = claimTask(db, taskId, assigneeAgentId, runtimeId)
   if (!claim.ok) return { ok: false, reason: 'conflict' }
+  // From here the task is ours; an unexpected throw must release it (see the
+  // safety net in runTaskOnRuntime).
+  claimState.claimed = true
 
   const exec = createExecutionProcess(db, {
     taskId,
@@ -359,7 +434,31 @@ async function runTaskInner(input: RunTaskInput, span: SpanCtx): Promise<RunTask
   })
 
   const kind = input.kind ?? 'code'
-  const { cwd, resume } = await acquireWorkspace(taskId, caps, input.repoPath, kind)
+  const workspace = await acquireWorkspace(taskId, caps, input.repoPath, kind)
+
+  // Isolation was required but unavailable. Running now would execute the agent
+  // in the SERVER's own working directory with permission gates bypassed, so the
+  // run is refused and the task released for a human to fix the repo path.
+  if (!workspace.ok) {
+    addComment(db, taskId, `[blocked: no isolation] ${workspace.reason}`, 'system')
+    completeExecutionProcess(db, exec.id, {
+      status: 'failed',
+      error: `workspace_unavailable: ${workspace.reason}`,
+    })
+    emitEvent(db, {
+      kind: 'execution_completed',
+      traceId: span.traceId,
+      spanId: span.spanId,
+      taskId,
+      teamId: task.teamId,
+      agentId: assigneeAgentId,
+      runtime: runtimeId,
+      data: { execId: exec.id, status: 'failed', error: 'workspace_unavailable' },
+    })
+    releaseTask(db, taskId)
+    return { ok: false, reason: 'workspace_unavailable' }
+  }
+  const { cwd, resume } = workspace
 
   // Memory auto-injection: seed the most-relevant facts for the task into the
   // VOLATILE tier (cache-safe — never the cached prefix, per the KV-cache

--- a/apps/web/server/lib/executorRunner.ts
+++ b/apps/web/server/lib/executorRunner.ts
@@ -71,6 +71,7 @@ import { buildMemoryInjection } from './memoryInjection'
 import {
   alertHarnessBug,
   emitEvent,
+  logStructured,
   recordToolSpan,
   spanIdFor,
   withTaskSpan,
@@ -230,10 +231,10 @@ async function acquireWorkspace(
   // substrate that runs inside its Gateway-owned workspace and is refused by
   // this runner before the claim (see the `connected_substrate` guard). Every
   // SPAWNED runtime declares `worktrees: true` and is therefore covered by the
-  // file-mutating refusal further down, which is the case that actually matters:
-  // those inherit THIS process's cwd when `cwd` is null. Do not "harden" this
-  // into a refusal — it breaks the deliberate `worktrees: false` fakes that let
-  // runner tests skip git setup, and guards a path that cannot be reached.
+  // file-mutating refusal further down, which is the case that matters: those
+  // inherit this process's cwd when `cwd` is null. Keep this branch permissive —
+  // refusing here guards an unreachable path and breaks the `worktrees: false`
+  // fakes that let runner tests skip git setup.
   if (!caps.worktrees) return { ok: true, cwd: null, resume: null }
 
   const existing = await getTaskWorkspace(taskId)
@@ -660,6 +661,11 @@ async function runTaskInner(
     inputTokens = 0
     outputTokens = 0
     doneReason = 'error'
+    // Whether the runtime reported ANY spend for this pass. Codex and Hermes only
+    // emit a cost event `if (ev.usage)`, so a CLI output-format drift silently
+    // yields zero recorded spend — the budget ledger would then under-count real
+    // money with no signal at all. Surfaced after the loop.
+    let sawSpend = false
 
     for await (const ev of adapter.events(run)) {
       if (ev.kind === 'text-delta') {
@@ -680,6 +686,7 @@ async function runTaskInner(
                 })
               : 0
         const costEstimated = ev.costUsd == null
+        sawSpend = true
         costUsd = usd
         if (ev.usage) {
           inputTokens = ev.usage.inputTokens
@@ -849,13 +856,39 @@ async function runTaskInner(
       } else if (ev.kind === 'done') {
         doneReason = ev.reason
         summary = ev.summary || lastText
-        if (ev.costUsd != null) costUsd = ev.costUsd
+        if (ev.costUsd != null) {
+          sawSpend = true
+          costUsd = ev.costUsd
+        }
         if (ev.usage) {
           inputTokens = ev.usage.inputTokens
           outputTokens = ev.usage.outputTokens
         }
         break
       }
+    }
+
+    // A pass that finished its stream without reporting spend means the budget
+    // ledger under-counts this run. Codex and Hermes emit a cost event only
+    // `if (ev.usage)`, so a change in a CLI's output format stops spend reaching
+    // the ledger without failing anything. An aborted pass is excluded: it may
+    // legitimately not have billed.
+    if (!sawSpend && doneReason !== 'aborted') {
+      logStructured({
+        level: 'warn',
+        component: 'executorRunner',
+        action: 'spend_unreported',
+        correlationId: span.traceId,
+        traceId: span.traceId,
+        spanId: span.spanId,
+        taskId,
+        agentId: assigneeAgentId,
+        runtime: runtimeId,
+        error:
+          'Run finished without reporting any usage or cost, so no spend was recorded. ' +
+          'Budgets and caps under-count for this run; suspect a runtime output-format change.',
+        output: { doneReason },
+      })
     }
 
     // External cancel forces the aborted terminal regardless of how the runtime

--- a/apps/web/server/lib/executorRunner.ts
+++ b/apps/web/server/lib/executorRunner.ts
@@ -225,6 +225,15 @@ async function acquireWorkspace(
   repoPath: string | null | undefined,
   kind: string,
 ): Promise<WorkspaceOutcome> {
+  // `worktrees: false` means the runtime MANAGES ITS OWN workspace, not that it
+  // has none. The only adapter that declares it is OpenClaw, a connected
+  // substrate that runs inside its Gateway-owned workspace and is refused by
+  // this runner before the claim (see the `connected_substrate` guard). Every
+  // SPAWNED runtime declares `worktrees: true` and is therefore covered by the
+  // file-mutating refusal further down, which is the case that actually matters:
+  // those inherit THIS process's cwd when `cwd` is null. Do not "harden" this
+  // into a refusal — it breaks the deliberate `worktrees: false` fakes that let
+  // runner tests skip git setup, and guards a path that cannot be reached.
   if (!caps.worktrees) return { ok: true, cwd: null, resume: null }
 
   const existing = await getTaskWorkspace(taskId)
@@ -342,6 +351,14 @@ export async function runTaskOnRuntime(input: RunTaskInput): Promise<RunTaskResu
         // the run reached a terminal state (e.g. writing the handoff on the success
         // path); releasing then would resurrect a finished task and clear its
         // verification verdict, which is worse than the stranded claim we're fixing.
+        // Close the execution row first: releasing the task without it leaves an
+        // orphaned `running` execution that only boot-time reconciliation clears.
+        if (claimState.execId) {
+          completeExecutionProcess(input.db, claimState.execId, {
+            status: 'failed',
+            error: err instanceof Error ? err.message : String(err),
+          })
+        }
         if (input.db && getTask(input.db, input.taskId)?.status === 'in_progress') {
           releaseTask(input.db, input.taskId)
         }
@@ -353,9 +370,11 @@ export async function runTaskOnRuntime(input: RunTaskInput): Promise<RunTaskResu
   }
 }
 
-/** Mutable claim flag shared with `runTaskInner` (see the safety net above). */
+/** Mutable run state shared with `runTaskInner` (see the safety net above). */
 interface ClaimState {
   claimed: boolean
+  /** Set once the execution row exists, so an unexpected throw can close it. */
+  execId?: string
 }
 
 async function runTaskInner(
@@ -422,6 +441,9 @@ async function runTaskInner(
     executorType: runtimeId,
     runReason: degr.resumeViaHandoff ? 'resume-via-handoff' : 'run',
   })
+  // Share it with the outer safety net so an unexpected throw can close the row
+  // instead of leaving it `running` with no runner behind it.
+  claimState.execId = exec.id
   emitEvent(db, {
     kind: 'execution_started',
     traceId: span.traceId,

--- a/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
@@ -187,6 +187,22 @@ describe('shutdownLiveSubprocesses — waits for children, bounded', () => {
     expect(elapsed).toBeLessThan(2_000) // but it gave up — shutdown cannot hang
   })
 
+  it('does not let a child that starts DURING shutdown escape', async () => {
+    const first = await startOne() // keeps the wait pending (never closes)
+
+    const shutdown = shutdownLiveSubprocesses(200)
+    // A run that spawns after the snapshot was taken.
+    const late = await startOne()
+    const out = await shutdown
+
+    // The late child was not in the snapshot...
+    expect(out.signalled).toBe(1)
+    // ...so it must remain tracked for the synchronous fallback rather than being
+    // silently dropped, which would let it outlive the server.
+    expect(killLiveSubprocesses()).toBe(1)
+    expect(first).not.toBe(late)
+  })
+
   it('clears the registry so a second pass is a no-op', async () => {
     await startOne()
     await shutdownLiveSubprocesses(60)

--- a/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
@@ -12,27 +12,48 @@ interface SpawnCall {
   args: string[]
   opts: Record<string, unknown>
 }
-const spawnState = vi.hoisted(() => ({ calls: [] as SpawnCall[] }))
+const spawnState = vi.hoisted(() => ({
+  calls: [] as SpawnCall[],
+  children: [] as Record<string, unknown>[],
+}))
 
 vi.mock('node:child_process', () => {
   const makeChild = (): unknown => {
+    const listeners: Record<string, ((...a: unknown[]) => void)[]> = {}
     const child: Record<string, unknown> = {
       stdout: { on: () => undefined },
       stderr: { on: () => undefined },
       kill: () => undefined,
+      // DELIBERATELY no `pid`: killProcessTree early-returns without one, so a
+      // test can never signal a real process group via `process.kill(-pid)`.
+      exitCode: null,
+      signalCode: null,
+      // Let a test drive the lifecycle the shutdown path actually waits on.
+      emitClose: () => {
+        child['exitCode'] = 0
+        for (const fn of listeners['close'] ?? []) fn(0, null)
+      },
     }
-    child['on'] = () => child // chainable no-op for 'error'/'close'
+    const add = (ev: string, fn: (...a: unknown[]) => void): unknown => {
+      ;(listeners[ev] ??= []).push(fn)
+      return child
+    }
+    child['on'] = add
+    child['once'] = add
     return child
   }
   return {
     spawn: (command: string, args: string[], opts: Record<string, unknown>) => {
       spawnState.calls.push({ command, args, opts })
-      return makeChild()
+      const child = makeChild()
+      spawnState.children.push(child as Record<string, unknown>)
+      return child
     },
   }
 })
 
-const { createSpawnDriver, killLiveSubprocesses } = await import('../subprocess')
+const { createSpawnDriver, killLiveSubprocesses, shutdownLiveSubprocesses } =
+  await import('../subprocess')
 
 describe('createSpawnDriver — never spawns with a shell', () => {
   it('passes shell:false and the untrusted prompt verbatim as argv', async () => {
@@ -114,5 +135,61 @@ describe('killLiveSubprocesses — shutdown reaps running children', () => {
 
   it('is safe to call when nothing is running', () => {
     expect(killLiveSubprocesses()).toBe(0)
+  })
+})
+
+// `killLiveSubprocesses` only SENDS SIGTERM; killTree then schedules a SIGKILL
+// escalation on a timer. A signal handler that calls process.exit(0) right after
+// destroys that timer with the process, so a child ignoring SIGTERM outlives the
+// server. Shutdown therefore waits — but must never be able to hang.
+describe('shutdownLiveSubprocesses — waits for children, bounded', () => {
+  const startOne = async () => {
+    await createSpawnDriver({
+      resolve: async () => ({ command: '/abs/codex', args: ['exec', 'work'] }),
+      parseLine: () => [],
+      onClose: () => [],
+    }).start()
+    return spawnState.children[spawnState.children.length - 1]!
+  }
+
+  beforeEach(() => {
+    spawnState.children.length = 0
+    killLiveSubprocesses() // start from an empty registry
+  })
+
+  it('returns immediately when nothing is running', async () => {
+    await expect(shutdownLiveSubprocesses(50)).resolves.toEqual({ signalled: 0, exited: 0 })
+  })
+
+  it('waits for a child to close and reports it exited', async () => {
+    const child = await startOne()
+    // Close on the next tick, as a real child would after SIGTERM.
+    setTimeout(() => (child['emitClose'] as () => void)(), 5)
+
+    const started = Date.now()
+    const out = await shutdownLiveSubprocesses(2_000)
+
+    expect(out).toEqual({ signalled: 1, exited: 1 })
+    // Resolved on the close, NOT by burning the full timeout.
+    expect(Date.now() - started).toBeLessThan(1_000)
+  })
+
+  it('gives up on the deadline when a child never dies, instead of hanging', async () => {
+    await startOne() // never emits close — the stuck-child case
+
+    const started = Date.now()
+    const out = await shutdownLiveSubprocesses(60)
+    const elapsed = Date.now() - started
+
+    expect(out.signalled).toBe(1)
+    expect(out.exited).toBe(0) // it never closed
+    expect(elapsed).toBeGreaterThanOrEqual(50) // it did wait
+    expect(elapsed).toBeLessThan(2_000) // but it gave up — shutdown cannot hang
+  })
+
+  it('clears the registry so a second pass is a no-op', async () => {
+    await startOne()
+    await shutdownLiveSubprocesses(60)
+    await expect(shutdownLiveSubprocesses(60)).resolves.toEqual({ signalled: 0, exited: 0 })
   })
 })

--- a/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/subprocess.spawn.test.ts
@@ -32,7 +32,7 @@ vi.mock('node:child_process', () => {
   }
 })
 
-const { createSpawnDriver } = await import('../subprocess')
+const { createSpawnDriver, killLiveSubprocesses } = await import('../subprocess')
 
 describe('createSpawnDriver — never spawns with a shell', () => {
   it('passes shell:false and the untrusted prompt verbatim as argv', async () => {
@@ -86,5 +86,33 @@ describe('createSpawnDriver — never spawns with a shell', () => {
       if (prevStudio === undefined) delete process.env['STUDIO_ACCESS_TOKEN']
       else process.env['STUDIO_ACCESS_TOKEN'] = prevStudio
     }
+  })
+})
+
+// A spawned runtime child is detached and never unref'd, so it OUTLIVES the server
+// unless shutdown reaps it explicitly. Without that, a Ctrl-C leaves an agent CLI
+// running against a task worktree while boot reconciliation hands that task to
+// another runner — two live runs, and untracked provider spend.
+describe('killLiveSubprocesses — shutdown reaps running children', () => {
+  it('reports the children it terminated and empties the registry', async () => {
+    killLiveSubprocesses() // start from a clean registry
+
+    const mk = () =>
+      createSpawnDriver({
+        resolve: async () => ({ command: '/abs/codex', args: ['exec', 'work'] }),
+        parseLine: () => [],
+        onClose: () => [],
+      })
+    await mk().start()
+    await mk().start()
+
+    // Both live children are reaped...
+    expect(killLiveSubprocesses()).toBe(2)
+    // ...and the registry is cleared, so a second pass is a no-op.
+    expect(killLiveSubprocesses()).toBe(0)
+  })
+
+  it('is safe to call when nothing is running', () => {
+    expect(killLiveSubprocesses()).toBe(0)
   })
 })

--- a/apps/web/server/lib/runtimes/subprocess.ts
+++ b/apps/web/server/lib/runtimes/subprocess.ts
@@ -17,6 +17,7 @@ import path from 'node:path'
 import { isWindows } from '../platform'
 import { buildChildEnv } from './childEnv'
 import { killProcessTree } from './killTree'
+import { resolveWindowsSpawn } from './winSpawn'
 
 /**
  * Every spawned runtime child that is still running.
@@ -47,7 +48,68 @@ export function killLiveSubprocesses(): number {
   liveChildren.clear()
   return count
 }
-import { resolveWindowsSpawn } from './winSpawn'
+
+/**
+ * How long shutdown waits for signalled children to actually die.
+ *
+ * Must exceed `killTree`'s SIGTERM→SIGKILL grace (3s): exiting sooner would kill
+ * the escalation timer before it fires, leaving a child that ignores SIGTERM
+ * running after the server is gone.
+ */
+export const SHUTDOWN_WAIT_MS = 5_000
+
+/**
+ * Signal every live runtime child and WAIT for it to exit (bounded).
+ *
+ * `killLiveSubprocesses` only sends SIGTERM; `killProcessTree` then schedules a
+ * SIGKILL escalation on a timer. A signal handler that calls `process.exit(0)`
+ * immediately afterwards kills that timer with the process, so a child ignoring
+ * SIGTERM survives. Awaiting here gives the escalation room to run.
+ *
+ * Bounded by design: a hung child must never prevent the server from exiting, so
+ * the wait resolves on the deadline regardless. Never rejects.
+ */
+export async function shutdownLiveSubprocesses(
+  timeoutMs: number = SHUTDOWN_WAIT_MS,
+): Promise<{ signalled: number; exited: number }> {
+  const children = [...liveChildren]
+  if (children.length === 0) return { signalled: 0, exited: 0 }
+
+  for (const child of children) {
+    try {
+      killProcessTree(child)
+    } catch {
+      // Best effort — one stubborn child must not block the rest of shutdown.
+    }
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs)
+    // Never let the deadline itself hold the event loop open.
+    timer.unref?.()
+  })
+  const allClosed = Promise.all(
+    children.map((child) =>
+      // Already reaped (its 'close' fired) — nothing left to await.
+      child.exitCode !== null || child.signalCode !== null
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => child.once('close', () => resolve())),
+    ),
+  ).then(() => undefined)
+
+  try {
+    await Promise.race([allClosed, deadline])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+
+  // Whatever is still tracked did not close in time; drop it so a second pass is
+  // a no-op and the registry cannot leak across a restart.
+  const exited = children.length - liveChildren.size
+  liveChildren.clear()
+  return { signalled: children.length, exited }
+}
 
 export interface ResolvedSpawn {
   command: string

--- a/apps/web/server/lib/runtimes/subprocess.ts
+++ b/apps/web/server/lib/runtimes/subprocess.ts
@@ -32,11 +32,19 @@ import { resolveWindowsSpawn } from './winSpawn'
 const liveChildren = new Set<ChildProcess>()
 
 /**
+ * Set once shutdown has begun. A run that spawns after this point is killed as
+ * soon as it registers: shutdown has already taken its snapshot, so an unsignalled
+ * late child would otherwise outlive the server.
+ */
+let shuttingDown = false
+
+/**
  * Kill every still-running runtime child. Called from the server's shutdown path
  * so a graceful stop doesn't orphan agent processes. Best-effort and synchronous:
  * it runs inside a signal handler, just before `process.exit`.
  */
 export function killLiveSubprocesses(): number {
+  shuttingDown = false
   const count = liveChildren.size
   for (const child of liveChildren) {
     try {
@@ -72,6 +80,7 @@ export const SHUTDOWN_WAIT_MS = 5_000
 export async function shutdownLiveSubprocesses(
   timeoutMs: number = SHUTDOWN_WAIT_MS,
 ): Promise<{ signalled: number; exited: number }> {
+  shuttingDown = true
   const children = [...liveChildren]
   if (children.length === 0) return { signalled: 0, exited: 0 }
 
@@ -104,10 +113,11 @@ export async function shutdownLiveSubprocesses(
     if (timer) clearTimeout(timer)
   }
 
-  // Whatever is still tracked did not close in time; drop it so a second pass is
-  // a no-op and the registry cannot leak across a restart.
-  const exited = children.length - liveChildren.size
-  liveChildren.clear()
+  // Untrack only what this pass signalled. A child that registered during the wait
+  // was killed on registration but stays tracked, so the synchronous fallback in
+  // `cleanup()` still sees it rather than it vanishing from the registry.
+  const exited = children.reduce((n, c) => n + (liveChildren.has(c) ? 0 : 1), 0)
+  for (const child of children) liveChildren.delete(child)
   return { signalled: children.length, exited }
 }
 
@@ -199,6 +209,15 @@ export function createSpawnDriver<N>(cfg: SpawnDriverConfig<N>): SpawnDriver<N> 
       // Track it so a server shutdown can reap it instead of orphaning it.
       // (Deregistered in the 'close' handler below.)
       liveChildren.add(child)
+      if (shuttingDown) {
+        // Spawned after shutdown began — it missed the snapshot, so signal it now
+        // rather than let it run on past process exit.
+        try {
+          killProcessTree(child)
+        } catch {
+          // Best effort — it may already be gone.
+        }
+      }
       const spawned = child
       let buf = ''
       child.stdout?.on('data', (d: Buffer) => {

--- a/apps/web/server/lib/runtimes/subprocess.ts
+++ b/apps/web/server/lib/runtimes/subprocess.ts
@@ -17,6 +17,36 @@ import path from 'node:path'
 import { isWindows } from '../platform'
 import { buildChildEnv } from './childEnv'
 import { killProcessTree } from './killTree'
+
+/**
+ * Every spawned runtime child that is still running.
+ *
+ * Children are spawned `detached` (POSIX) so `abort()` can signal the whole
+ * process group, and they are deliberately never `unref`'d. That means a server
+ * exit does NOT take them with it: without this registry a Ctrl-C or crash leaves
+ * an agent CLI running against a task worktree, still burning provider spend,
+ * while boot-time reconciliation releases that task for another runner to claim —
+ * two live runs on one worktree.
+ */
+const liveChildren = new Set<ChildProcess>()
+
+/**
+ * Kill every still-running runtime child. Called from the server's shutdown path
+ * so a graceful stop doesn't orphan agent processes. Best-effort and synchronous:
+ * it runs inside a signal handler, just before `process.exit`.
+ */
+export function killLiveSubprocesses(): number {
+  const count = liveChildren.size
+  for (const child of liveChildren) {
+    try {
+      killProcessTree(child)
+    } catch {
+      // Best effort — one stubborn child must not block the rest of shutdown.
+    }
+  }
+  liveChildren.clear()
+  return count
+}
 import { resolveWindowsSpawn } from './winSpawn'
 
 export interface ResolvedSpawn {
@@ -104,6 +134,10 @@ export function createSpawnDriver<N>(cfg: SpawnDriverConfig<N>): SpawnDriver<N> 
         ...(plan.windowsVerbatimArguments ? { windowsVerbatimArguments: true } : {}),
         stdio: ['ignore', 'pipe', 'pipe'],
       })
+      // Track it so a server shutdown can reap it instead of orphaning it.
+      // (Deregistered in the 'close' handler below.)
+      liveChildren.add(child)
+      const spawned = child
       let buf = ''
       child.stdout?.on('data', (d: Buffer) => {
         const s = d.toString()
@@ -124,6 +158,8 @@ export function createSpawnDriver<N>(cfg: SpawnDriverConfig<N>): SpawnDriver<N> 
           push(ev)
       })
       child.on('close', (code: number | null, signal: NodeJS.Signals | null) => {
+        // No longer running — drop it from the shutdown-reap registry.
+        liveChildren.delete(spawned)
         if (buf.trim()) for (const ev of cfg.parseLine(buf)) push(ev)
         for (const ev of cfg.onClose(code, signal, stdoutAll, stderrAll)) push(ev)
       })

--- a/docs/intro/index.md
+++ b/docs/intro/index.md
@@ -5,7 +5,7 @@ description: Clawboo is an open-source, local-first multi-agent mission-control 
 
 Clawboo is an open-source, local-first dashboard and orchestrator for teams of AI agents. You install it with `npm install -g clawboo` and run `clawboo` (or `npx clawboo` to try it without installing), and it runs entirely on your machine: a single Node server binds to loopback by default, persists everything to one local SQLite file, and opens a browser dashboard. There is no cloud account, no managed control plane, and no telemetry leaving your laptop.
 
-What makes Clawboo more than a chat wrapper is that it runs _heterogeneous_ runtimes as one team. Native agents are built in; paste a provider key and Clawboo runs them in-process, while Claude Code, Codex, Hermes, and the OpenClaw Gateway connect as peer teammates in the same room. They share one board, one memory, and one capability inventory, and their autonomous work is independently verified before it counts as done.
+Clawboo's core capability is orchestration: it runs _heterogeneous_ runtimes as one team. Native agents are built in; paste a provider key and Clawboo runs them in-process, while Claude Code, Codex, Hermes, and the OpenClaw Gateway connect as peer teammates in the same room. They share one board, one memory, and one capability inventory, and their autonomous file-mutating work is independently verified before it counts as done.
 
 ![The Clawboo team space: Boo Zero and three specialists in a live team graph, with delegated task cards completing in the group chat below](/images/team-space.png)
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=22.12.0",
     "pnpm": ">=9.0.0"
   },
   "packageManager": "pnpm@9.15.0"

--- a/packages/adapters/claude-code/src/adapter.ts
+++ b/packages/adapters/claude-code/src/adapter.ts
@@ -43,6 +43,9 @@ export class ClaudeCodeAdapter implements RuntimeAdapter {
       mcp: true,
       worktrees: true,
       resume: true,
+      // Capability of the runtime, not of a board run: clawboo drives this
+      // runtime headless, where the SDK run sets permissionMode: 'bypassPermissions'.
+      // Isolation for those runs comes from the per-task worktree instead.
       toolApproval: true,
       models: ['sonnet', 'opus', 'haiku'],
       // Claude (Sonnet/Opus) ships a 200k-token context window — drives the

--- a/packages/adapters/codex/src/adapter.ts
+++ b/packages/adapters/codex/src/adapter.ts
@@ -39,6 +39,9 @@ export class CodexAdapter implements RuntimeAdapter {
       mcp: true,
       worktrees: true,
       resume: true,
+      // Capability of the runtime, not of a board run: clawboo drives this
+      // runtime headless, where the CLI run passes --dangerously-bypass-approvals-and-sandbox.
+      // Isolation for those runs comes from the per-task worktree instead.
       toolApproval: true,
       models: ['gpt-5-codex', 'gpt-5', 'o4-mini'],
       // Native-preservation seam: a wrapped one-shot with a PERSISTENT per-identity

--- a/packages/adapters/hermes/src/adapter.ts
+++ b/packages/adapters/hermes/src/adapter.ts
@@ -41,6 +41,9 @@ export class HermesAdapter implements RuntimeAdapter {
       mcp: true,
       worktrees: true,
       resume: true,
+      // Capability of the runtime, not of a board run: clawboo drives this
+      // runtime headless, where the CLI run passes --yolo.
+      // Isolation for those runs comes from the per-task worktree instead.
       toolApproval: true,
       models: [], // provider-defined — Hermes resolves models via its own provider config
       // Native-preservation seam: a wrapped one-shot whose value COMPOUNDS in

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -44,7 +44,7 @@
     "@clawboo/governance": "workspace:*",
     "@clawboo/obs": "workspace:*",
     "@noble/ed25519": "^2.1.0",
-    "better-sqlite3": "^11.8.0",
+    "better-sqlite3": "^13.0.1",
     "drizzle-orm": "^0.45.2",
     "zod": "^3.25.0"
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -44,7 +44,7 @@
     "@clawboo/governance": "workspace:*",
     "@clawboo/obs": "workspace:*",
     "@noble/ed25519": "^2.1.0",
-    "better-sqlite3": "^13.0.1",
+    "better-sqlite3": "^12.11.1",
     "drizzle-orm": "^0.45.2",
     "zod": "^3.25.0"
   },

--- a/packages/executor/src/types.ts
+++ b/packages/executor/src/types.ts
@@ -41,7 +41,15 @@ export interface Capabilities {
   worktrees: boolean
   /** Can resume a prior session from a serialized handle. */
   resume: boolean
-  /** Surfaces tool-approval gates the host must resolve. */
+  /**
+   * The RUNTIME can surface tool-approval gates for a host to resolve.
+   *
+   * This describes what the runtime is capable of, NOT whether a given host path
+   * actually gates. Clawboo's per-task runner deliberately spawns the CLI
+   * runtimes headless with their gates bypassed and relies on the per-task
+   * worktree as the isolation boundary, so `true` here must not be read as
+   * "board runs are approval-gated".
+   */
   toolApproval: boolean
   /** Model identifiers this runtime can use (may be empty when unknown). */
   models: string[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.1
       better-sqlite3:
-        specifier: 13.0.1
-        version: 13.0.1
+        specifier: 12.11.1
+        version: 12.11.1
       chalk:
         specifier: ^5.4.0
         version: 5.6.2
@@ -281,7 +281,7 @@ importers:
         version: 4.0.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(gel@2.2.0)
       elkjs:
         specifier: ^0.12.0
         version: 0.12.0
@@ -348,7 +348,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(vite@8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 6.0.5(vite@8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       concurrently:
         specifier: ^10.0.4
         version: 10.0.4
@@ -369,10 +369,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.2.1
-        version: 8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^5.1.0
-        version: 5.1.4(typescript@5.9.3)(vite@8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 5.1.4(typescript@5.9.3)(vite@8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   docs:
     devDependencies:
@@ -614,11 +614,11 @@ importers:
         specifier: ^2.1.0
         version: 2.3.0
       better-sqlite3:
-        specifier: ^13.0.1
-        version: 13.0.1
+        specifier: ^12.11.1
+        version: 12.11.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(gel@2.2.0)
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -3370,13 +3370,22 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@13.0.1:
-    resolution: {integrity: sha512-LYpmOXdkpQYf4wmlxkdzW01XGlOXNIbjLg45yNkh0FQ4814VbK9PdOFmhZpYbej+EZtR/i3FDdhEG98HqZdgnA==}
-    engines: {node: '>=22'}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -3398,6 +3407,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -3468,6 +3480,9 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -3697,9 +3712,17 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4035,6 +4058,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -4113,6 +4140,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4169,6 +4199,9 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4217,6 +4250,9 @@ packages:
 
   get-tsconfig@4.14.1:
     resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4332,6 +4368,9 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4358,6 +4397,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -4985,6 +5027,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5006,6 +5052,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -5053,6 +5102,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5060,9 +5112,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-addon-api@8.9.1:
-    resolution: {integrity: sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==}
-    engines: {node: ^18 || ^20 || >= 21}
+  node-abi@3.87.0:
+    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+    engines: {node: '>=10'}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -5288,6 +5340,12 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5359,6 +5417,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -5407,6 +5469,10 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5511,6 +5577,9 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -5585,6 +5654,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-icons@16.28.0:
     resolution: {integrity: sha512-sQPR5AtK/ijRjou7zw7mlLp08oB6FH7i0lOy5XJ2zp9mJs/yejgiOn7KvQoe2q4YJIx6VmgUSW5AOefebPt5kg==}
@@ -5676,6 +5751,9 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -5702,6 +5780,10 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -5751,6 +5833,13 @@ packages:
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   term-size@2.2.1:
@@ -5902,6 +5991,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   turbo@2.10.8:
     resolution: {integrity: sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg==}
     hasBin: true
@@ -5972,6 +6064,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8199,10 +8294,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/coverage-v8@3.2.4(vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@25.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.10)(yaml@2.9.0))':
     dependencies:
@@ -8385,13 +8480,26 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@13.0.1:
+  better-sqlite3@12.11.1:
     dependencies:
-      node-addon-api: 8.9.1
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@2.2.2:
     dependencies:
@@ -8425,6 +8533,11 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.3):
     dependencies:
@@ -8483,6 +8596,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
 
@@ -8685,7 +8800,13 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -8725,11 +8846,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)(gel@2.2.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 13.0.1
+      better-sqlite3: 12.11.1
       gel: 2.2.0
 
   dunder-proto@1.0.1:
@@ -9020,6 +9141,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expand-template@2.0.3: {}
+
   expect-type@1.4.0: {}
 
   expect@30.4.1:
@@ -9122,6 +9245,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9186,6 +9311,8 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fs-constants@1.0.0: {}
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -9245,6 +9372,8 @@ snapshots:
   get-tsconfig@4.14.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -9375,6 +9504,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -9395,6 +9526,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -10199,6 +10332,8 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.6:
@@ -10216,6 +10351,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -10273,11 +10410,15 @@ snapshots:
 
   nanoid@3.3.18: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
 
-  node-addon-api@8.9.1: {}
+  node-abi@3.87.0:
+    dependencies:
+      semver: 7.8.5
 
   npm-run-path@5.3.0:
     dependencies:
@@ -10506,6 +10647,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.87.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -10586,6 +10742,13 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -10647,6 +10810,12 @@ snapshots:
       js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -10841,6 +11010,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-buffer@5.2.1: {}
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -10927,6 +11098,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   simple-icons@16.28.0: {}
 
   sisteransi@1.0.5: {}
@@ -11008,6 +11187,10 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -11032,6 +11215,8 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
+
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -11076,6 +11261,21 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -11239,6 +11439,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   turbo@2.10.8:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.8
@@ -11326,6 +11530,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  util-deprecate@1.0.2: {}
+
   vary@1.1.2: {}
 
   vfile-message@4.0.3:
@@ -11397,13 +11603,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
-      vite: 8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -11440,7 +11646,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vite@8.2.1(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
+  vite@8.2.1(@types/node@22.19.11)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -11449,7 +11655,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.11
-      esbuild: 0.28.2
+      esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.1
       better-sqlite3:
-        specifier: 11.10.0
-        version: 11.10.0
+        specifier: 13.0.1
+        version: 13.0.1
       chalk:
         specifier: ^5.4.0
         version: 5.6.2
@@ -281,7 +281,7 @@ importers:
         version: 4.0.2
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0)
       elkjs:
         specifier: ^0.12.0
         version: 0.12.0
@@ -614,11 +614,11 @@ importers:
         specifier: ^2.1.0
         version: 2.3.0
       better-sqlite3:
-        specifier: ^11.8.0
-        version: 11.10.0
+        specifier: ^13.0.1
+        version: 13.0.1
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0)
+        version: 0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0)
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -3370,21 +3370,13 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  base64-js@1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+  better-sqlite3@13.0.1:
+    resolution: {integrity: sha512-LYpmOXdkpQYf4wmlxkdzW01XGlOXNIbjLg45yNkh0FQ4814VbK9PdOFmhZpYbej+EZtR/i3FDdhEG98HqZdgnA==}
+    engines: {node: '>=22'}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -3406,9 +3398,6 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -3479,9 +3468,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -3711,17 +3697,9 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -4057,10 +4035,6 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -4139,9 +4113,6 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4198,9 +4169,6 @@ packages:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -4249,9 +4217,6 @@ packages:
 
   get-tsconfig@4.14.1:
     resolution: {integrity: sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4367,9 +4332,6 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
-  ieee754@1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -4396,9 +4358,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -5026,10 +4985,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -5051,9 +5006,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
@@ -5101,9 +5053,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5111,9 +5060,9 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  node-abi@3.87.0:
-    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
-    engines: {node: '>=10'}
+  node-addon-api@8.9.1:
+    resolution: {integrity: sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -5339,12 +5288,6 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -5416,10 +5359,6 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
-
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
@@ -5468,10 +5407,6 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
-
-  readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
-    engines: {node: '>= 6'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -5576,9 +5511,6 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
-  safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -5653,12 +5585,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-icons@16.28.0:
     resolution: {integrity: sha512-sQPR5AtK/ijRjou7zw7mlLp08oB6FH7i0lOy5XJ2zp9mJs/yejgiOn7KvQoe2q4YJIx6VmgUSW5AOefebPt5kg==}
@@ -5750,9 +5676,6 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
-  string_decoder@1.3.0:
-    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
@@ -5779,10 +5702,6 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
-
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -5832,13 +5751,6 @@ packages:
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
-    engines: {node: '>=6'}
-
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   term-size@2.2.1:
@@ -5990,9 +5902,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
   turbo@2.10.8:
     resolution: {integrity: sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg==}
     hasBin: true
@@ -6063,9 +5972,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -8479,26 +8385,13 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1: {}
-
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
 
-  better-sqlite3@11.10.0:
+  better-sqlite3@13.0.1:
     dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
+      node-addon-api: 8.9.1
 
   body-parser@2.2.2:
     dependencies:
@@ -8532,11 +8425,6 @@ snapshots:
       fill-range: 7.1.1
 
   buffer-from@1.1.2: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.3):
     dependencies:
@@ -8595,8 +8483,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
 
@@ -8799,13 +8685,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   deep-eql@5.0.2: {}
-
-  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -8845,11 +8725,11 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.23.12
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.2.0):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.1)(gel@2.2.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 11.10.0
+      better-sqlite3: 13.0.1
       gel: 2.2.0
 
   dunder-proto@1.0.1:
@@ -9140,8 +9020,6 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expand-template@2.0.3: {}
-
   expect-type@1.4.0: {}
 
   expect@30.4.1:
@@ -9244,8 +9122,6 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -9310,8 +9186,6 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0: {}
-
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -9371,8 +9245,6 @@ snapshots:
   get-tsconfig@4.14.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -9503,8 +9375,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
-
   ignore@5.3.2: {}
 
   ignore@7.0.6: {}
@@ -9525,8 +9395,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
-
-  ini@1.3.8: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -10331,8 +10199,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
   min-indent@1.0.1: {}
 
   minimatch@10.2.6:
@@ -10350,8 +10216,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  mkdirp-classic@0.5.3: {}
 
   mlly@1.8.0:
     dependencies:
@@ -10409,15 +10273,11 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  napi-build-utils@2.0.0: {}
-
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
 
-  node-abi@3.87.0:
-    dependencies:
-      semver: 7.8.5
+  node-addon-api@8.9.1: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -10646,21 +10506,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.87.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -10741,13 +10586,6 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
-
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
@@ -10809,12 +10647,6 @@ snapshots:
       js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   readdirp@4.1.2: {}
 
@@ -11009,8 +10841,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  safe-buffer@5.2.1: {}
-
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -11097,14 +10927,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
   simple-icons@16.28.0: {}
 
   sisteransi@1.0.5: {}
@@ -11186,10 +11008,6 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
@@ -11214,8 +11032,6 @@ snapshots:
   strip-indent@3.0.0:
     dependencies:
       min-indent: 1.0.1
-
-  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -11260,21 +11076,6 @@ snapshots:
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
-
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   term-size@2.2.1: {}
 
@@ -11438,10 +11239,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   turbo@2.10.8:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.8
@@ -11528,8 +11325,6 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
       react: 19.2.8
-
-  util-deprecate@1.0.2: {}
 
   vary@1.1.2: {}
 

--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,10 +1,21 @@
 # Cloudflare Pages headers for www.claw.boo
 
+# Content-Security-Policy. `script-src` keeps 'unsafe-inline': the theme,
+# analytics and behaviour snippets are inline by design (the theme script must run
+# before first paint, or the page flashes the wrong colour scheme). The policy
+# therefore constrains WHERE resources may load from rather than blocking inline
+# injection. Two allow-listed origins are not discoverable from source:
+#   - us-assets.i.posthog.com is derived at runtime by the PostHog snippet
+#     (api_host.replace('.i.posthog.com', '-assets.i.posthog.com')).
+#   - static.cloudflareinsights.com is injected at the edge by Cloudflare Pages
+#     Web Analytics, which also beacons to cloudflareinsights.com.
+
 /*
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://us-assets.i.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' data: https://fonts.gstatic.com https://api.fontshare.com https://cdn.fontshare.com; img-src 'self' data:; media-src 'self'; connect-src 'self' https://us.i.posthog.com https://us-assets.i.posthog.com https://api.github.com https://static.cloudflareinsights.com https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'
 
 # Hashed build assets are immutable.
 /_astro/*

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -213,6 +213,10 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph }
         cookieless_mode: 'always',
         defaults: '2026-05-30',
         autocapture: true,
+        // Honour the browser's Do Not Track signal: when set, posthog-js opts the
+        // visitor out at init and sends nothing. Re-evaluated on every page load,
+        // so it still applies under cookieless (memory-only) persistence.
+        respect_dnt: true,
       })
     </script>
 

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -162,8 +162,18 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph }
       PostHog product analytics in cookieless mode: no cookies, no local or
       session storage, no consent banner. Project is US-hosted. The phc_ key is
       a publishable client-side ingestion key (safe to ship in the browser).
+      Skipped entirely for Do Not Track visitors (see the guard below).
     -->
     <script is:inline>
+      // Do Not Track: skip the ENTIRE analytics bootstrap, not just capture.
+      // Gating here (rather than relying on posthog's own respect_dnt) means the
+      // loader never runs and no request is ever made, which is verifiable from
+      // the network panel and independent of posthog-js internals.
+      const dnt =
+        navigator.doNotTrack === '1' ||
+        window.doNotTrack === '1' ||
+        navigator.msDoNotTrack === '1'
+      if (!dnt) {
       !(function (t, e) {
         var o, n, p, r
         e.__SV ||
@@ -213,11 +223,11 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph }
         cookieless_mode: 'always',
         defaults: '2026-05-30',
         autocapture: true,
-        // Honour the browser's Do Not Track signal: when set, posthog-js opts the
-        // visitor out at init and sends nothing. Re-evaluated on every page load,
-        // so it still applies under cookieless (memory-only) persistence.
+        // Defense in depth. The DNT guard above already prevents this bootstrap
+        // from running at all; this covers any path that reaches init anyway.
         respect_dnt: true,
       })
+      }
     </script>
 
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd).replace(/</g, '\\u003c')} />

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -165,15 +165,19 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph }
       Skipped entirely for Do Not Track visitors (see the guard below).
     -->
     <script is:inline>
-      // Do Not Track: skip the ENTIRE analytics bootstrap, not just capture.
-      // Gating here (rather than relying on posthog's own respect_dnt) means the
-      // loader never runs and no request is ever made, which is verifiable from
-      // the network panel and independent of posthog-js internals.
-      const dnt =
-        navigator.doNotTrack === '1' ||
-        window.doNotTrack === '1' ||
-        navigator.msDoNotTrack === '1'
-      if (!dnt) {
+      // Wrapped in an IIFE because <ClientRouter /> can re-execute an is:inline
+      // script on a client-side navigation; a top-level `const` would then throw
+      // "Identifier 'dnt' has already been declared" and take the page with it.
+      ;(function () {
+        // Do Not Track: skip the ENTIRE analytics bootstrap, not just capture.
+        // Gating here (rather than relying on posthog's own respect_dnt) means the
+        // loader never runs and no request is ever made, which is verifiable from
+        // the network panel and independent of posthog-js internals.
+        var dnt =
+          navigator.doNotTrack === '1' ||
+          window.doNotTrack === '1' ||
+          navigator.msDoNotTrack === '1'
+        if (dnt) return
       !(function (t, e) {
         var o, n, p, r
         e.__SV ||
@@ -227,7 +231,7 @@ const jsonLd = { '@context': 'https://schema.org', '@graph': graph }
         // from running at all; this covers any path that reaches init anyway.
         respect_dnt: true,
       })
-      }
+      })()
     </script>
 
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd).replace(/</g, '\\u003c')} />

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -37,10 +37,13 @@ const a = 'text-foreground underline decoration-foreground/30 underline-offset-2
         <li>
           <strong class="font-semibold text-foreground/90">The marketing site (www.claw.boo)</strong>
           uses Cloudflare Web Analytics for page views and performance, and PostHog (US-hosted) in
-          cookieless mode to measure which calls-to-action and features people use. Neither sets
-          cookies nor stores anything in your browser, and PostHog does not identify you across
-          sessions. Both process your IP address to serve and count requests, acting as our
-          processors.
+          cookieless mode to measure which calls-to-action and features people use. PostHog's
+          autocapture is enabled, so it records interaction events across the site — clicks, form
+          submissions, and the text and attributes of the element you interacted with — alongside the
+          page URL. Neither sets cookies nor stores anything in your browser, and PostHog does not
+          identify you across sessions. Both process your IP address to serve and count requests,
+          acting as our processors. If your browser sends a Do Not Track signal, PostHog opts you out
+          at load and sends nothing.
         </li>
         <li>
           <strong class="font-semibold text-foreground/90">The documentation (docs.claw.boo)</strong>

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -38,12 +38,12 @@ const a = 'text-foreground underline decoration-foreground/30 underline-offset-2
           <strong class="font-semibold text-foreground/90">The marketing site (www.claw.boo)</strong>
           uses Cloudflare Web Analytics for page views and performance, and PostHog (US-hosted) in
           cookieless mode to measure which calls-to-action and features people use. PostHog's
-          autocapture is enabled, so it records interaction events across the site — clicks, form
-          submissions, and the text and attributes of the element you interacted with — alongside the
+          autocapture is enabled, so it records interaction events across the site (clicks, form
+          submissions, and the text and attributes of the element you interacted with) alongside the
           page URL. Neither sets cookies nor stores anything in your browser, and PostHog does not
           identify you across sessions. Both process your IP address to serve and count requests,
-          acting as our processors. If your browser sends a Do Not Track signal, PostHog opts you out
-          at load and sends nothing.
+          acting as our processors. If your browser sends a Do Not Track signal, we skip loading PostHog
+          altogether, so no analytics request is made at all.
         </li>
         <li>
           <strong class="font-semibold text-foreground/90">The documentation (docs.claw.boo)</strong>


### PR DESCRIPTION
## Summary

* Raises the minimum supported Node.js version to **22.12.0** across the project to align with current runtime requirements.
* Upgrades `better-sqlite3` to **13.0.1** across all packages for improved compatibility, stability, and performance.
* Refreshes the lockfile to ensure consistent dependency resolution and reproducible installs.

## Type

* [ ] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [x] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [ ] Added changeset (not needed — dependency and runtime updates only)

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dashboard server logs with startup diagnostics and recent output when launches time out.
  - File-changing tasks now require isolated workspaces and won’t run in the server directory.
  - Running subprocesses are cleaned up during server shutdown.

- **Bug Fixes**
  - Tasks are safely released when execution or workspace setup fails.
  - Added clearer errors for unsupported Node.js versions.

- **Privacy**
  - Analytics now honors Do Not Track, with expanded disclosure of collected interaction data.

- **Documentation**
  - Clarified verification, governance, runtime behavior, and third-party license information.

- **Reliability**
  - Releases are queued instead of canceling an active release.
  - Added stronger security headers for the website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->