### PR TITLE
feat(server): serve the dashboard under a URL path prefix

### DIFF
--- a/.changeset/serve-under-a-path-prefix.md
+++ b/.changeset/serve-under-a-path-prefix.md
@@ -1,0 +1,13 @@
+---
+'clawboo': minor
+---
+
+Clawboo can now be served under a URL path prefix. Set `CLAWBOO_BASE_PATH=/clawboo` and the whole app moves together: the dashboard, every `/api` route, the SSE streams, and the Gateway WebSocket proxy. This is for the case where Clawboo shares a hostname with other apps behind a reverse proxy, which previously could not work because the built dashboard asked for its assets and its API at the origin root and got a 404 for each one.
+
+The prebuilt bundle needs no rebuild to move. The server templates the mount point into the shell it serves, and the app reads it at runtime, so the same package that `npx clawboo` installs works at the root and under any prefix.
+
+The shell the server sends always carries the mount point, whatever spelling asked for it. That matters because a shell without it boots an app that addresses the origin root for everything, which on a shared hostname means handing clawboo's requests to a neighbouring app. Recognizing the shell is therefore a question for the filesystem rather than for string comparison, since more than one spelling names one file: the request and the shell are both resolved to their canonical paths and compared, which is what makes a case-insensitive volume, a symlink, or a percent-encoded name all land on the templated copy.
+
+Requests are stripped of the prefix before any routing or security check runs. That is deliberate and load-bearing: the same-origin guard and the access gate decide what to protect by matching on the API path, and anything they do not recognize is treated as a static asset and let through. Mounting the API somewhere they were not looking would have left every prefixed route unauthenticated. Stripping first means both keep the checks they already had, and the prefixed surface is enforced exactly as the root one is. The access cookie is scoped to the prefix, so a sibling app on the same origin never receives it. The unprefixed `/api` surface stays served for the loopback control plane that talks to it directly (the CLI discovery probe, the callback URLs handed to spawned runtimes, the self-update check) and stays exactly as gated as before.
+
+An invalid value makes the server refuse to start and say why, rather than quietly serving at the root and looking like a broken proxy. In development the Vite dev server still serves the dashboard at the root and proxies the API, so the prefix shapes only what the API server accepts. Leaving it unset keeps every behavior a previous release had, with one deliberate addition: the served shell carries a base tag naming its mount, which at the root is simply the root.

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,7 +23,7 @@ import { exec } from 'child_process'
 import path from 'path'
 import fs from 'fs'
 
-import { resolveClawbooDir } from '@clawboo/config'
+import { resolveBasePathOrRoot, resolveClawbooDir } from '@clawboo/config'
 
 import { VERSION } from './version'
 import { nodeVersionError } from './node-version'
@@ -75,6 +75,15 @@ function fail(err: unknown): never {
 }
 
 // ─── Server start / stop reporting ────────────────────────────────────────────
+
+// The URL prefix the server is mounted under, for the links we PRINT. Display
+// only: a malformed value falls back to the root here and the server refuses to
+// start with a precise message, so the CLI never dies on a bad setting. The
+// trailing slash matters under a mount, since the shell's assets are relative.
+const uiPath = (): string => {
+  const base = resolveBasePathOrRoot(process.env)
+  return base ? `${base}/` : ''
+}
 
 /**
  * Start a dashboard and narrate it. Returns the port, or null when the user is
@@ -166,7 +175,7 @@ function printGatedNotice(port: number): void {
   )
   p.log.info(
     chalk.gray('Open ') +
-      chalk.cyan.underline(`http://localhost:${port}/?access_token=<token>`) +
+      chalk.cyan.underline(`http://localhost:${port}${uiPath()}?access_token=<token>`) +
       chalk.gray(' once to set it in your browser, or unset the variable and restart the server.'),
   )
 }
@@ -336,7 +345,7 @@ async function run(opts: LaunchOptions): Promise<void> {
     if (dashboardPort === null) process.exit(1)
   }
 
-  const dashboardUrl = `http://localhost:${dashboardPort}`
+  const dashboardUrl = `http://localhost:${dashboardPort}${uiPath()}`
 
   // ── 4. Open browser ────────────────────────────────────────────────────────
 
@@ -469,7 +478,7 @@ async function runRestart(opts: { open: boolean }): Promise<void> {
     process.exit(1)
   }
 
-  const url = `http://localhost:${started}`
+  const url = `http://localhost:${started}${uiPath()}`
   if (opts.open) {
     const browserSpinner = ora({ text: 'Opening Clawboo...', color: 'cyan' }).start()
     await openBrowser(url)

--- a/apps/web/server/index.ts
+++ b/apps/web/server/index.ts
@@ -5,7 +5,7 @@ import express from 'express'
 import cors from 'cors'
 
 import { createAccessGate, createGatewayProxy, createOriginGuard } from '@clawboo/gateway-proxy'
-import { loadSettings } from '@clawboo/config'
+import { loadSettings, resolveBasePath } from '@clawboo/config'
 import { createLogger } from '@clawboo/logger'
 import {
   listAgentsWithUndeliveredInbox,
@@ -37,6 +37,7 @@ import {
 } from './lib/portUtils'
 import { resolveHost, isLoopbackHost, shouldRefuseInsecureBind } from './lib/resolveHost'
 import { runBootProbe } from './lib/bootProbe'
+import { createBasePathMiddleware } from './lib/basePathMiddleware'
 import { mountSpa } from './lib/serveSpa'
 
 /** A duration env var, defaulted and BOUNDED to a positive integer. The bare
@@ -77,6 +78,18 @@ const resolvePathname = (url: string | undefined): string => {
   return (idx === -1 ? raw : raw.slice(0, idx)) || '/'
 }
 
+const GATEWAY_WS_PATH = '/api/gateway/ws'
+
+/**
+ * The Gateway proxy route, in either spelling. WS upgrades bypass the Express
+ * middleware stack, so the base-path strip never runs on them: a browser served
+ * under `/clawboo` connects to `/clawboo/api/gateway/ws`, while the loopback
+ * control plane still uses the root path. Exact matches only, so no other path
+ * can reach the proxy.
+ */
+const isGatewayWsPath = (pathname: string, basePath: string): boolean =>
+  pathname === GATEWAY_WS_PATH || (basePath !== '' && pathname === `${basePath}${GATEWAY_WS_PATH}`)
+
 /** Parse a comma-separated env var into a trimmed, non-empty list. */
 const parseCsvEnv = (raw: string | undefined): string[] =>
   String(raw ?? '')
@@ -89,6 +102,21 @@ const parseCsvEnv = (raw: string | undefined): string[] =>
 async function main() {
   const dev = process.argv.includes('--dev')
   const hostname = resolveHost()
+
+  // The URL prefix the whole app is served under ('' = the origin root, the
+  // default). Refuse to start on a malformed value rather than silently serving
+  // at the root: an operator who set it has a proxy pointing here, and a quiet
+  // fallback would look like a broken deployment instead of a bad setting.
+  const basePathResult = resolveBasePath(process.env)
+  if (!basePathResult.ok) {
+    log.error(
+      { value: process.env['CLAWBOO_BASE_PATH'] },
+      `SECURITY/CONFIG: CLAWBOO_BASE_PATH is invalid (${basePathResult.reason}). ` +
+        'Use a path like /clawboo, or unset it to serve at the root.',
+    )
+    process.exit(1)
+  }
+  const basePath = basePathResult.basePath
 
   // If we were launched as a self-restart successor by an in-app update, the
   // exiting parent still holds the API port for a brief moment. Wait for it to
@@ -113,6 +141,9 @@ async function main() {
 
   const accessGate = createAccessGate({
     token: process.env['STUDIO_ACCESS_TOKEN'],
+    // Scopes the operator cookie to the mount and prefixes the post-exchange
+    // redirect, so sharing an origin with another app does not share the cookie.
+    basePath,
   })
 
   // ── Same-origin guard (CSWSH / DNS-rebinding / cross-site CSRF) ────────────
@@ -179,7 +210,7 @@ async function main() {
       return { url: settings.gatewayUrl, token: settings.gatewayToken }
     },
     allowWs: (req) => {
-      if (resolvePathname(req.url) !== '/api/gateway/ws') return false
+      if (!isGatewayWsPath(resolvePathname(req.url), basePath)) return false
       // Same-origin guard first (CSWSH), then the optional token gate.
       if (!originGuard.allowUpgrade(req)) return false
       if (!accessGate.allowUpgrade(req)) return false
@@ -204,6 +235,13 @@ async function main() {
   // header — a forged Host must never redirect a runtime's Tasks/Memory/Tools/TeamChat
   // traffic. Mirrors the `http://127.0.0.1:${port}` the boot/ticker callers use.
   app.locals['apiPort'] = port
+
+  // Base-path strip, BEFORE the origin guard, and nothing may be mounted ahead
+  // of it. The guards below decide what to protect with `startsWith('/api/')` and
+  // fail OPEN otherwise, so they must only ever see root-form paths; stripping
+  // here is what lets them keep their existing checks and cover the prefixed
+  // surface too. A pass-through when no prefix is configured.
+  app.use(createBasePathMiddleware(basePath))
 
   // Same-origin guard — FIRST, before body parsing / CORS / the access gate, so a
   // cross-origin (CSWSH/rebinding/CSRF) /api/* request is 403'd before any work.
@@ -244,8 +282,10 @@ async function main() {
     const start = Date.now()
     res.on('finish', () => {
       const url = req.originalUrl ?? req.url
-      // Skip high-frequency static asset requests
-      if (url.startsWith('/assets/') || url.startsWith('/fonts/')) return
+      // Skip high-frequency static asset requests. `originalUrl` keeps the mount
+      // prefix, so the test allows for it.
+      const rel = basePath && url.startsWith(basePath) ? url.slice(basePath.length) : url
+      if (rel.startsWith('/assets/') || rel.startsWith('/fonts/')) return
       const durationMs = Date.now() - start
       const level = res.statusCode >= 500 ? 'error' : res.statusCode >= 400 ? 'warn' : 'info'
       reqLog[level]({ method: req.method, url, status: res.statusCode, durationMs })
@@ -258,7 +298,9 @@ async function main() {
 
   // Production: serve Vite build output as static SPA
   if (!dev) {
-    mountSpa(app, process.env['CLAWBOO_UI_DIR'] || path.join(__dirname, 'ui'))
+    // Requests arrive with the prefix already stripped; `basePath` is passed only
+    // so the served shell can advertise its own mount point.
+    mountSpa(app, process.env['CLAWBOO_UI_DIR'] || path.join(__dirname, 'ui'), basePath)
   }
 
   // ── HTTP server (raw, for WS upgrade handling) ────────────────────────────
@@ -268,7 +310,11 @@ async function main() {
   // ── WebSocket upgrade routing ─────────────────────────────────────────────
 
   server.on('upgrade', (req, socket, head) => {
-    if (resolvePathname(req.url) === '/api/gateway/ws') {
+    // The raw upgrade handler runs OUTSIDE Express, so the base-path middleware
+    // never sees these and the prefix is still present. Accept both spellings:
+    // the prefixed one a browser under the mount sends, and the root one the
+    // loopback control plane uses.
+    if (isGatewayWsPath(resolvePathname(req.url), basePath)) {
       // Same-origin guard on the WS upgrade (CSWSH). Reply 403 before handing off
       // so a rejected handshake gets a real response, not a bare socket teardown.
       // `socket.end(...)` flushes the response bytes before the FIN.
@@ -468,7 +514,9 @@ async function main() {
 
   server.listen(port, hostname, () => {
     const hostForBrowser = hostname === '0.0.0.0' || hostname === '::' ? 'localhost' : hostname
-    const browserUrl = `http://${hostForBrowser}:${port}`
+    // Trailing slash under a mount so the shell's relative assets resolve without
+    // relying on the redirect (which is there for hand-typed URLs).
+    const browserUrl = `http://${hostForBrowser}:${port}${basePath ? `${basePath}/` : ''}`
 
     // Publish the chosen port for external tools (CLI, Vite proxy fallback,
     // e2e helpers). Best-effort: if writing fails, downstream consumers can

--- a/apps/web/server/lib/__tests__/basePathMiddleware.test.ts
+++ b/apps/web/server/lib/__tests__/basePathMiddleware.test.ts
@@ -1,0 +1,154 @@
+// The prefix-strip middleware, and the security property it exists to provide.
+//
+// The origin guard and the access gate decide whether to protect a request by
+// testing `pathname.startsWith('/api/')`, and those tests fail OPEN. So the thing
+// that actually has to hold is not "the prefix is stripped" but "nothing behind
+// this middleware ever observes a prefixed path". The last test asserts exactly
+// that against a recorder standing where the guards stand.
+
+import express from 'express'
+import type { Server } from 'node:http'
+import { afterAll, describe, expect, it } from 'vitest'
+
+import { createBasePathMiddleware } from '../basePathMiddleware'
+
+const servers: Server[] = []
+afterAll(() => {
+  for (const s of servers) s.close()
+})
+
+/** Boot an app on an ephemeral port and return its origin. */
+function serve(build: (app: express.Express) => void): Promise<string> {
+  const app = express()
+  build(app)
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      servers.push(server)
+      const addr = server.address()
+      const port = typeof addr === 'object' && addr ? addr.port : 0
+      resolve(`http://127.0.0.1:${port}`)
+    })
+  })
+}
+
+/** An app mounted under `/clawboo` that echoes the path each layer observed. */
+function mountedApp(basePath: string) {
+  return (app: express.Express) => {
+    app.use(createBasePathMiddleware(basePath))
+    app.get('/api/settings', (req, res) => {
+      res.json({ seenUrl: req.url, originalUrl: req.originalUrl })
+    })
+    // Stands in for the SPA catch-all.
+    app.use((req, res) => {
+      res.status(200).json({ shell: true, seenUrl: req.url, originalUrl: req.originalUrl })
+    })
+  }
+}
+
+describe('createBasePathMiddleware', () => {
+  it('is a pass-through when no base path is configured', async () => {
+    const origin = await serve(mountedApp(''))
+    const res = await fetch(`${origin}/api/settings`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ seenUrl: '/api/settings' })
+    // A deep route still reaches the shell exactly as before.
+    const deep = await fetch(`${origin}/some/deep/route`)
+    expect(deep.status).toBe(200)
+    expect(await deep.json()).toMatchObject({ shell: true })
+  })
+
+  it('strips the prefix for routes underneath it, keeping originalUrl intact', async () => {
+    const origin = await serve(mountedApp('/clawboo'))
+    const res = await fetch(`${origin}/clawboo/api/settings`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      seenUrl: '/api/settings',
+      originalUrl: '/clawboo/api/settings',
+    })
+  })
+
+  it('serves the shell for the mount root and for deep routes under it', async () => {
+    const origin = await serve(mountedApp('/clawboo'))
+    for (const path of ['/clawboo/', '/clawboo/board', '/clawboo/agents/x/y']) {
+      const res = await fetch(`${origin}${path}`)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({ shell: true })
+    }
+  })
+
+  it('redirects the bare prefix and the root to the canonical mount, preserving the query', async () => {
+    const origin = await serve(mountedApp('/clawboo'))
+    // The injected <base href> ends in a slash, so relative assets only resolve
+    // once the page URL does too.
+    const bare = await fetch(`${origin}/clawboo`, { redirect: 'manual' })
+    expect(bare.status).toBe(302)
+    expect(bare.headers.get('location')).toBe('/clawboo/')
+
+    // The CLI prints `/?access_token=...`; losing the query would break that link.
+    const root = await fetch(`${origin}/?access_token=abc123`, { redirect: 'manual' })
+    expect(root.status).toBe(302)
+    expect(root.headers.get('location')).toBe('/clawboo/?access_token=abc123')
+  })
+
+  it('keeps the unprefixed /api surface for the loopback control plane', async () => {
+    // The CLI probe, the MCP attach URLs handed to spawned runtimes, the boot
+    // probe and the self-update check all address the API at the root and know
+    // nothing about the prefix.
+    const origin = await serve(mountedApp('/clawboo'))
+    const res = await fetch(`${origin}/api/settings`)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ seenUrl: '/api/settings' })
+  })
+
+  it('404s paths outside the mount instead of falling through to the shell', async () => {
+    const origin = await serve(mountedApp('/clawboo'))
+    for (const path of ['/clawboonot/x', '/elsewhere', '/assets/index.js']) {
+      const res = await fetch(`${origin}${path}`)
+      expect(res.status).toBe(404)
+    }
+  })
+
+  it('does not treat a case-mismatched prefix as the mount', async () => {
+    // Route matching is case-sensitive server-wide (`case sensitive routing`), so
+    // a prefix test that folded case would disagree with the routes behind it.
+    const origin = await serve(mountedApp('/clawboo'))
+    const res = await fetch(`${origin}/Clawboo/api/settings`)
+    expect(res.status).toBe(404)
+  })
+
+  it('SECURITY: nothing behind the middleware ever observes a prefixed path', async () => {
+    // The origin guard and access gate gate on `startsWith('/api/')` and fail OPEN
+    // for anything else, so a prefixed path reaching them would be an unguarded,
+    // unauthenticated API. This is the property that makes stripping safe, so it
+    // is asserted directly rather than inferred from the routing tests above.
+    const observed: string[] = []
+    const origin = await serve((app) => {
+      app.use(createBasePathMiddleware('/clawboo'))
+      // Stands exactly where the origin guard and access gate are installed.
+      app.use((req, _res, next) => {
+        observed.push(req.url)
+        next()
+      })
+      app.get('/api/settings', (_req, res) => res.json({ ok: true }))
+      app.use((_req, res) => res.status(200).json({ shell: true }))
+    })
+
+    for (const path of [
+      '/clawboo/',
+      '/clawboo/api/settings',
+      '/clawboo/api/agents?includeArchived=true',
+      '/clawboo/board',
+      '/api/settings',
+    ]) {
+      await fetch(`${origin}${path}`)
+    }
+
+    expect(observed.length).toBeGreaterThan(0)
+    for (const url of observed) {
+      expect(url.startsWith('/clawboo')).toBe(false)
+    }
+    // And the API paths still arrive in the exact form the guards test for.
+    expect(observed).toContain('/api/settings')
+    expect(observed).toContain('/api/agents?includeArchived=true')
+  })
+})

--- a/apps/web/server/lib/__tests__/serveSpa.test.ts
+++ b/apps/web/server/lib/__tests__/serveSpa.test.ts
@@ -6,18 +6,34 @@
 // The second only reproduces when the install path contains a dot-directory,
 // which is exactly where `npx clawboo` lands (`~/.npm/_npx/…`) and never where
 // CI checks out. So this test builds both layouts explicitly.
+//
+// `sendFile` is gone entirely now: the shell is read with `readFileSync` and
+// served from memory so the mount point can be templated into it, and
+// `readFileSync` is indifferent to dot-directories. That RETIRES the hazard
+// rather than guarding it, and the dot-directory matrix now proves the weaker
+// but still worthwhile claim that an npx-shaped install path serves end to end.
+//
+// The invariant those cases defend is stated in serveSpa.ts: a request for the
+// shell is answered with the TEMPLATED shell or with an error, never with the
+// file on disk. An untemplated shell carries no mount point, so the SPA it boots
+// addresses the origin root for the whole session.
 
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import fs, { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import http from 'node:http'
 import os from 'node:os'
 import path from 'node:path'
 
 import express from 'express'
-import { afterAll, describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it, vi } from 'vitest'
 
 import { mountSpa } from '../serveSpa'
 
-const INDEX_HTML = '<!doctype html><html><body><div id="root"></div></body></html>'
+// Mirrors the real shell closely enough to exercise the head injection: a <head>
+// to inject after, and a RELATIVE asset ref (the build uses a relative Vite base,
+// which is what makes the injected <base href> load-bearing).
+const INDEX_HTML =
+  '<!doctype html><html><head><meta charset="UTF-8" /></head>' +
+  '<body><div id="root"></div><script type="module" src="./assets/index.js"></script></body></html>'
 
 /** Build a ui dir at `<tmp>/<segment>/ui` holding an index.html + one real asset. */
 function makeUiDir(segment: string): string {
@@ -31,9 +47,9 @@ function makeUiDir(segment: string): string {
 
 const servers: http.Server[] = []
 
-function serve(uiDir: string): Promise<string> {
+function serve(uiDir: string, basePath = ''): Promise<string> {
   const app = express()
-  mountSpa(app, uiDir)
+  mountSpa(app, uiDir, basePath)
   return new Promise((resolve) => {
     const server = app.listen(0, () => {
       servers.push(server)
@@ -80,5 +96,182 @@ describe.each([
     const base = await serve(makeUiDir(segment))
     const res = await fetch(`${base}/api/nope`, { method: 'POST' })
     expect(res.status).toBe(404)
+  })
+
+  it('injects the mount point into the shell it serves', async () => {
+    // The build uses a RELATIVE Vite base, so `./assets/...` resolves against the
+    // page URL. Without an injected <base href>, a deep route would resolve it to
+    // `/some/spa/route/assets/...` and white-screen. Injected at the root too, so
+    // there is one code path and the deep-route case is covered there as well.
+    const base = await serve(makeUiDir(segment))
+    for (const route of ['/', '/some/spa/route']) {
+      const html = await (await fetch(`${base}${route}`)).text()
+      expect(html).toContain('<base href="/" />')
+      expect(html).toContain('window.__CLAWBOO_BASE__=""')
+      // Injected INSIDE head and after its opening tag: a <base> only governs
+      // elements that follow it.
+      expect(html.indexOf('<base')).toBeGreaterThan(html.indexOf('<head>'))
+      expect(html.indexOf('<base')).toBeLessThan(html.indexOf('./assets/index.js'))
+    }
+  })
+
+  it('injects the configured prefix when mounted under one', async () => {
+    // Requests reach mountSpa with the prefix already stripped, so the paths here
+    // are root-form; the prefix only shapes what gets templated into the shell.
+    const base = await serve(makeUiDir(segment), '/clawboo')
+    for (const route of ['/', '/board']) {
+      const html = await (await fetch(`${base}${route}`)).text()
+      expect(html).toContain('<base href="/clawboo/" />')
+      expect(html).toContain('window.__CLAWBOO_BASE__="/clawboo"')
+    }
+    // Real assets are still served raw, never templated.
+    const asset = await fetch(`${base}/app.js`)
+    expect(await asset.text()).toContain('export const x = 1')
+  })
+
+  it('serves the templated shell for /index.html too, not the raw file', async () => {
+    // `express.static` runs first and would otherwise hand back an un-injected
+    // document for this one path.
+    const base = await serve(makeUiDir(segment), '/clawboo')
+    const html = await (await fetch(`${base}/index.html`)).text()
+    expect(html).toContain('window.__CLAWBOO_BASE__="/clawboo"')
+  })
+
+  it('SECURITY: no spelling of the shell path can return the UNTEMPLATED file', async () => {
+    // `send` percent-decodes and normalizes before reading from disk, so these
+    // all resolve to index.html. Matching only the raw spelling let them reach
+    // the static handler, which answered with the un-injected document: the SPA
+    // then booted with no mount point and addressed every API call at the origin
+    // root, which on a shared origin means handing clawboo's requests (provider
+    // key writes among them) to a neighbouring app.
+    const base = await serve(makeUiDir(segment), '/clawboo')
+    for (const spelling of [
+      '//index.html',
+      '/index.htm%6C',
+      '/%69ndex.html',
+      // Case variants: on macOS and Windows (the platforms `npx clawboo` mostly
+      // runs on) the filesystem itself resolves these to the same file, so a
+      // string comparison against '/index.html' waves them through to the static
+      // handler. On a case-SENSITIVE volume they are simply 404s that fall to the
+      // catch-all, which serves the templated shell, so the assertion holds
+      // either way.
+      '/INDEX.HTML',
+      '/Index.html',
+      '/index.HTML',
+      '//INDEX.HTML',
+      // Dot segments are removed by the WHATWG URL parser before the request is
+      // sent, so these two arrive as plain '/index.html'. Kept as documentation
+      // that the client-side normalization is what makes them safe.
+      '/./index.html',
+      '/sub/../index.html',
+      // Not a dot segment: '//' survives the URL parser intact and reaches the
+      // server, where it is the directory-index spelling of the mount root.
+      '//',
+    ]) {
+      const res = await fetch(`${base}${spelling}`)
+      const html = await res.text()
+      expect(html, `${spelling} must not serve the raw shell`).toContain(
+        'window.__CLAWBOO_BASE__="/clawboo"',
+      )
+    }
+  })
+
+  it('keeps the caching headers the static handler used to send', async () => {
+    // Serving from memory silently dropped these. Without them a browser
+    // re-downloads the shell on every navigation instead of revalidating into a
+    // 304. `Accept-Ranges` is deliberately not restored: it advertised range
+    // support that a string response cannot honor.
+    const base = await serve(makeUiDir(segment), '/clawboo')
+    for (const p of ['/', '/index.html', '/board']) {
+      const res = await fetch(`${base}${p}`)
+      expect(res.headers.get('cache-control'), p).toBe('public, max-age=0')
+      expect(res.headers.get('last-modified'), p).toBeTruthy()
+      expect(res.headers.get('etag'), p).toBeTruthy()
+    }
+  })
+
+  it('answers HEAD wherever it answers GET', async () => {
+    // `index: false` removed the handler that used to answer a bare `HEAD /`,
+    // so it fell through to a 404 while GET stayed 200. Uptime probes use HEAD,
+    // and disagreeing with GET on the same URL violates RFC 9110.
+    const base = await serve(makeUiDir(segment), '/clawboo')
+    for (const p of ['/', '/index.html', '/board']) {
+      const head = await fetch(`${base}${p}`, { method: 'HEAD' })
+      const get = await fetch(`${base}${p}`)
+      expect(head.status, `HEAD ${p}`).toBe(get.status)
+      expect(head.status).toBe(200)
+    }
+  })
+})
+
+describe('SPA serving when the shell cannot be read', () => {
+  it('503s rather than crashing when the ui dir has no index.html', async () => {
+    // Per request, never a boot-time throw. 503 rather than 404 because the
+    // server knows exactly what was asked for and cannot produce it, and because
+    // the alternative was falling through to a handler that answers 200 with the
+    // raw file (see the SECURITY case below).
+    const empty = mkdtempSync(path.join(os.tmpdir(), 'clawboo-spa-empty-'))
+    const base = await serve(empty)
+    for (const p of ['/', '/board', '/index.html']) {
+      expect((await fetch(`${base}${p}`)).status, p).toBe(503)
+    }
+  })
+
+  it('SECURITY: an unreadable shell is an error, never the raw file', async () => {
+    // The invariant, stated as a test: a request for the shell is answered with
+    // the TEMPLATED shell or with an error. A transient read failure used to
+    // `next()` into express.static (for /index.html) or `sendFile` (for a deep
+    // route), each of which answers 200 with the untemplated document, which
+    // strips the mount point and points the whole session at the origin root.
+    const uiDir = mkdtempSync(path.join(os.tmpdir(), 'clawboo-spa-unread-'))
+    writeFileSync(path.join(uiDir, 'index.html'), INDEX_HTML)
+    const base = await serve(uiDir, '/clawboo')
+
+    // Make the file unreadable the way a lock or an fd exhaustion would, while
+    // leaving it perfectly servable by `send`.
+    const realRead = fs.readFileSync
+    const spy = vi.spyOn(fs, 'readFileSync').mockImplementation(((p: unknown, ...rest: never[]) => {
+      if (typeof p === 'string' && p.endsWith('index.html')) {
+        throw Object.assign(new Error('EMFILE'), { code: 'EMFILE' })
+      }
+      return (realRead as (...a: unknown[]) => unknown)(p, ...rest)
+    }) as typeof fs.readFileSync)
+    try {
+      for (const p of ['/', '/index.html', '/INDEX.HTML', '/board']) {
+        const res = await fetch(`${base}${p}`)
+        const body = await res.text()
+        expect(res.status, `${p} must not answer 200 with the raw shell`).toBe(503)
+        expect(body).not.toContain('<div id="root">')
+      }
+    } finally {
+      spy.mockRestore()
+    }
+
+    // And it recovers on the next request once the read succeeds again.
+    const html = await (await fetch(`${base}/index.html`)).text()
+    expect(html).toContain('window.__CLAWBOO_BASE__="/clawboo"')
+  })
+
+  it('SECURITY: recovers the shell identity when the ui dir appears after mount', async () => {
+    // The ui dir can be unreadable for a moment at boot (a slow network or
+    // container mount, an indexer's handle, EMFILE). Resolving the shell's
+    // identity ONCE would leave it null forever, and a null identity makes every
+    // spelling look like "not the shell", so express.static answers with the RAW
+    // untemplated file: a latch here fails OPEN, permanently, on exactly the
+    // deployment this feature exists for.
+    const late = mkdtempSync(path.join(os.tmpdir(), 'clawboo-spa-late-'))
+    const uiDir = path.join(late, 'ui')
+    const base = await serve(uiDir, '/clawboo')
+
+    // Nothing on disk yet: an honest error, and no raw file to leak.
+    expect((await fetch(`${base}/index.html`)).status).toBe(503)
+
+    mkdirSync(uiDir, { recursive: true })
+    writeFileSync(path.join(uiDir, 'index.html'), INDEX_HTML)
+
+    for (const p of ['/', '/index.html', '/INDEX.HTML', '/board']) {
+      const html = await (await fetch(`${base}${p}`)).text()
+      expect(html, `${p} after the ui dir appeared`).toContain('window.__CLAWBOO_BASE__="/clawboo"')
+    }
   })
 })

--- a/apps/web/server/lib/basePathMiddleware.ts
+++ b/apps/web/server/lib/basePathMiddleware.ts
@@ -1,0 +1,92 @@
+// Serve the whole app under a URL path prefix (CLAWBOO_BASE_PATH) by STRIPPING the
+// prefix at the very front of the middleware stack, so nothing behind it ever sees
+// a prefixed path.
+//
+// This is the security-load-bearing choice. The origin guard and the access gate
+// both decide whether to protect a request by testing `pathname.startsWith('/api/')`,
+// and those tests FAIL OPEN: a path they do not recognize is treated as a static
+// asset and waved through. Mounting the API at `${base}/api` while leaving those
+// tests matching `/api/` would therefore leave every prefixed API route
+// unauthenticated and unguarded. Stripping first means the guards keep their
+// existing, tested checks and cover both surfaces with no change at all.
+//
+// It also keeps the ROOT `/api/*` surface served unstripped, because the loopback
+// control plane talks to it directly and knows nothing about the prefix: the CLI's
+// discovery probe, the MCP attach URLs handed to spawned runtimes, and the
+// self-update check. That surface stays exactly as gated as it is today
+// (origin guard + access gate + the loopback-only MCP exemption).
+//
+// Ordering rule: this must be installed BEFORE the origin guard, and no route may
+// be mounted ahead of it. A route registered earlier would see prefixed paths and
+// would be judged by guards that never ran.
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express'
+
+/** Path portion of a raw request URL (no query, never empty). */
+function pathnameOf(url: string | undefined): string {
+  const raw = typeof url === 'string' ? url : ''
+  const idx = raw.indexOf('?')
+  return (idx === -1 ? raw : raw.slice(0, idx)) || '/'
+}
+
+/** Query portion including the leading '?', or '' when there is none. */
+function searchOf(url: string | undefined): string {
+  const raw = typeof url === 'string' ? url : ''
+  const idx = raw.indexOf('?')
+  return idx === -1 ? '' : raw.slice(idx)
+}
+
+/**
+ * Build the prefix-strip middleware. `basePath` must already be normalized by
+ * `normalizeBasePath` ('' or a leading-slash, no-trailing-slash prefix).
+ *
+ * With `basePath === ''` this returns a pass-through, so an install that never
+ * sets the variable behaves exactly as it did before this existed.
+ */
+export function createBasePathMiddleware(basePath: string): RequestHandler {
+  if (!basePath) return (_req, _res, next) => next()
+
+  const prefix = `${basePath}/`
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const pathname = pathnameOf(req.url)
+
+    // Under the prefix: strip it so everything downstream sees a root-form path.
+    // `originalUrl` keeps the prefix, so logs and redirects can still show it.
+    if (pathname === prefix || pathname.startsWith(prefix)) {
+      req.url = req.url.slice(basePath.length) || '/'
+      next()
+      return
+    }
+
+    // Bare prefix with no trailing slash: send the browser to the canonical form.
+    // The shell's injected `<base href>` ends in a slash, so relative asset URLs
+    // only resolve correctly once the page URL does too. Query is preserved.
+    if (pathname === basePath) {
+      res.redirect(302, `${prefix}${searchOf(req.url)}`)
+      return
+    }
+
+    // The loopback control plane addresses the API at the root, unprefixed, and
+    // must keep working: the CLI probe, the MCP attach URLs, the self-update
+    // check. Passed through UNSTRIPPED and therefore judged by exactly the same
+    // origin guard and access gate as before.
+    if (pathname.toLowerCase().startsWith('/api/')) {
+      next()
+      return
+    }
+
+    // The root itself: point a browser that landed on '/' at the real mount, so a
+    // bookmark or a proxy misconfiguration is a redirect rather than a blank page.
+    // Query is preserved, which is what keeps the CLI's printed
+    // `/?access_token=...` link working.
+    if (pathname === '/') {
+      res.redirect(302, `${prefix}${searchOf(req.url)}`)
+      return
+    }
+
+    // Everything else is outside the mount. 404 rather than fall through, so the
+    // SPA exists at exactly one place and a stray path cannot reach the catch-all.
+    res.status(404).json({ error: `Not found. This Clawboo is served under ${prefix}` })
+  }
+}

--- a/apps/web/server/lib/serveSpa.ts
+++ b/apps/web/server/lib/serveSpa.ts
@@ -1,6 +1,97 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
-import express, { type Express } from 'express'
+import express, { type Express, type Response } from 'express'
+
+/** Escape a value for use inside a double-quoted HTML attribute. */
+function attr(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')
+}
+
+/**
+ * Resolve a path to its canonical on-disk identity, or null when it is not a
+ * readable file. `realpathSync.native` delegates to the OS, so it answers with
+ * the filesystem's own idea of identity: real casing on case-insensitive volumes
+ * (macOS APFS, Windows NTFS), symlinks followed, and Windows' trailing-dot and
+ * trailing-space trimming already applied.
+ */
+function canonicalFile(candidate: string): string | null {
+  try {
+    return fs.realpathSync.native(candidate)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Would `express.static` resolve this request path to the shell?
+ *
+ * This has to be answered the way `send` answers it, and `send` does not compare
+ * strings at all: it percent-decodes, normalizes, and then STATS the file. So a
+ * string comparison is always a guess at what the filesystem will do, and it
+ * loses on any volume where more than one spelling names one file. On the two
+ * platforms `npx clawboo` mostly runs on, that is the default: `INDEX.HTML`
+ * opens `index.html` on macOS and Windows. Enumerating spellings cannot win, so
+ * this asks the filesystem instead and compares canonical paths.
+ *
+ * Getting it wrong serves the UNTEMPLATED shell, which boots an app with no
+ * mount point that addresses the origin root for every request. On the shared
+ * hostname this feature exists for, that hands clawboo's traffic, including the
+ * provider-key writes, to a neighbouring app.
+ */
+function isShellPath(rawPath: string, root: string, shellFile: string): boolean {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(rawPath)
+  } catch {
+    // Malformed encoding: `send` rejects it, so it is not the shell.
+    return false
+  }
+  // Normalizing first keeps `..` from ever reaching outside `root`.
+  const normalized = path.posix.normalize(decoded)
+  // The directory index, which `send` resolves without touching a filename.
+  if (normalized === '/') return true
+  // Resolve the REQUEST first: a deep SPA route resolves to nothing, so the
+  // common case costs one syscall and never touches the shell.
+  const candidate = canonicalFile(path.join(root, normalized))
+  if (candidate === null) return false
+  // Both sides are resolved fresh, per request, and neither answer is cached.
+  // Caching either one latches: a null latch makes every spelling look like "not
+  // the shell", and a SUCCESS latch keeps the identity the shell had at first
+  // request, so a symlink-swap deploy or a replaced build leaves the cached
+  // identity pointing at a file the request no longer names. Both mistakes end
+  // the same way, with `express.static` serving the raw file.
+  return candidate === canonicalFile(shellFile)
+}
+
+/**
+ * Inject the mount point into the shell's `<head>`.
+ *
+ * The bundle is built with a RELATIVE Vite base, so `index.html` asks for
+ * `./assets/…` and the browser resolves that against the page URL. A deep route
+ * like `/clawboo/board` would resolve it to `/clawboo/board/assets/…`, so the
+ * `<base href>` pins resolution to the mount regardless of the current route.
+ *
+ * Injected even at the root (`href="/"`), on purpose: the catch-all serves this
+ * same shell for manufactured deep paths, so an uninjected relative-base document
+ * would white-screen there. One code path, and the root's behavior is unchanged.
+ *
+ * `window.__CLAWBOO_BASE__` is the same answer for JS, read by
+ * `src/app/bootstrapBase.ts` (API + SSE URLs) and by the gateway client (the
+ * WebSocket URL). Assets use `<base>`, code uses the global.
+ */
+function injectBase(html: string, basePath: string): string {
+  const href = `${basePath}/`
+  const tags =
+    `<base href="${attr(href)}" />` +
+    `<script>window.__CLAWBOO_BASE__=${JSON.stringify(basePath)}</script>`
+  // After the opening <head> so the base applies to every URL that follows it
+  // (a <base> only governs elements AFTER it in document order).
+  const headIdx = html.search(/<head[^>]*>/i)
+  if (headIdx === -1) return tags + html
+  const insertAt = html.indexOf('>', headIdx) + 1
+  return html.slice(0, insertAt) + tags + html.slice(insertAt)
+}
 
 /**
  * Serve the Vite build output as a static SPA: real files first, then an
@@ -8,27 +99,116 @@ import express, { type Express } from 'express'
  *
  * Extracted from the server boot purely so it can be tested — the dot-directory
  * case below is impossible to reproduce from a normal repo checkout.
+ *
+ * `basePath` is the already-normalized URL prefix the app is mounted under ('' at
+ * the root). Requests arrive here with the prefix ALREADY STRIPPED (see
+ * `basePathMiddleware`), so it is used only to template the shell, never to match.
  */
-export function mountSpa(app: Express, uiDir: string): void {
+export function mountSpa(app: Express, uiDir: string, basePath = ''): void {
   const root = path.resolve(uiDir)
-  app.use(express.static(root))
+
+  /**
+   * Send the templated shell with the caching headers `express.static` used to
+   * put on it. Serving from memory would otherwise silently drop them, and
+   * `Cache-Control: public, max-age=0` plus `Last-Modified` are what let a
+   * browser revalidate into a 304 instead of re-downloading the document on
+   * every navigation. `Accept-Ranges` is deliberately NOT restored: `send`
+   * advertised range support because it streamed a file, and this response
+   * cannot serve one. Express adds the ETag itself.
+   */
+  const sendShell = (res: Response, html: string): void => {
+    res.type('html')
+    res.setHeader('Cache-Control', 'public, max-age=0')
+    const mtime = shellMtime()
+    if (mtime) res.setHeader('Last-Modified', mtime)
+    // `send` omits the body for HEAD on its own.
+    res.send(html)
+  }
+
+  const shellFile = path.join(root, 'index.html')
+
+  /** The shell's on-disk mtime as an HTTP date, or null when it cannot be read. */
+  const shellMtime = (): string | null => {
+    try {
+      return fs.statSync(shellFile).mtime.toUTCString()
+    } catch {
+      return null
+    }
+  }
+
+  // Read + template on demand, then serve from memory. The shell is a few KB and
+  // the injection is a pure function of (file, basePath), so re-reading per
+  // request would buy nothing. Failure is NOT latched: the ui dir can be
+  // unreadable for a moment (a slow network or container mount, a Windows
+  // indexer's handle, EMFILE), and one bad read must not outlive it.
+  let cached: string | null = null
+
+  const shell = (): string | null => {
+    if (cached !== null) return cached
+    try {
+      cached = injectBase(fs.readFileSync(shellFile, 'utf8'), basePath)
+      return cached
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * The invariant: a request for the shell is answered with the TEMPLATED shell
+   * or with an error. Never with the file on disk.
+   *
+   * An untemplated shell carries no mount point, so the SPA it boots addresses
+   * the origin root for every request, and on the shared hostname this feature
+   * exists for that hands clawboo's traffic to a neighbouring app. It is also
+   * broken on its own terms: the build uses a relative base, so without the
+   * injected `<base href>` a deep route resolves `./assets/…` against the route
+   * and white-screens.
+   *
+   * So there is no fall-through here. Calling `next()` on a shell-shaped path
+   * would hand it to `express.static` (or, in the catch-all, to `sendFile`),
+   * either of which answers 200 with the raw document. A read failure is a
+   * genuine 503: the server knows what was wanted and cannot produce it, and
+   * saying so is both honest and safe, where guessing is neither.
+   */
+  const serveShellOr503 = (res: Response): void => {
+    const html = shell()
+    if (html !== null) {
+      sendShell(res, html)
+      return
+    }
+    res
+      .status(503)
+      .type('text')
+      .send('The Clawboo dashboard could not be read from disk. Check CLAWBOO_UI_DIR.')
+  }
+
+  // Intercept the shell BEFORE the static handler, which would otherwise answer
+  // with the raw file. (`index: false` below only suppresses the DIRECTORY
+  // index, not an explicit `/index.html`.)
+  app.use((req, res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') return next()
+    if (!isShellPath(req.path, root, shellFile)) return next()
+    serveShellOr503(res)
+  })
+
+  app.use(express.static(root, { index: false }))
 
   // SPA catch-all: any unmatched GET serves index.html so client-side routing
   // works. We use `app.use(handler)` rather than a wildcard pattern
   // (`'/*splat'` / `'/{*splat}'`) — Express 5 + path-to-regexp v8 have subtle
   // matching quirks around the bare `/` path that produced "Cannot GET /".
   // `app.use` with no path matches every request by definition. Restricting to
-  // GET keeps non-GET 404s honest.
+  // GET and HEAD keeps other methods 404ing honestly, while keeping HEAD and GET
+  // in agreement on every URL (a HEAD that 404s where GET returns 200 breaks
+  // uptime probes and violates RFC 9110).
+  //
+  // Historical note: this used to end in `res.sendFile('index.html', { root })`,
+  // and the `{ root }` form was load-bearing, because `send` explodes a bare
+  // absolute path into segments and 404s any that starts with a dot, which is
+  // where `npx clawboo` installs (`~/.npm/_npx/…`). Serving from memory retires
+  // that hazard: `readFileSync` does not care about dot-directories.
   app.use((req, res, next) => {
-    if (req.method !== 'GET') return next()
-    // `sendFile` MUST take a relative path + `{ root }`, never one absolute
-    // path. Without `root`, `send` explodes the WHOLE absolute path into
-    // segments and 404s if any segment starts with a dot (its default
-    // `dotfiles: 'ignore'`). `npx clawboo` installs under `~/.npm/_npx/…`, so
-    // the `.npm` segment made every deep route 404 for real users while `/`
-    // still worked — `express.static` above already passes a `root`, so only
-    // this fallback was affected. CI never caught it: runners check out to a
-    // dot-free path.
-    res.sendFile('index.html', { root })
+    if (req.method !== 'GET' && req.method !== 'HEAD') return next()
+    serveShellOr503(res)
   })
 }

--- a/apps/web/src/app/bootstrapBase.ts
+++ b/apps/web/src/app/bootstrapBase.ts
@@ -1,0 +1,34 @@
+// Teach the control client which URL prefix this page is served under, BEFORE any
+// module that might issue a request is evaluated.
+//
+// The bundle ships prebuilt through npm, so the prefix cannot be baked in at build
+// time: the same `dist/ui` has to work at `/` and at `/clawboo/`. The server
+// templates the answer into the shell it serves (`window.__CLAWBOO_BASE__`), and
+// this module hands it to `setApiBase` so every `apiUrl`/`apiFetch` call resolves
+// against it.
+//
+// Import it FIRST in main.tsx. ES module evaluation is depth-first in import
+// order, so a first-position import runs before the rest of the graph, which is
+// what guarantees no request is built against the default empty base.
+//
+// With the global absent (dev, or an older server serving a newer bundle) nothing
+// is called and the client keeps its same-origin default, so the root install is
+// byte-identical to before this existed.
+
+import { setApiBase } from '@clawboo/control-client'
+
+/** The prefix the server templated into the shell, or '' when served at the root. */
+export function readInjectedBase(): string {
+  const raw = (globalThis as { __CLAWBOO_BASE__?: unknown }).__CLAWBOO_BASE__
+  if (typeof raw !== 'string') return ''
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed === '/') return ''
+  // Defensive: the server normalizes before injecting, so this only guards a
+  // hand-edited shell. Same shape the contract guarantees (leading slash, no
+  // trailing slash) so `${base}/api/...` keeps exactly one slash.
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeading.replace(/\/+$/, '')
+}
+
+const base = readInjectedBase()
+if (base) setApiBase(base)

--- a/apps/web/src/app/bootstrapBase.ts
+++ b/apps/web/src/app/bootstrapBase.ts
@@ -27,7 +27,11 @@ export function readInjectedBase(): string {
   // hand-edited shell. Same shape the contract guarantees (leading slash, no
   // trailing slash) so `${base}/api/...` keeps exactly one slash.
   const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
-  return withLeading.replace(/\/+$/, '')
+  // Scanned, not `/\/+$/`: that pattern backtracks polynomially on a long run of
+  // slashes, and this reads a value out of the document.
+  let end = withLeading.length
+  while (end > 0 && withLeading[end - 1] === '/') end -= 1
+  return withLeading.slice(0, end)
 }
 
 const base = readInjectedBase()

--- a/apps/web/src/app/cost/CostDashboard.tsx
+++ b/apps/web/src/app/cost/CostDashboard.tsx
@@ -18,6 +18,7 @@ import { PanelHeader } from '@/features/shared/PanelHeader'
 import { EmptyState } from '@/features/shared/EmptyState'
 import { FormattedAlert } from '@/features/shared/FormattedAlert'
 import { Skeleton } from '@/features/shared/Skeleton'
+import { apiFetch } from '@clawboo/control-client'
 
 // ─── API response types ─────────────────────────────────────────────────────
 
@@ -295,7 +296,7 @@ export function CostDashboard() {
     setLoading(true)
     setError(null)
 
-    fetch('/api/cost-records/summary')
+    apiFetch('/api/cost-records/summary')
       .then((res) => res.json() as Promise<TokenSummaryResponse>)
       .then((json) => {
         if (!cancelled) {

--- a/apps/web/src/features/agent-detail/MiniGraph.tsx
+++ b/apps/web/src/features/agent-detail/MiniGraph.tsx
@@ -35,7 +35,7 @@ import { nativeProviderIdForGroup } from '@/lib/nativeModelCatalog'
 import { refreshFleetFromRegistry } from '@/lib/agentSourceClient'
 import { useOpenclawDefaultModel } from '@/lib/openclawDefaultModel'
 import { onReducedMotionChange, prefersReducedMotion } from '@/lib/prefersReducedMotion'
-import { setAgentModel } from '@clawboo/control-client'
+import { apiFetch, setAgentModel } from '@clawboo/control-client'
 import type { GraphNode, GraphEdge, BooNodeData, SkillNodeData } from '@/features/graph/types'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -652,7 +652,7 @@ export function MiniGraph({ agentId }: { agentId: string }) {
       }
       // OpenClaw: persist to openclaw.json + apply to the live session.
       try {
-        await fetch('/api/system/openclaw-config', {
+        await apiFetch('/api/system/openclaw-config', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentModel: { agentId: agent.id, model } }),

--- a/apps/web/src/features/approvals/useApprovalActions.ts
+++ b/apps/web/src/features/approvals/useApprovalActions.ts
@@ -6,7 +6,7 @@ import { useFleetStore } from '@/stores/fleet'
 import type { DbApprovalHistory } from '@clawboo/db'
 import { GatewayResponseError } from '@clawboo/gateway-client'
 import { resolveExecPatchParams, upsertExecApprovalPolicy } from '@/lib/execSettingsForGateway'
-import { listAgentSessions } from '@clawboo/control-client'
+import { apiFetch, listAgentSessions } from '@clawboo/control-client'
 
 // ─── Parsers ─────────────────────────────────────────────────────────────────
 
@@ -187,7 +187,7 @@ export function useApprovalActions() {
 
         if (agentId) {
           try {
-            const res = await fetch('/api/approvals', {
+            const res = await apiFetch('/api/approvals', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({

--- a/apps/web/src/features/approvals/usePendingApprovals.ts
+++ b/apps/web/src/features/approvals/usePendingApprovals.ts
@@ -5,6 +5,7 @@ import { useBooZeroStore } from '@/stores/booZero'
 import { useFleetStore } from '@/stores/fleet'
 import { useReadSequencer } from '@/lib/useReadSequencer'
 import { useVisiblePolling } from '@/lib/useVisiblePolling'
+import { apiFetch } from '@clawboo/control-client'
 
 // A pending MCP tool-call / delegation approval (from GET /api/tools/approvals).
 // Distinct from the OpenClaw exec `ApprovalRequest` — different fields + a different
@@ -55,7 +56,7 @@ export function useToolApprovals(): {
   const refetch = useCallback(async () => {
     const read = reads.beginRead()
     try {
-      const r = await fetch('/api/tools/approvals?status=pending')
+      const r = await apiFetch('/api/tools/approvals?status=pending')
       const body = r.ok ? ((await r.json()) as { approvals?: ToolApproval[] }) : { approvals: [] }
       if (!read.isCurrent()) return // predates a resolve, or superseded by a newer read
       setTool(body.approvals ?? [])
@@ -75,7 +76,7 @@ export function useToolApprovals(): {
       reads.commitLocalWrite() // any read already in flight still lists this approval
       setTool((prev) => prev.filter((a) => a.id !== id)) // optimistic removal
       try {
-        await fetch(`/api/tools/approvals/${id}/resolve`, {
+        await apiFetch(`/api/tools/approvals/${id}/resolve`, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ decision }),

--- a/apps/web/src/features/boo-zero/DisplayNameEditor.tsx
+++ b/apps/web/src/features/boo-zero/DisplayNameEditor.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/features/shared/Button'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
 import { syncBooZeroSoulIdentity } from '@/lib/booZeroIdentitySync'
+import { apiFetch } from '@clawboo/control-client'
 
 export function DisplayNameEditor({
   agentId,
@@ -34,7 +35,7 @@ export function DisplayNameEditor({
     const trimmed = value.trim() || 'Boo Zero'
     setSaving(true)
     try {
-      const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(agentId)}`, {
+      const res = await apiFetch(`/api/boo-zero/display-name/${encodeURIComponent(agentId)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: trimmed }),

--- a/apps/web/src/features/boo-zero/GlobalBriefEditor.tsx
+++ b/apps/web/src/features/boo-zero/GlobalBriefEditor.tsx
@@ -12,6 +12,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { RefreshCw, Save } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { Button } from '@/features/shared/Button'
 import { useTeamStore } from '@/stores/team'
 import { useToastStore } from '@/stores/toast'
@@ -23,13 +24,13 @@ interface BriefResponse {
 }
 
 async function fetchGlobalBrief(): Promise<BriefResponse> {
-  const res = await fetch('/api/boo-zero/global-brief')
+  const res = await apiFetch('/api/boo-zero/global-brief')
   if (!res.ok) throw new Error('Failed to load global brief')
   return (await res.json()) as BriefResponse
 }
 
 async function putGlobalBrief(content: string): Promise<void> {
-  const res = await fetch('/api/boo-zero/global-brief', {
+  const res = await apiFetch('/api/boo-zero/global-brief', {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content }),

--- a/apps/web/src/features/chat/ChatPanel.tsx
+++ b/apps/web/src/features/chat/ChatPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 import { AgentBooAvatar } from '@/components/AgentBooAvatar'
 import { useFleetStore } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
@@ -68,7 +69,7 @@ export function ChatPanel({
     const existing = useChatStore.getState().transcripts.get(sessionKey)
     if (existing && existing.length > 0) return
 
-    fetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`)
+    apiFetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`)
       .then((r) => r.json())
       .then(({ entries: historical }: { entries?: TranscriptEntry[] }) => {
         if (historical && historical.length > 0) {
@@ -190,7 +191,7 @@ export function ChatPanel({
       const trimmed = message.trim()
       if (isNativeChat && (trimmed === '/reset' || trimmed === '/new')) {
         useChatStore.getState().clearTranscript(sessionKey)
-        void fetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`, {
+        void apiFetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`, {
           method: 'DELETE',
         }).catch(() => {})
         return
@@ -245,7 +246,7 @@ export function ChatPanel({
           // Best-effort: a miss injects nothing.
           let activityBlock: string | null = null
           try {
-            const res = await fetch(
+            const res = await apiFetch(
               `/api/teams/${encodeURIComponent(mention.targetId)}/activity-summary`,
             )
             if (res.ok) {

--- a/apps/web/src/features/chat/chatSendOperation.ts
+++ b/apps/web/src/features/chat/chatSendOperation.ts
@@ -2,6 +2,7 @@
 
 import type { GatewayClientLike } from '@clawboo/gateway-client'
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 import { useChatStore } from '@/stores/chat'
 import { useFleetStore } from '@/stores/fleet'
 import { useConnectionStore } from '@/stores/connection'
@@ -134,7 +135,7 @@ export async function sendChatMessage({
 
   // Persist user message to SQLite (best-effort)
   const gwUrl = useConnectionStore.getState().gatewayUrl ?? ''
-  void fetch('/api/chat-history', {
+  void apiFetch('/api/chat-history', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ sessionKey, gatewayUrl: gwUrl, entries: [userEntry] }),

--- a/apps/web/src/features/chat/nativeAgentChatSend.ts
+++ b/apps/web/src/features/chat/nativeAgentChatSend.ts
@@ -5,6 +5,7 @@
 // replaces `client.chat.send` (which only knows OpenClaw agents).
 
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 
 import { nextSeq } from '@/lib/sequenceKey'
 import { useChatStore } from '@/stores/chat'
@@ -54,7 +55,7 @@ export async function sendNativeAgentMessage({
     .appendTranscript(sessionKey, [makeUserEntry(sessionKey, shownText, entryId)])
 
   try {
-    const res = await fetch(`/api/agents/${encodeURIComponent(agentId)}/chat`, {
+    const res = await apiFetch(`/api/agents/${encodeURIComponent(agentId)}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: trimmed, displayText: shownText, entryId }),
@@ -76,7 +77,7 @@ export async function sendNativeAgentMessage({
 /** Abort the in-flight conversational turn (the composer's Stop button). */
 export async function stopNativeAgentChat(agentId: string): Promise<void> {
   try {
-    await fetch(`/api/agents/${encodeURIComponent(agentId)}/chat/stop`, { method: 'POST' })
+    await apiFetch(`/api/agents/${encodeURIComponent(agentId)}/chat/stop`, { method: 'POST' })
   } catch {
     // best-effort
   }

--- a/apps/web/src/features/chat/useNativeAgentChatStream.ts
+++ b/apps/web/src/features/chat/useNativeAgentChatStream.ts
@@ -13,6 +13,7 @@ import {
   applyDeltaFrame,
   type EventSourceFactory,
 } from '@/features/group-chat/useTeamChatStream'
+import { apiUrl } from '@clawboo/control-client'
 
 export interface UseNativeAgentChatStreamParams {
   agentId: string
@@ -39,7 +40,7 @@ export function useNativeAgentChatStream({
       (typeof EventSource !== 'undefined' ? (url: string) => new EventSource(url) : null)
     if (!factory) return
 
-    const es = factory(`/api/agents/${encodeURIComponent(agentId)}/chat/stream`)
+    const es = factory(apiUrl(`/api/agents/${encodeURIComponent(agentId)}/chat/stream`))
     const onCommitted = (e: MessageEvent): void => {
       applyCommittedFrame(e.data as string)
       onActivityRef.current?.()

--- a/apps/web/src/features/connection/DevicePairingApproval.tsx
+++ b/apps/web/src/features/connection/DevicePairingApproval.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import { motion } from 'framer-motion'
 import { CheckCircle2, ShieldCheck } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { Button } from '@/features/shared/Button'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -36,7 +37,7 @@ export function DevicePairingApproval({ onApproved, onCancel }: DevicePairingApp
     setPhase('approving')
     setErrorMessage(null)
     try {
-      const res = await fetch('/api/system/approve-device', { method: 'POST' })
+      const res = await apiFetch('/api/system/approve-device', { method: 'POST' })
       const data = (await res.json().catch(() => ({}))) as {
         ok?: boolean
         error?: string

--- a/apps/web/src/features/connection/GatewayBootstrap.tsx
+++ b/apps/web/src/features/connection/GatewayBootstrap.tsx
@@ -64,7 +64,7 @@ import { useBooZeroStore, identifyBooZero } from '@/stores/booZero'
 import { hydrateTeams } from '@/lib/hydrateTeams'
 import { DEFAULT_COLLECTION_ID } from '@/lib/teamPalettes'
 import { TEAM_ACCENT_PRESETS } from '@/features/teams/TeamAccentPicker'
-import { consumeApiSSE, pushAgentSync, listAgents } from '@clawboo/control-client'
+import { apiFetch, consumeApiSSE, pushAgentSync, listAgents } from '@clawboo/control-client'
 import { fetchAgentModelMap } from '@/lib/agentModelMap'
 import type { AgentState } from '@/stores/fleet'
 import type { SystemInfo } from '@/stores/system'
@@ -89,7 +89,7 @@ function markOnboarded(): void {
  *  dashboard on reload rather than re-running the wizard. Best-effort (REST). */
 async function hasNativeAgents(): Promise<boolean> {
   try {
-    const res = await fetch('/api/agents')
+    const res = await apiFetch('/api/agents')
     if (!res.ok) return false
     const body = (await res.json()) as {
       agents?: { id?: string; runtime?: string; sourceId?: string }[]
@@ -114,7 +114,7 @@ async function hasNativeAgents(): Promise<boolean> {
  *  Best-effort (REST). */
 async function hasGatewayIndependentAgents(): Promise<boolean> {
   try {
-    const res = await fetch('/api/agents')
+    const res = await apiFetch('/api/agents')
     if (!res.ok) return false
     const body = (await res.json()) as {
       agents?: { runtime?: string; sourceId?: string }[]
@@ -141,7 +141,7 @@ async function hasGatewayIndependentAgents(): Promise<boolean> {
  *  non-OpenClaw runtimes, so OpenClaw is excluded by construction. Best-effort. */
 async function hasConnectedRuntime(): Promise<boolean> {
   try {
-    const res = await fetch('/api/runtimes')
+    const res = await apiFetch('/api/runtimes')
     if (!res.ok) return false
     const body = (await res.json()) as {
       runtimes?: { hasVaultCredential?: boolean; authKind?: string; loggedIn?: boolean }[]
@@ -160,7 +160,7 @@ async function hasConnectedRuntime(): Promise<boolean> {
  *  not-configured reading may have left set. */
 async function hasAnyTeam(): Promise<boolean> {
   try {
-    const res = await fetch('/api/teams')
+    const res = await apiFetch('/api/teams')
     if (!res.ok) return false
     const body = (await res.json()) as { teams?: unknown[] } | unknown[]
     const teams = Array.isArray(body) ? body : (body.teams ?? [])
@@ -197,7 +197,7 @@ async function autoMigrateTeamlessAgents(): Promise<void> {
   } else {
     // Case A: no active teams (either empty or all archived) — create "Default" team
     try {
-      const res = await fetch('/api/teams', {
+      const res = await apiFetch('/api/teams', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -241,9 +241,9 @@ async function autoMigrateTeamlessAgents(): Promise<void> {
   if (booZeroId) {
     const booZero = agents.find((a) => a.id === booZeroId)
     if (booZero?.teamId) {
-      await fetch(`/api/teams/${booZero.teamId}/agents/${booZeroId}`, { method: 'DELETE' }).catch(
-        () => {},
-      )
+      await apiFetch(`/api/teams/${booZero.teamId}/agents/${booZeroId}`, {
+        method: 'DELETE',
+      }).catch(() => {})
       useFleetStore.setState((s) => ({
         agents: s.agents.map((a) => (a.id === booZeroId ? { ...a, teamId: null } : a)),
       }))
@@ -269,7 +269,7 @@ async function autoMigrateTeamlessAgents(): Promise<void> {
   // Assign each unassigned agent to the target team (upserts SQLite row)
   for (const agent of unassigned) {
     try {
-      await fetch(`/api/teams/${targetTeamId}/agents`, {
+      await apiFetch(`/api/teams/${targetTeamId}/agents`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId: agent.id, agentName: agent.name }),
@@ -293,7 +293,7 @@ async function autoMigrateTeamlessAgents(): Promise<void> {
 
 /** Fire-and-forget: pre-populate approval history from SQLite on connect. */
 function preloadApprovalHistory(): void {
-  fetch('/api/approvals')
+  apiFetch('/api/approvals')
     .then((r) => r.json())
     .then(({ records }: { records?: DbApprovalHistory[] }) => {
       if (records?.length) {
@@ -445,7 +445,7 @@ async function hydrateFleetFromClient(liveClient: GatewayClient): Promise<number
     if (booZeroId) {
       let override = ''
       try {
-        const res = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`)
+        const res = await apiFetch(`/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`)
         if (res.ok) {
           const body = (await res.json()) as { name?: string | null }
           override = (body.name ?? '').trim()
@@ -458,11 +458,14 @@ async function hydrateFleetFromClient(liveClient: GatewayClient): Promise<number
       // Gateway-side name; the next successful connect will seed).
       if (override.length === 0) {
         try {
-          const seed = await fetch(`/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name: 'Boo Zero' }),
-          })
+          const seed = await apiFetch(
+            `/api/boo-zero/display-name/${encodeURIComponent(booZeroId)}`,
+            {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: 'Boo Zero' }),
+            },
+          )
           if (seed.ok) override = 'Boo Zero'
         } catch {
           // Best-effort.
@@ -589,7 +592,7 @@ export function GatewayBootstrap() {
       // then got trapped in the wizard forever. `info === null` ⇒ transient.
       let info: SystemInfo | null = null
       try {
-        const resp = await fetch('/api/system/status')
+        const resp = await apiFetch('/api/system/status')
         if (resp.ok) info = (await resp.json()) as SystemInfo
       } catch {
         // Transient — `info` stays null; the decision preserves existing flags.
@@ -786,7 +789,7 @@ export function GatewayBootstrap() {
         // 1. Check system status first
         let gatewayRunning = true // optimistic default if status check fails
         try {
-          const statusResp = await fetch('/api/system/status')
+          const statusResp = await apiFetch('/api/system/status')
           if (statusResp.ok) {
             const systemInfo = (await statusResp.json()) as SystemInfo
             gatewayRunning = systemInfo.gateway.running
@@ -808,7 +811,7 @@ export function GatewayBootstrap() {
         }
 
         // 2. If Gateway is running (or status unknown), try normal auto-connect
-        const resp = await fetch('/api/settings')
+        const resp = await apiFetch('/api/settings')
         if (!resp.ok) return
 
         const data = (await resp.json()) as { gatewayUrl?: string }
@@ -886,7 +889,7 @@ export function GatewayBootstrap() {
 
           // Gateway is up — now auto-connect
           try {
-            const resp = await fetch('/api/settings')
+            const resp = await apiFetch('/api/settings')
             const data = resp.ok
               ? ((await resp.json()) as { gatewayUrl?: string })
               : { gatewayUrl: 'ws://localhost:18789' }
@@ -975,7 +978,7 @@ export function GatewayBootstrap() {
 
   /** Connect a fresh client + upgrade native mode → gateway mode. */
   const connectAndEnterGatewayMode = useCallback(async () => {
-    const resp = await fetch('/api/settings')
+    const resp = await apiFetch('/api/settings')
     const data = resp.ok ? ((await resp.json()) as { gatewayUrl?: string }) : {}
     const url = data.gatewayUrl?.trim() || 'ws://localhost:18789'
     const prev = useConnectionStore.getState().client
@@ -1024,7 +1027,7 @@ export function GatewayBootstrap() {
       // 1. Ensure the Gateway process is running (start it if not).
       let running = true
       try {
-        const st = await fetch('/api/system/status')
+        const st = await apiFetch('/api/system/status')
         if (st.ok) running = ((await st.json()) as SystemInfo).gateway.running
       } catch {
         /* optimistic — attempt the connect anyway */
@@ -1231,7 +1234,7 @@ export function GatewayBootstrap() {
               className="surface-overlay-tier w-full max-w-[340px] rounded-2xl p-8"
             >
               <div className="flex flex-col items-center gap-4 text-center">
-                <img src="/logo.svg" alt="Clawboo" width={48} height={44} className="opacity-40" />
+                <img src="logo.svg" alt="Clawboo" width={48} height={44} className="opacity-40" />
                 <div>
                   <h2
                     className="text-[20px] font-bold text-text"

--- a/apps/web/src/features/connection/GatewayConnectScreen.tsx
+++ b/apps/web/src/features/connection/GatewayConnectScreen.tsx
@@ -8,6 +8,7 @@ import {
   isLocalGatewayUrl,
   resolveProxyGatewayUrl,
 } from '@clawboo/gateway-client'
+import { apiFetch } from '@clawboo/control-client'
 import { useConnectionStore } from '@/stores/connection'
 import { DevicePairingApproval } from './DevicePairingApproval'
 
@@ -60,7 +61,7 @@ export function GatewayConnectScreen({
 
   // Pre-fill from persisted settings on mount
   useEffect(() => {
-    fetch('/api/settings')
+    apiFetch('/api/settings')
       .then((r) => r.json())
       .then((data: { gatewayUrl?: string; hasToken?: boolean }) => {
         if (data.gatewayUrl?.trim()) setUrl(data.gatewayUrl.trim())
@@ -104,7 +105,7 @@ export function GatewayConnectScreen({
       // only save the URL — leave the existing saved token intact so the proxy
       // can inject it. If the user explicitly cleared or typed a new token, save that.
       const tokenChanged = trimmedToken.length > 0
-      await fetch('/api/settings', {
+      await apiFetch('/api/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -195,7 +196,7 @@ export function GatewayConnectScreen({
         {/* ── Logo / header ── */}
         <div className="mb-8 flex flex-col items-center gap-3 text-center">
           <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-accent/12 ring-1 ring-accent/20">
-            <img src="/logo.svg" alt="Clawboo" width={32} height={30} />
+            <img src="logo.svg" alt="Clawboo" width={32} height={30} />
           </div>
           <div>
             <h1

--- a/apps/web/src/features/connection/useGatewayEvents.ts
+++ b/apps/web/src/features/connection/useGatewayEvents.ts
@@ -4,7 +4,7 @@ import type { AgentStatusPatch, ChatCost } from '@clawboo/events'
 import { createEventHandler, createPatchQueue, processEvent } from '@clawboo/events'
 import type { TranscriptEntry } from '@clawboo/protocol'
 import { isTeamSessionKey } from '@clawboo/team-orchestration'
-import { listAgentSessions } from '@clawboo/control-client'
+import { apiFetch, listAgentSessions } from '@clawboo/control-client'
 import { useChatStore } from '@/stores/chat'
 import { useConnectionStore } from '@/stores/connection'
 import { useFleetStore } from '@/stores/fleet'
@@ -59,7 +59,7 @@ export function recordChatCost(agentId: string, runId: string | null, cost: Chat
     useChatStore.getState().setLastTokenUsage(runId, inputTokens, cost.outputTokens)
   }
 
-  void fetch('/api/cost-records', {
+  void apiFetch('/api/cost-records', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -281,7 +281,7 @@ export function useGatewayEvents(client: GatewayClient | null): void {
 
         // Best-effort persistence — never throw in an event handler
         const gwUrl = useConnectionStore.getState().gatewayUrl ?? ''
-        void fetch('/api/chat-history', {
+        void apiFetch('/api/chat-history', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ sessionKey, gatewayUrl: gwUrl, entries }),

--- a/apps/web/src/features/editor/AgentFileEditor.tsx
+++ b/apps/web/src/features/editor/AgentFileEditor.tsx
@@ -1,4 +1,4 @@
-import { readAgentFile, writeAgentFile } from '@clawboo/control-client'
+import { apiFetch, readAgentFile, writeAgentFile } from '@clawboo/control-client'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Save, X } from 'lucide-react'
 import {
@@ -113,7 +113,7 @@ export function AgentFileEditor({ agentId, agentName, onClose }: AgentFileEditor
         // description, or values are out of date).
         const soulRaw = next['SOUL.md']?.content ?? ''
         try {
-          const res = await fetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
+          const res = await apiFetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
           const data = (await res.json()) as { values: unknown }
           if (data.values && isPersonalityValues(data.values)) {
             const base = stripPersonalityBlock(soulRaw)
@@ -141,7 +141,7 @@ export function AgentFileEditor({ agentId, agentName, onClose }: AgentFileEditor
     // Re-fetch personality from SQLite + re-merge into current SOUL.md
     void (async () => {
       try {
-        const res = await fetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
+        const res = await apiFetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
         const data = (await res.json()) as { values: unknown }
         if (data.values && isPersonalityValues(data.values)) {
           const currentSoul = filesRef.current['SOUL.md']?.content ?? ''

--- a/apps/web/src/features/editor/useAgentFiles.ts
+++ b/apps/web/src/features/editor/useAgentFiles.ts
@@ -1,4 +1,4 @@
-import { readAgentFile, writeAgentFile } from '@clawboo/control-client'
+import { apiFetch, readAgentFile, writeAgentFile } from '@clawboo/control-client'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AGENT_FILE_NAMES, type AgentFileName } from '@clawboo/protocol'
 import { useConnectionStore } from '@/stores/connection'
@@ -88,7 +88,7 @@ export function useAgentFiles(agentId: string): UseAgentFilesReturn {
         // Strip stale personality block from SOUL.md and re-merge from SQLite
         const soulRaw = next['SOUL.md']?.content ?? ''
         try {
-          const res = await fetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
+          const res = await apiFetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
           const data = (await res.json()) as { values: unknown }
           if (data.values && isPersonalityValues(data.values)) {
             const base = stripPersonalityBlock(soulRaw)
@@ -114,7 +114,7 @@ export function useAgentFiles(agentId: string): UseAgentFilesReturn {
 
     void (async () => {
       try {
-        const res = await fetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
+        const res = await apiFetch(`/api/personality?agentId=${encodeURIComponent(agentId)}`)
         const data = (await res.json()) as { values: unknown }
         if (data.values && isPersonalityValues(data.values)) {
           const currentSoul = filesRef.current['SOUL.md']?.content ?? ''

--- a/apps/web/src/features/fleet/CreateBooModal.tsx
+++ b/apps/web/src/features/fleet/CreateBooModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useId } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 import { useConnectionStore } from '@/stores/connection'
 import { useTeamStore } from '@/stores/team'
 import { createAgent } from '@/lib/createAgent'
@@ -70,7 +71,7 @@ export function CreateBooModal({
       })
 
       // Persist default personality to SQLite so sliders load correctly
-      void fetch('/api/personality', {
+      void apiFetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId, values: DEFAULT_PERSONALITY }),
@@ -80,7 +81,7 @@ export function CreateBooModal({
       const selectedTeamId = useTeamStore.getState().selectedTeamId
       if (selectedTeamId) {
         try {
-          await fetch(`/api/teams/${selectedTeamId}/agents`, {
+          await apiFetch(`/api/teams/${selectedTeamId}/agents`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ agentId }),

--- a/apps/web/src/features/fleet/FirstRunNudge.tsx
+++ b/apps/web/src/features/fleet/FirstRunNudge.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Rocket, X } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 
 import { useViewStore } from '@/stores/view'
 import { useTourStore } from '@/stores/tour'
@@ -16,7 +17,7 @@ const muted = (o: number) => `rgb(var(--foreground-rgb) / ${o})`
 
 async function countCompletedTasks(): Promise<number> {
   try {
-    const res = await fetch('/api/board?status=done')
+    const res = await apiFetch('/api/board?status=done')
     if (!res.ok) return 0
     const body = (await res.json()) as { tasks?: unknown[] }
     return Array.isArray(body.tasks) ? body.tasks.length : 0
@@ -27,7 +28,7 @@ async function countCompletedTasks(): Promise<number> {
 
 async function persistDismiss(): Promise<void> {
   try {
-    await fetch('/api/settings', {
+    await apiFetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ firstRunDismissedAt: Date.now() }),
@@ -53,7 +54,7 @@ export function FirstRunNudge() {
     let alive = true
     void (async () => {
       try {
-        const settings = (await (await fetch('/api/settings')).json()) as {
+        const settings = (await (await apiFetch('/api/settings')).json()) as {
           firstRunDismissedAt?: number | null
         }
         if (settings.firstRunDismissedAt != null) return

--- a/apps/web/src/features/fleet/deleteAgentOperation.ts
+++ b/apps/web/src/features/fleet/deleteAgentOperation.ts
@@ -1,7 +1,7 @@
 import { useFleetStore } from '@/stores/fleet'
 import { useChatStore } from '@/stores/chat'
 import { useBooZeroStore, identifyBooZero } from '@/stores/booZero'
-import { archiveAgentRecord } from '@clawboo/control-client'
+import { apiFetch, archiveAgentRecord } from '@clawboo/control-client'
 
 export async function deleteAgentOperation(
   agentId: string,
@@ -22,7 +22,7 @@ export async function deleteAgentOperation(
   // 4. Clear transcript + SQLite history (if session key exists)
   if (sessionKey) {
     useChatStore.getState().clearTranscript(sessionKey)
-    fetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`, {
+    apiFetch(`/api/chat-history?sessionKey=${encodeURIComponent(sessionKey)}`, {
       method: 'DELETE',
     }).catch(() => {})
   }

--- a/apps/web/src/features/graph/GhostGraph.tsx
+++ b/apps/web/src/features/graph/GhostGraph.tsx
@@ -1,4 +1,4 @@
-import { readAgentFile, writeAgentFile } from '@clawboo/control-client'
+import { apiFetch, readAgentFile, writeAgentFile } from '@clawboo/control-client'
 import '@xyflow/react/dist/style.css'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -876,7 +876,7 @@ export function GhostGraph({ scope = 'team' }: { scope?: GhostGraphScope } = {})
         })
 
         // Ensure agent-to-agent coordination is enabled in Gateway config (idempotent)
-        fetch('/api/system/openclaw-config', {
+        apiFetch('/api/system/openclaw-config', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentToAgent: { enabled: true } }),

--- a/apps/web/src/features/graph/useGraphPersistence.ts
+++ b/apps/web/src/features/graph/useGraphPersistence.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 import { useGraphStore } from './store'
 import { useConnectionStore } from '@/stores/connection'
 import { useTeamStore } from '@/stores/team'
@@ -69,7 +70,7 @@ export function useGraphPersistence(scope: GhostGraphScope = 'team') {
     setIsLoaded(false) // Reset on team / mode switch — wait for fresh positions
 
     const url = `/api/graph-layout?name=${encodeURIComponent(layoutName)}&url=${encodeURIComponent(scopeUrl)}`
-    void fetch(url)
+    void apiFetch(url)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: LayoutData | null) => {
         // Always reset savedPositions to whatever the new key holds —
@@ -96,7 +97,7 @@ export function useGraphPersistence(scope: GhostGraphScope = 'team') {
     (positions: LayoutData['positions']) => {
       if (saveTimer.current) clearTimeout(saveTimer.current)
       saveTimer.current = setTimeout(() => {
-        void fetch('/api/graph-layout', {
+        void apiFetch('/api/graph-layout', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: layoutName, positions, gatewayUrl: scopeUrl }),

--- a/apps/web/src/features/group-chat/GroupChatPanel.tsx
+++ b/apps/web/src/features/group-chat/GroupChatPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 import { useFleetStore } from '@/stores/fleet'
 import { useTeamStore } from '@/stores/team'
 import { useChatStore } from '@/stores/chat'
@@ -377,7 +378,7 @@ export function GroupChatPanel({
       const existing = useChatStore.getState().transcripts.get(teamSk)
       if (existing && existing.length > 0) continue
 
-      void fetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
+      void apiFetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
         .then((r) => r.json())
         .then(({ entries: historical }: { entries?: TranscriptEntry[] }) => {
           if (cancelled) return

--- a/apps/web/src/features/group-chat/GroupChatView.tsx
+++ b/apps/web/src/features/group-chat/GroupChatView.tsx
@@ -23,6 +23,7 @@
 
 import { useEffect, useMemo, useRef } from 'react'
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 import { TeamOnboardingGate } from './TeamOnboardingGate'
 import { GroupChatViewHeader } from './GroupChatViewHeader'
 import { useTeamOnboarding } from './useTeamOnboarding'
@@ -74,7 +75,7 @@ export function GroupChatView({ teamId }: { teamId: string }) {
       const teamSk = buildTeamSessionKey(agent.id, teamId)
       const existing = useChatStore.getState().transcripts.get(teamSk)
       if (existing && existing.length > 0) continue
-      fetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
+      apiFetch(`/api/chat-history?sessionKey=${encodeURIComponent(teamSk)}`)
         .then((r) => r.json())
         .then(({ entries: historical }: { entries?: TranscriptEntry[] }) => {
           if (historical && historical.length > 0) {

--- a/apps/web/src/features/group-chat/TeamBriefForm.tsx
+++ b/apps/web/src/features/group-chat/TeamBriefForm.tsx
@@ -7,6 +7,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { RefreshCw, Save } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { Button } from '@/features/shared/Button'
 import { Spinner } from '@/features/shared/Spinner'
 import { useFleetStore } from '@/stores/fleet'
@@ -20,13 +21,13 @@ interface BriefResponse {
 }
 
 async function fetchTeamBrief(teamId: string): Promise<BriefResponse> {
-  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
+  const res = await apiFetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`)
   if (!res.ok) throw new Error('Failed to load team brief')
   return (await res.json()) as BriefResponse
 }
 
 async function putTeamBrief(teamId: string, content: string): Promise<void> {
-  const res = await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
+  const res = await apiFetch(`/api/boo-zero/team-briefs/${encodeURIComponent(teamId)}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content }),

--- a/apps/web/src/features/group-chat/TeamSettingsSheet.tsx
+++ b/apps/web/src/features/group-chat/TeamSettingsSheet.tsx
@@ -8,6 +8,7 @@
 
 import { useCallback, useId, useState } from 'react'
 import { X } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import type { Team } from '@/stores/team'
 import { useTeamStore } from '@/stores/team'
 import { IconButton } from '@/features/shared/Button'
@@ -37,7 +38,7 @@ export function TeamSettingsSheet({ team, onClose }: TeamSettingsSheetProps) {
   const persist = useCallback(
     (patch: { colorCollectionId?: CollectionId; color?: string; icon?: string }) => {
       useTeamStore.getState().updateTeam(team.id, patch)
-      void fetch(`/api/teams/${team.id}`, {
+      void apiFetch(`/api/teams/${team.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),

--- a/apps/web/src/features/group-chat/__tests__/serverTeamChatSend.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/serverTeamChatSend.test.ts
@@ -92,6 +92,13 @@ describe('stopServerTeam', () => {
     expect(useChatStore.getState().streamingText.get(sk1)).toBeUndefined()
     expect(useChatStore.getState().streamingText.get(sk2)).toBeUndefined()
     expect(useChatStore.getState().streamStartedAt.get(sk1)).toBeUndefined()
-    expect(fetchMock).toHaveBeenCalledWith('/api/teams/t1/chat/stop', { method: 'POST' })
+    // `headers: {}` is the control-client seam's injected-header slot (empty by
+    // default, populated by a remote/authenticated client). The URL stays
+    // root-relative because the base is empty unless the server mounts the app
+    // under a path prefix.
+    expect(fetchMock).toHaveBeenCalledWith('/api/teams/t1/chat/stop', {
+      method: 'POST',
+      headers: {},
+    })
   })
 })

--- a/apps/web/src/features/group-chat/__tests__/useTeamOnboarding.test.ts
+++ b/apps/web/src/features/group-chat/__tests__/useTeamOnboarding.test.ts
@@ -37,7 +37,10 @@ describe('useTeamOnboarding', () => {
 
     expect(result.current.agentsIntroduced).toBe(true)
     expect(result.current.userIntroduced).toBe(false)
-    expect(mockFetch).toHaveBeenCalledWith('/api/teams/team-1/onboarding')
+    // `headers: {}` is the control-client seam's injected-header slot (empty by
+    // default). The PATCH assertions below pass their own Content-Type, which
+    // wins the merge, so only this header-less GET shows the empty object.
+    expect(mockFetch).toHaveBeenCalledWith('/api/teams/team-1/onboarding', { headers: {} })
   })
 
   it('defaults to false/false when teamId is null and never fetches', async () => {

--- a/apps/web/src/features/group-chat/serverTeamChatSend.ts
+++ b/apps/web/src/features/group-chat/serverTeamChatSend.ts
@@ -7,6 +7,7 @@
 // `client` dependency (native mode has `client === null`).
 
 import type { TranscriptEntry } from '@clawboo/protocol'
+import { apiFetch } from '@clawboo/control-client'
 
 import { nextSeq } from '@/lib/sequenceKey'
 import { useChatStore } from '@/stores/chat'
@@ -49,7 +50,7 @@ export async function sendServerTeamMessage(params: SendServerTeamMessageParams)
   useChatStore.getState().appendTranscript(targetSessionKey, [optimistic])
 
   try {
-    const res = await fetch(`/api/teams/${encodeURIComponent(teamId)}/chat`, {
+    const res = await apiFetch(`/api/teams/${encodeURIComponent(teamId)}/chat`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message, targetAgentId, entryId }),
@@ -84,7 +85,7 @@ export async function stopServerTeam(params: StopServerTeamParams): Promise<void
     chat.clearStreamStart(sk)
   }
   try {
-    await fetch(`/api/teams/${encodeURIComponent(teamId)}/chat/stop`, { method: 'POST' })
+    await apiFetch(`/api/teams/${encodeURIComponent(teamId)}/chat/stop`, { method: 'POST' })
   } catch {
     // best-effort — the server also releases via its idle watchdog
   }

--- a/apps/web/src/features/group-chat/useTeamChatStream.ts
+++ b/apps/web/src/features/group-chat/useTeamChatStream.ts
@@ -30,6 +30,7 @@ import type { BoardChange } from '@/features/group-chat/boardOrchestration'
 import { useBoardStore } from '@/stores/board'
 import { useChatStore } from '@/stores/chat'
 import { useFleetStore } from '@/stores/fleet'
+import { apiUrl } from '@clawboo/control-client'
 
 export interface TeamChatDelta {
   sessionKey: string
@@ -158,7 +159,7 @@ export function useTeamChatStream({
       (typeof EventSource !== 'undefined' ? (url: string) => new EventSource(url) : null)
     if (!factory) return
 
-    const es = factory(`/api/teams/${encodeURIComponent(teamId)}/chat/stream`)
+    const es = factory(apiUrl(`/api/teams/${encodeURIComponent(teamId)}/chat/stream`))
 
     const onCommitted = (e: MessageEvent): void => {
       applyCommittedFrame(e.data as string)

--- a/apps/web/src/features/group-chat/useTeamOnboarding.ts
+++ b/apps/web/src/features/group-chat/useTeamOnboarding.ts
@@ -3,6 +3,7 @@
 // normal chat composer behind the "Know Your Team" + user introduction flow.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 
 export interface TeamOnboardingState {
   agentsIntroduced: boolean
@@ -42,7 +43,7 @@ export function useTeamOnboarding(teamId: string | null): UseTeamOnboardingResul
     setIsLoading(true)
     setError(null)
     try {
-      const res = await fetch(`/api/teams/${encodeURIComponent(id)}/onboarding`)
+      const res = await apiFetch(`/api/teams/${encodeURIComponent(id)}/onboarding`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = (await res.json()) as TeamOnboardingState
       if (mountedRef.current) {
@@ -76,7 +77,7 @@ export function useTeamOnboarding(teamId: string | null): UseTeamOnboardingResul
     async (body: Partial<TeamOnboardingState>): Promise<void> => {
       if (!teamId) return
       try {
-        const res = await fetch(`/api/teams/${encodeURIComponent(teamId)}/onboarding`, {
+        const res = await apiFetch(`/api/teams/${encodeURIComponent(teamId)}/onboarding`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body),

--- a/apps/web/src/features/health/healthClient.ts
+++ b/apps/web/src/features/health/healthClient.ts
@@ -2,6 +2,8 @@
 // probe surface). All calls return a parsed BootReport or throw a readable error;
 // the panel renders loading / error / report states.
 
+import { apiFetch } from '@clawboo/control-client'
+
 export interface BootCheck {
   id: string
   ok: boolean
@@ -46,10 +48,10 @@ async function parse(res: Response): Promise<BootReport> {
 
 /** GET the latest boot report (computed at boot, cached). */
 export async function fetchHealth(): Promise<BootReport> {
-  return parse(await fetch('/api/health'))
+  return parse(await apiFetch('/api/health'))
 }
 
 /** Recompute the boot report fresh (the "Re-run probe" button). */
 export async function recheckHealth(): Promise<BootReport> {
-  return parse(await fetch('/api/health/recheck', { method: 'POST' }))
+  return parse(await apiFetch('/api/health/recheck', { method: 'POST' }))
 }

--- a/apps/web/src/features/layout/TeamSidebar.tsx
+++ b/apps/web/src/features/layout/TeamSidebar.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { PanelLeftClose, PanelLeftOpen, Plus } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { useTeamStore, type Team } from '@/stores/team'
 import { useFleetStore } from '@/stores/fleet'
 import { useConnectionStore } from '@/stores/connection'
@@ -98,7 +99,7 @@ function MascotIcon({
             : 'border-2 border-transparent bg-foreground/[0.04] hover:bg-foreground/[0.07]',
         ].join(' ')}
       >
-        <img src="/logo.svg" width={26} height={24} alt="Boo Zero" />
+        <img src="logo.svg" width={26} height={24} alt="Boo Zero" />
       </button>
     </RailTip>
   )
@@ -175,7 +176,7 @@ export function TeamSidebar() {
     setContextMenu(null)
 
     try {
-      await fetch(`/api/teams/${team.id}`, {
+      await apiFetch(`/api/teams/${team.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ isArchived: wasArchived ? 0 : 1 }),
@@ -218,7 +219,7 @@ export function TeamSidebar() {
     }
 
     try {
-      await fetch(`/api/teams/${team.id}`, { method: 'DELETE' })
+      await apiFetch(`/api/teams/${team.id}`, { method: 'DELETE' })
       useTeamStore.getState().removeTeam(team.id)
 
       useFleetStore.setState((s) => ({
@@ -275,7 +276,7 @@ export function TeamSidebar() {
         }
       }
 
-      await fetch(`/api/teams/${team.id}`, { method: 'DELETE' })
+      await apiFetch(`/api/teams/${team.id}`, { method: 'DELETE' })
       useTeamStore.getState().removeTeam(team.id)
 
       if (useTeamStore.getState().selectedTeamId === null) {

--- a/apps/web/src/features/layout/WelcomeState.tsx
+++ b/apps/web/src/features/layout/WelcomeState.tsx
@@ -6,7 +6,7 @@ import { useViewStore } from '@/stores/view'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 import { isSessionLive, useConnectionStore } from '@/stores/connection'
 import { CreateTeamModalLazy, preloadCreateTeamModal } from '@/features/teams/CreateTeamModalLazy'
-import { consumeApiSSE } from '@clawboo/control-client'
+import { apiFetch, consumeApiSSE } from '@clawboo/control-client'
 import { SkyAtmosphere } from '@/features/atmosphere'
 import { Button } from '@/features/shared/Button'
 import type { SystemInfo } from '@/stores/system'
@@ -22,7 +22,7 @@ function SystemHint({ isConnected }: { isConnected: boolean }) {
   useEffect(() => {
     if (isConnected) return
     let cancelled = false
-    fetch('/api/system/status')
+    apiFetch('/api/system/status')
       .then((r) => r.json())
       .then((data: SystemInfo) => {
         if (!cancelled) setSystemInfo(data)
@@ -165,7 +165,7 @@ export function WelcomeState() {
         transition={{ type: 'spring', stiffness: 200, damping: 22 }}
       >
         <motion.img
-          src="/logo.svg"
+          src="logo.svg"
           alt="Clawboo"
           width={96}
           height={88}

--- a/apps/web/src/features/maintenance/MaintenancePanel.tsx
+++ b/apps/web/src/features/maintenance/MaintenancePanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react'
 import { RefreshCw, Settings } from 'lucide-react'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
-import { consumeApiSSE } from '@clawboo/control-client'
+import { apiFetch, consumeApiSSE } from '@clawboo/control-client'
 import { GitHubStarButton } from '@/features/promo/GitHubStarButton'
 import { PanelHeader } from '@/features/shared/PanelHeader'
 import { Button } from '@/features/shared/Button'
@@ -89,7 +89,7 @@ function CommandApprovalDefault() {
 
   // Fetch current value from openclaw.json
   useEffect(() => {
-    fetch('/api/system/openclaw-config')
+    apiFetch('/api/system/openclaw-config')
       .then((r) => r.json() as Promise<{ config?: { tools?: { exec?: { ask?: string } } } }>)
       .then((data) => {
         const ask = data?.config?.tools?.exec?.ask
@@ -106,7 +106,7 @@ function CommandApprovalDefault() {
       const prev = execAsk
       setExecAsk(value)
       try {
-        const res = await fetch('/api/system/openclaw-config', {
+        const res = await apiFetch('/api/system/openclaw-config', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ exec: { ask: value } }),
@@ -173,7 +173,7 @@ export function MaintenancePanel() {
   useEffect(() => {
     let cancelled = false
 
-    fetch('/api/system/status')
+    apiFetch('/api/system/status')
       .then((r) => r.json() as Promise<SystemStatus>)
       .then((statusData) => {
         if (cancelled) return
@@ -214,7 +214,7 @@ export function MaintenancePanel() {
           if (e.success) {
             addToast({ message: `Updated to ${e.version ?? 'latest'}`, type: 'success' })
             // Refresh status to get new version
-            void fetch('/api/system/status')
+            void apiFetch('/api/system/status')
               .then((r) => r.json() as Promise<SystemStatus>)
               .then(setStatus)
           } else {

--- a/apps/web/src/features/marketplace/MarketplacePanel.tsx
+++ b/apps/web/src/features/marketplace/MarketplacePanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Blocks, Bot, SearchX, ShoppingBag, Users, Wrench } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { Select } from '@/features/shared/Select'
 import { Button } from '@/features/shared/Button'
 import { Chip } from '@/features/shared/Chip'
@@ -66,7 +67,7 @@ async function installSkillFromMarketplace(
     // reads it (injection-scanned + audited server-side), so the skill appears on
     // the Ghost Graph + the Capabilities dashboard. (Supersedes the legacy
     // per-agent markdown skill-file write.)
-    const res = await fetch('/api/skills', {
+    const res = await apiFetch('/api/skills', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/apps/web/src/features/obs/ObsPanel.tsx
+++ b/apps/web/src/features/obs/ObsPanel.tsx
@@ -27,6 +27,7 @@ import { useReadSequencer } from '@/lib/useReadSequencer'
 import { useVisiblePolling } from '@/lib/useVisiblePolling'
 
 import { EvalScorecard } from './EvalScorecard'
+import { apiFetch } from '@clawboo/control-client'
 
 interface ObsEvent {
   seq: number
@@ -99,7 +100,7 @@ const KICKER_COLOR = 'rgb(var(--foreground-rgb) / 0.4)'
 
 async function getJson<T>(url: string): Promise<T | null> {
   try {
-    const r = await fetch(url)
+    const r = await apiFetch(url)
     if (!r.ok) return null
     return (await r.json()) as T
   } catch {

--- a/apps/web/src/features/obs/useObsGraphOverlay.ts
+++ b/apps/web/src/features/obs/useObsGraphOverlay.ts
@@ -6,6 +6,7 @@
 // untouched — this only augments.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 
 import { useVisiblePolling } from '@/lib/useVisiblePolling'
 
@@ -33,8 +34,8 @@ export function useObsGraphOverlay(teamId: string | null): ObsOverlay {
     try {
       const q = teamId ? `?teamId=${encodeURIComponent(teamId)}` : ''
       const [hRes, gRes] = await Promise.all([
-        fetch(`/api/obs/health${q}`),
-        fetch(`/api/obs/graph${q}`),
+        apiFetch(`/api/obs/health${q}`),
+        apiFetch(`/api/obs/graph${q}`),
       ])
       if (generationRef.current !== generation || !hRes.ok || !gRes.ok) return
       const h = (await hRes.json()) as {

--- a/apps/web/src/features/obs/useObsStream.ts
+++ b/apps/web/src/features/obs/useObsStream.ts
@@ -5,6 +5,7 @@
 // and resumes from the last `seq` via its `Last-Event-ID` header.
 
 import { useEffect, useRef, useState } from 'react'
+import { apiFetch, apiUrl } from '@clawboo/control-client'
 
 /** One row of the obs event log (server-redacted `data`, parsed to an object). */
 export interface ObsLogEvent {
@@ -106,7 +107,7 @@ export function useObsStream(
       if (typeof EventSource === 'undefined') return
       const sp = new URLSearchParams(base)
       sp.set('since', String(maxSeq))
-      es = new EventSource(`/api/obs/stream?${sp.toString()}`)
+      es = new EventSource(apiUrl(`/api/obs/stream?${sp.toString()}`))
       es.onopen = () => {
         if (!cancelled) setLive(true)
       }
@@ -143,7 +144,9 @@ export function useObsStream(
         // terminal still renders chronologically and the cursor starts live.
         bp.set('order', 'desc')
         bp.set('limit', String(limit))
-        const r = await fetch(`/api/obs/events?${bp.toString()}`, { signal: backfillAbort.signal })
+        const r = await apiFetch(`/api/obs/events?${bp.toString()}`, {
+          signal: backfillAbort.signal,
+        })
         if (!cancelled && r.ok) {
           const body = (await r.json()) as { events?: Record<string, unknown>[] }
           const rows = (body.events ?? []).map(parseRow).reverse()

--- a/apps/web/src/features/onboarding/CapabilityTour.tsx
+++ b/apps/web/src/features/onboarding/CapabilityTour.tsx
@@ -245,7 +245,7 @@ function BooMascot({ size = 60 }: { size?: number }) {
         style={{ background: 'rgb(var(--primary-rgb) / 0.1)', filter: 'blur(3px)' }}
       />
       <motion.img
-        src="/logo.svg"
+        src="logo.svg"
         alt=""
         width={size}
         height={size * 0.92}

--- a/apps/web/src/features/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/features/onboarding/OnboardingWizard.tsx
@@ -30,6 +30,7 @@ import {
   isLocalGatewayUrl,
   resolveProxyGatewayUrl,
 } from '@clawboo/gateway-client'
+import { apiFetch } from '@clawboo/control-client'
 import {
   DetectStep,
   InstallStep,
@@ -155,7 +156,7 @@ function WelcomeStep({ onContinue }: { onContinue: () => void }) {
             animate={{ y: [0, -14, 0] }}
             transition={{ duration: 3.2, repeat: Infinity, ease: 'easeInOut' }}
           >
-            <img src="/logo.svg" alt="Clawboo" width={84} height={77} />
+            <img src="logo.svg" alt="Clawboo" width={84} height={77} />
           </motion.div>
         </div>
 
@@ -233,7 +234,7 @@ function ConnectStep({
 
   // Pre-fill from persisted settings (in case user ran npx clawboo first)
   useEffect(() => {
-    fetch('/api/settings')
+    apiFetch('/api/settings')
       .then((r) => r.json() as Promise<{ gatewayUrl?: string; hasToken?: boolean }>)
       .then((data) => {
         if (data.gatewayUrl?.trim()) setUrl(data.gatewayUrl.trim())
@@ -269,7 +270,7 @@ function ConnectStep({
       // If the user left the placeholder dots, omit gatewayToken so we don't
       // overwrite a previously saved real token with an empty string.
       const tokenChanged = token !== '••••••••'
-      await fetch('/api/settings', {
+      await apiFetch('/api/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/apps/web/src/features/onboarding/steps/ConfigureStep.tsx
+++ b/apps/web/src/features/onboarding/steps/ConfigureStep.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowLeft, ArrowRight, Check, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { MODEL_GROUPS } from '@/lib/modelCatalog'
 import { NATIVE_STEPS } from '../StepIndicator'
 import { OnboardingGhost, OnboardingPrimary, OnboardingScreen } from '../OnboardingScreen'
@@ -207,7 +208,7 @@ export function ConfigureStep({ onConfigured, onBack }: ConfigureStepProps) {
   const refreshCodexAuth = useCallback(async () => {
     setCodexChecking(true)
     try {
-      const res = await fetch('/api/system/openclaw-config')
+      const res = await apiFetch('/api/system/openclaw-config')
       // A transient failure must NOT drop a known-good confirmation (the toggle
       // re-probes on every re-entry). Keep the last state; Re-check re-probes.
       // A never-succeeded probe stays null, so Continue stays gated as before.
@@ -261,7 +262,7 @@ export function ConfigureStep({ onConfigured, onBack }: ConfigureStepProps) {
     setError(null)
 
     try {
-      const res = await fetch('/api/system/configure-openclaw', {
+      const res = await apiFetch('/api/system/configure-openclaw', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/apps/web/src/features/onboarding/steps/DetectStep.tsx
+++ b/apps/web/src/features/onboarding/steps/DetectStep.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowRight, Check, ExternalLink, Loader2, X } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { useSystemStore } from '@/stores/system'
 import type { SystemInfo } from '@/stores/system'
 import { NATIVE_STEPS } from '../StepIndicator'
@@ -79,7 +80,7 @@ export function DetectStep({
 
     void (async () => {
       try {
-        const res = await fetch('/api/system/status')
+        const res = await apiFetch('/api/system/status')
         const data = (await res.json()) as SystemInfo
         setInfo(data)
       } catch {

--- a/apps/web/src/features/onboarding/steps/StartGatewayStep.tsx
+++ b/apps/web/src/features/onboarding/steps/StartGatewayStep.tsx
@@ -196,7 +196,7 @@ export function StartGatewayStep({ onStarted, onBack }: StartGatewayStepProps) {
           {/* Glow */}
           <div className="pointer-events-none absolute -inset-8 bg-[radial-gradient(circle,rgb(var(--primary-rgb) / 0.15),transparent)]" />
           <motion.img
-            src="/logo.svg"
+            src="logo.svg"
             alt="Clawboo"
             className="relative h-20 w-20"
             animate={

--- a/apps/web/src/features/promo/UpdateChip.tsx
+++ b/apps/web/src/features/promo/UpdateChip.tsx
@@ -16,7 +16,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import { AlertCircle, Check, Copy, X } from 'lucide-react'
-import { consumeApiSSE, type SSEEvent } from '@clawboo/control-client'
+import { apiFetch, consumeApiSSE, type SSEEvent } from '@clawboo/control-client'
 
 import { Spinner } from '@/features/shared/Spinner'
 import { useUpdateCheck } from './useUpdateCheck'
@@ -39,7 +39,7 @@ async function pollThenReload(onTimeout: () => void): Promise<void> {
   while (Date.now() < deadline) {
     await sleep(1000)
     try {
-      const res = await fetch('/api/settings', { cache: 'no-store' })
+      const res = await apiFetch('/api/settings', { cache: 'no-store' })
       if (res.ok) {
         const body = (await res.json()) as { gatewayUrl?: unknown }
         if (typeof body.gatewayUrl === 'string') {

--- a/apps/web/src/features/promo/useUpdateCheck.ts
+++ b/apps/web/src/features/promo/useUpdateCheck.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useRefreshOnVisible } from '@/lib/useVisiblePolling'
+import { apiFetch } from '@clawboo/control-client'
 
 // useUpdateCheck — polls the server's self-version endpoint and decides whether
 // to surface the "update available" chip. Mirrors GitHubStarButton's
@@ -95,7 +96,7 @@ export function useUpdateCheck(): UseUpdateCheck {
     if (!force && readCache()) return
     inflight.current = true
     try {
-      const res = await fetch(ENDPOINT, { cache: 'no-store' })
+      const res = await apiFetch(ENDPOINT, { cache: 'no-store' })
       if (!res.ok) return
       const data = (await res.json()) as SelfVersionInfo
       if (typeof data.current !== 'string') return

--- a/apps/web/src/features/runtimes/OpenClawDefaultModel.tsx
+++ b/apps/web/src/features/runtimes/OpenClawDefaultModel.tsx
@@ -9,6 +9,8 @@
 
 import { useCallback, useEffect, useState } from 'react'
 
+import { apiFetch } from '@clawboo/control-client'
+
 import { ModelSelector } from '@/features/maintenance/ModelSelector'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
@@ -23,7 +25,7 @@ export function OpenClawDefaultModel() {
 
   useEffect(() => {
     let cancelled = false
-    fetch('/api/system/openclaw-config')
+    apiFetch('/api/system/openclaw-config')
       .then(
         (r) =>
           r.json() as Promise<{
@@ -46,7 +48,7 @@ export function OpenClawDefaultModel() {
   const handleModelChange = useCallback(
     async (model: string) => {
       try {
-        const res = await fetch('/api/system/openclaw-config', {
+        const res = await apiFetch('/api/system/openclaw-config', {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ model }),

--- a/apps/web/src/features/runtimes/OpenClawGatewaySection.tsx
+++ b/apps/web/src/features/runtimes/OpenClawGatewaySection.tsx
@@ -10,7 +10,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Play, RotateCw } from 'lucide-react'
 
-import { consumeApiSSE } from '@clawboo/control-client'
+import { apiFetch, consumeApiSSE } from '@clawboo/control-client'
 
 import { Button } from '@/features/shared/Button'
 import { StatusPill } from '@/features/shared/StatusPill'
@@ -54,7 +54,7 @@ export function OpenClawGatewaySection({
     // poll that was already in flight and still reports the pre-action gateway state.
     const read = reads.beginRead()
     try {
-      const data = (await fetch('/api/system/status').then((r) => r.json())) as {
+      const data = (await apiFetch('/api/system/status').then((r) => r.json())) as {
         gateway?: GatewayState
       }
       if (data.gateway && read.isCurrent()) setGw(data.gateway)

--- a/apps/web/src/features/runtimes/OpenClawInlineSetup.tsx
+++ b/apps/web/src/features/runtimes/OpenClawInlineSetup.tsx
@@ -15,7 +15,7 @@ import { ArrowRight, Check, Eye, EyeOff, Loader2, Terminal } from 'lucide-react'
 
 import type { GatewayClient } from '@clawboo/gateway-client'
 import { GatewayResponseError } from '@clawboo/gateway-client'
-import { connectProvider, consumeApiSSE } from '@clawboo/control-client'
+import { apiFetch, connectProvider, consumeApiSSE } from '@clawboo/control-client'
 
 import { connectGatewayFromSettings } from '@/lib/gatewayConnect'
 import { enterGatewayMode } from '@/features/connection/GatewayBootstrap'
@@ -122,7 +122,7 @@ export function OpenClawInlineSetup({ onConnected, onFinish, onCancel }: OpenCla
       setPhase('preparing')
       // Reuse an already-connected credential — a provider key, or an existing
       // OpenClaw ChatGPT-subscription (openai-codex) auth profile.
-      const auto = (await fetch('/api/system/auto-configure-openclaw', { method: 'POST' })
+      const auto = (await apiFetch('/api/system/auto-configure-openclaw', { method: 'POST' })
         .then((r) => r.json())
         .catch(() => ({ ok: false, needsKey: true }))) as {
         ok?: boolean
@@ -138,7 +138,7 @@ export function OpenClawInlineSetup({ onConnected, onFinish, onCancel }: OpenCla
           if (typeof auto.loginCommand === 'string' && auto.loginCommand) {
             setCodexLoginCommand(auto.loginCommand)
           }
-          const st = (await fetch('/api/system/status')
+          const st = (await apiFetch('/api/system/status')
             .then((r) => r.json())
             .catch(() => null)) as { openclaw?: { installed?: boolean } } | null
           if (!st?.openclaw?.installed) {
@@ -152,7 +152,7 @@ export function OpenClawInlineSetup({ onConnected, onFinish, onCancel }: OpenCla
         setPhase('needs-key')
         return
       }
-      const status = (await fetch('/api/system/status')
+      const status = (await apiFetch('/api/system/status')
         .then((r) => r.json())
         .catch(() => null)) as { openclaw?: { installed?: boolean } } | null
       if (!status?.openclaw?.installed) {

--- a/apps/web/src/features/runtimes/RuntimeDiagnosticsDrawer.tsx
+++ b/apps/web/src/features/runtimes/RuntimeDiagnosticsDrawer.tsx
@@ -31,7 +31,7 @@ import { fetchCapabilities } from '@/lib/capabilitiesClient'
 import { formatRelative } from '@/lib/formatRelative'
 import { ENTER_SPRING } from '@/lib/motion'
 import { useVisiblePolling } from '@/lib/useVisiblePolling'
-import { type ConnectionState, type RuntimeClass } from '@clawboo/control-client'
+import { apiFetch, type ConnectionState, type RuntimeClass } from '@clawboo/control-client'
 import { useCapabilityFilterStore } from '@/stores/capabilityFilter'
 import { useSettingsModalStore } from '@/stores/settingsModal'
 
@@ -146,7 +146,7 @@ export function RuntimeDiagnosticsDrawer({
     let alive = true
     void (async () => {
       try {
-        const res = await fetch('/api/obs/errors')
+        const res = await apiFetch('/api/obs/errors')
         if (!res.ok) return
         const body = (await res.json()) as { errors?: RuntimeErrorRow[] }
         if (alive) setErrors((body.errors ?? []).filter((e) => e.runtime === target.id).slice(0, 5))

--- a/apps/web/src/features/runtimes/RuntimeManageBody.tsx
+++ b/apps/web/src/features/runtimes/RuntimeManageBody.tsx
@@ -13,7 +13,12 @@
 import { useState, type ReactNode } from 'react'
 import { ArrowRight, LogOut, RotateCcw } from 'lucide-react'
 
-import { disconnectRuntime, signOutRuntime, type RuntimeId } from '@clawboo/control-client'
+import {
+  apiFetch,
+  disconnectRuntime,
+  signOutRuntime,
+  type RuntimeId,
+} from '@clawboo/control-client'
 
 import { Button } from '@/features/shared/Button'
 import { confirm } from '@/stores/confirm'
@@ -105,7 +110,7 @@ export function RuntimeManageBody({
     setBusy(true)
     let result: { ok: boolean; error?: string }
     if (runtimeId === 'openclaw') {
-      result = await fetch('/api/system/gateway', {
+      result = await apiFetch('/api/system/gateway', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'stop' }),

--- a/apps/web/src/features/runtimes/RuntimesPanel.tsx
+++ b/apps/web/src/features/runtimes/RuntimesPanel.tsx
@@ -12,6 +12,7 @@ import { PanelHeader } from '@/features/shared/PanelHeader'
 import { type StatusTone } from '@/features/shared/StatusPill'
 import { useVisiblePolling } from '@/lib/useVisiblePolling'
 import {
+  apiFetch,
   fetchRegistryHealth,
   fetchRuntimes,
   recheckRuntime,
@@ -58,7 +59,7 @@ function McpAttach({ runtimeId }: { runtimeId: string }) {
     setOpen(next)
     if (next && snippet === null) {
       try {
-        const r = await fetch(
+        const r = await apiFetch(
           `/api/mcp/config?runtime=${encodeURIComponent(runtimeId)}&server=tasks&transport=http`,
         )
         const body = (await r.json()) as unknown
@@ -201,7 +202,7 @@ export function RuntimesPanel() {
     // OpenClaw's own ChatGPT-subscription oauth profile (defensive: false on any
     // error). `codexAuth.profile` is the ACTUAL profile, distinct from a bare
     // codex-CLI login (which only OFFERS the path).
-    const cfg = (await fetch('/api/system/openclaw-config')
+    const cfg = (await apiFetch('/api/system/openclaw-config')
       .then((r) => (r.ok ? r.json() : null))
       .catch(() => null)) as { config?: unknown; codexAuth?: { profile?: boolean } } | null
     if (!read.isCurrent()) return

--- a/apps/web/src/features/settings/ExecSettings.tsx
+++ b/apps/web/src/features/settings/ExecSettings.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Shield } from 'lucide-react'
+import { apiFetch } from '@clawboo/control-client'
 import { useFleetStore } from '@/stores/fleet'
 import { useConnectionStore } from '@/stores/connection'
 import { useToastStore } from '@/stores/toast'
@@ -36,7 +37,7 @@ export function ExecSettings({ agentId }: { agentId: string }) {
   // Load saved exec config from SQLite on mount
   useEffect(() => {
     setLoaded(false)
-    fetch(`/api/exec-settings?agentId=${encodeURIComponent(agentId)}`)
+    apiFetch(`/api/exec-settings?agentId=${encodeURIComponent(agentId)}`)
       .then((r) => r.json())
       .then((data: { values: { execAsk?: string } | null }) => {
         if (data.values?.execAsk) {
@@ -55,7 +56,7 @@ export function ExecSettings({ agentId }: { agentId: string }) {
 
       // Persist to SQLite
       try {
-        await fetch('/api/exec-settings', {
+        await apiFetch('/api/exec-settings', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentId, values: { execAsk: newAsk } }),

--- a/apps/web/src/features/settings/PersonalitySliders.tsx
+++ b/apps/web/src/features/settings/PersonalitySliders.tsx
@@ -1,4 +1,4 @@
-import { readAgentFile, writeAgentFile } from '@clawboo/control-client'
+import { apiFetch, readAgentFile, writeAgentFile } from '@clawboo/control-client'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { Check, FileText, PenLine, SlidersHorizontal } from 'lucide-react'
 import { useConnectionStore } from '@/stores/connection'
@@ -74,7 +74,9 @@ export function PersonalitySliders({ agentId: propAgentId }: { agentId?: string 
     baseSoulRef.current = ''
 
     // Fetch both SQLite personality values and existing SOUL.md in parallel
-    const sqlitePromise = fetch(`/api/personality?agentId=${encodeURIComponent(selectedAgentId)}`)
+    const sqlitePromise = apiFetch(
+      `/api/personality?agentId=${encodeURIComponent(selectedAgentId)}`,
+    )
       .then((res) => res.json())
       .then((data: { values: PersonalityValues | null; customText?: string | null }) => {
         if (data.values && isPersonalityValues(data.values)) {
@@ -107,7 +109,7 @@ export function PersonalitySliders({ agentId: propAgentId }: { agentId?: string 
       if (dirty && client) {
         dirtyRef.current = null
         // Best-effort save to both SQLite and SOUL.md on agent switch
-        void fetch('/api/personality', {
+        void apiFetch('/api/personality', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentId: selectedAgentId, values: dirty }),
@@ -145,7 +147,7 @@ export function PersonalitySliders({ agentId: propAgentId }: { agentId?: string 
       setError(null)
 
       // 1. Save to SQLite — persistent source of truth for slider values
-      const sqliteSave = fetch('/api/personality', {
+      const sqliteSave = apiFetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId: selectedAgentId, values: next, customText: null }),
@@ -199,7 +201,7 @@ export function PersonalitySliders({ agentId: propAgentId }: { agentId?: string 
       setError(null)
 
       // 1. Save to SQLite with custom text
-      const sqliteSave = fetch('/api/personality', {
+      const sqliteSave = apiFetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId: selectedAgentId, values, customText: text }),
@@ -247,7 +249,7 @@ export function PersonalitySliders({ agentId: propAgentId }: { agentId?: string 
       customTextDirtyRef.current = false
 
       // Save cleared custom text + restore slider personality to SOUL.md
-      void fetch('/api/personality', {
+      void apiFetch('/api/personality', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ agentId: selectedAgentId, values, customText: null }),

--- a/apps/web/src/features/teams/CreateTeamModal.tsx
+++ b/apps/web/src/features/teams/CreateTeamModal.tsx
@@ -16,6 +16,7 @@ import { useSettingsModalStore } from '@/stores/settingsModal'
 import { createAgent } from '@/lib/createAgent'
 import { refreshFleetFromRegistry } from '@/lib/agentSourceClient'
 import {
+  apiFetch,
   fetchBooZeroOverride,
   fetchNativeLeaderModel,
   fetchProviders,
@@ -537,7 +538,7 @@ export function CreateTeamModal({
       const finalTeamName = dedupPlan.teamName
 
       // Create the team via API
-      const res = await fetch('/api/teams', {
+      const res = await apiFetch('/api/teams', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -588,7 +589,7 @@ export function CreateTeamModal({
       // The PATCH merges partials, so omitting the field leaves it false.
       if (presatisfyOnboardingGate) {
         try {
-          await fetch(`/api/teams/${team.id}/onboarding`, {
+          await apiFetch(`/api/teams/${team.id}/onboarding`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ agentsIntroduced: true }),
@@ -753,7 +754,7 @@ export function CreateTeamModal({
         // model-inert as members, so this only applies to an OpenClaw pick. Best-effort.
         if (sourceId === 'openclaw' && agentModels[agent.id]) {
           try {
-            await fetch('/api/system/openclaw-config', {
+            await apiFetch('/api/system/openclaw-config', {
               method: 'PATCH',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ agentModel: { agentId, model: agentModels[agent.id] } }),
@@ -764,7 +765,7 @@ export function CreateTeamModal({
         }
 
         // Persist default personality to SQLite so sliders load correctly
-        void fetch('/api/personality', {
+        void apiFetch('/api/personality', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ agentId, values: defaultPersonality }),
@@ -778,7 +779,7 @@ export function CreateTeamModal({
 
         // Assign the successfully-created agent to the team (best-effort).
         try {
-          await fetch(`/api/teams/${team.id}/agents`, {
+          await apiFetch(`/api/teams/${team.id}/agents`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ agentId }),
@@ -818,7 +819,7 @@ export function CreateTeamModal({
       // PATCH always runs (incl. writing null) so the column stays accurate on re-deploys.
       if (team.id) {
         try {
-          await fetch(`/api/teams/${team.id}`, {
+          await apiFetch(`/api/teams/${team.id}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ leaderAgentId }),
@@ -891,7 +892,7 @@ export function CreateTeamModal({
             : null,
       })
       try {
-        await fetch(`/api/boo-zero/team-briefs/${encodeURIComponent(team.id)}`, {
+        await apiFetch(`/api/boo-zero/team-briefs/${encodeURIComponent(team.id)}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ content: briefMarkdown }),
@@ -910,7 +911,7 @@ export function CreateTeamModal({
       const hasRouting = resolved.some((a) => a.agentsTemplate && /@[\w"']/.test(a.agentsTemplate))
       if (hasRouting) {
         try {
-          await fetch('/api/system/openclaw-config', {
+          await apiFetch('/api/system/openclaw-config', {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ agentToAgent: { enabled: true } }),

--- a/apps/web/src/globals.d.ts
+++ b/apps/web/src/globals.d.ts
@@ -1,0 +1,8 @@
+// The URL prefix the server templates into the SPA shell it serves. Absent when
+// clawboo is served at the origin root (the default) and in `pnpm dev`, where
+// Vite serves the shell untouched. Read once by `app/bootstrapBase.ts`.
+declare global {
+  var __CLAWBOO_BASE__: string | undefined
+}
+
+export {}

--- a/apps/web/src/lib/__tests__/noRootAbsoluteApiUrls.test.ts
+++ b/apps/web/src/lib/__tests__/noRootAbsoluteApiUrls.test.ts
@@ -1,0 +1,111 @@
+// Every network call the SPA makes must go through the base-aware seam in
+// @clawboo/control-client, because clawboo can be mounted under a URL path
+// prefix (CLAWBOO_BASE_PATH) and a root-absolute `/api/...` escapes the mount.
+//
+// This is a SOURCE SCAN rather than a lint rule on purpose. The ESLint selectors
+// in eslint.config.mjs can only see a URL literal sitting directly in a
+// `fetch(...)` / `new EventSource(...)` argument list, and real sites reach the
+// network through one level of indirection instead: a local `getJson(url)`
+// helper, a module-level `ENDPOINT` const, and an injectable EventSource
+// `factory`. Each was invisible to the rules while being exactly the bug they
+// exist to prevent, and invisible to the e2e too, since the server deliberately
+// keeps serving the unprefixed `/api` for its loopback control plane and so
+// answers a root-absolute call with a 200.
+//
+// So the invariant is enforced one step earlier, at the CALL, where the argument
+// shape cannot hide it.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const SRC = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+// The marketplace catalog is agent PROMPT TEXT, not code: it discusses APIs and
+// `fetch` in prose, and none of it is executed.
+const DATA_DIRS = [
+  path.join('features', 'marketplace', 'agents'),
+  path.join('features', 'marketplace', 'teams'),
+]
+
+/**
+ * Calls that legitimately bypass the seam because their URL is an absolute
+ * third-party origin, where a base path is meaningless.
+ */
+const EXTERNAL_CALLERS = new Set([path.join('features', 'promo', 'GitHubStarButton.tsx')])
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === '__vitest__' || entry === 'node_modules') continue
+      sourceFiles(full, out)
+      continue
+    }
+    if (/\.tsx?$/.test(entry)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * A call to the global `fetch`, however it is spelled: bare, or through
+ * `window.` / `globalThis.` / `self.`. Only `apiFetch` is excluded, and only as a
+ * whole word, so `window.fetch(` cannot hide behind the property-access escape.
+ * No space before the paren: prose in a comment writes "the board-task fetch (an
+ * exec store...)", and a formatted call never does.
+ */
+const BARE_FETCH = /(^|[^\w.'"`])(?:(?:window|globalThis|self)\.)?fetch\(/
+/**
+ * A root-absolute `/api/` URL opening a stream. The literal may sit on the next
+ * line when prettier wraps the call, so the scan is per-file rather than
+ * per-line and tolerates whitespace between the paren and the quote.
+ */
+const ROOT_ABSOLUTE_SSE = /(?:EventSource|factory)\s*\(\s*['"`]\/api\//
+
+describe('the SPA reaches the API only through the base-aware seam', () => {
+  const files = sourceFiles(SRC).filter(
+    (f) => !DATA_DIRS.some((d) => path.relative(SRC, f).startsWith(d)),
+  )
+
+  it('never calls the global fetch directly', () => {
+    // A bare `fetch` skips `apiUrl`, so its URL is whatever the caller wrote,
+    // which is how the ObsPanel helper and the update-check const escaped both
+    // the lint rules and review.
+    const offenders: string[] = []
+    for (const file of files) {
+      const rel = path.relative(SRC, file)
+      if (EXTERNAL_CALLERS.has(rel)) continue
+      readFileSync(file, 'utf8')
+        .split('\n')
+        .forEach((line, i) => {
+          if (line.trimStart().startsWith('//') || line.trimStart().startsWith('*')) return
+          if (BARE_FETCH.test(line)) offenders.push(`${rel}:${i + 1}`)
+        })
+    }
+    expect(
+      offenders,
+      "Use apiFetch() from '@clawboo/control-client' so the call honors CLAWBOO_BASE_PATH:\n  " +
+        offenders.join('\n  '),
+    ).toEqual([])
+  })
+
+  it('never opens an SSE stream at a root-absolute /api URL', () => {
+    const offenders: string[] = []
+    for (const file of files) {
+      const rel = path.relative(SRC, file)
+      // Whole-file, so a prettier-wrapped call whose URL landed on the next line
+      // is still seen.
+      const text = readFileSync(file, 'utf8')
+      for (const m of text.matchAll(new RegExp(ROOT_ABSOLUTE_SSE, 'g'))) {
+        offenders.push(`${rel}:${text.slice(0, m.index).split('\n').length}`)
+      }
+    }
+    expect(
+      offenders,
+      'Wrap the stream URL in apiUrl() so it honors CLAWBOO_BASE_PATH:\n  ' +
+        offenders.join('\n  '),
+    ).toEqual([])
+  })
+})

--- a/apps/web/src/lib/agentModelMap.ts
+++ b/apps/web/src/lib/agentModelMap.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '@clawboo/control-client'
+
 /**
  * Fetches the per-agent model map from openclaw.json via the API.
  * Returns a Map of agentId → model string. Returns empty map on failure.
@@ -5,7 +7,7 @@
 export async function fetchAgentModelMap(): Promise<Map<string, string>> {
   const map = new Map<string, string>()
   try {
-    const res = await fetch('/api/system/openclaw-config')
+    const res = await apiFetch('/api/system/openclaw-config')
     const data = (await res.json()) as {
       config?: {
         agents?: {

--- a/apps/web/src/lib/boardClient.ts
+++ b/apps/web/src/lib/boardClient.ts
@@ -7,6 +7,7 @@
 // null/false result, never throw) and 409-aware: a claim conflict means
 // "someone else won" and MUST NOT be retried.
 
+import { apiFetch } from '@clawboo/control-client'
 import type { BoardClient, BoardTask, TaskDetail, ExecutionRef } from '@clawboo/team-orchestration'
 
 export type {
@@ -25,7 +26,7 @@ const JSON_HEADERS = { 'Content-Type': 'application/json' } as const
 export const boardClient: BoardClient = {
   async createTask(input) {
     try {
-      const r = await fetch('/api/board', {
+      const r = await apiFetch('/api/board', {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),
@@ -40,7 +41,7 @@ export const boardClient: BoardClient = {
 
   async claim(taskId, assigneeAgentId, assigneeRuntime) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/claim`, {
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/claim`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ assigneeAgentId, assigneeRuntime }),
@@ -65,7 +66,7 @@ export const boardClient: BoardClient = {
 
   async addComment(taskId, body, authorType = 'system', authorAgentId) {
     try {
-      await fetch(`/api/board/${encodeURIComponent(taskId)}/comments`, {
+      await apiFetch(`/api/board/${encodeURIComponent(taskId)}/comments`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ body, authorType, authorAgentId }),
@@ -77,7 +78,7 @@ export const boardClient: BoardClient = {
 
   async getTask(taskId) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}`)
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}`)
       if (!r.ok) return null
       return (await r.json()) as TaskDetail
     } catch {
@@ -87,7 +88,7 @@ export const boardClient: BoardClient = {
 
   async createExecution(taskId, executorType) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/executions`, {
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/executions`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ executorType }),
@@ -102,7 +103,7 @@ export const boardClient: BoardClient = {
 
   async completeExecution(execId, outcome) {
     try {
-      await fetch(`/api/board/executions/${encodeURIComponent(execId)}`, {
+      await apiFetch(`/api/board/executions/${encodeURIComponent(execId)}`, {
         method: 'PATCH',
         headers: JSON_HEADERS,
         body: JSON.stringify(outcome),
@@ -114,7 +115,7 @@ export const boardClient: BoardClient = {
 
   async linkDep(taskId, dependsOnTaskId) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/deps`, {
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/deps`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ dependsOnTaskId }),
@@ -127,7 +128,7 @@ export const boardClient: BoardClient = {
 
   async getReadyTasks(teamId) {
     try {
-      const r = await fetch(`/api/board?teamId=${encodeURIComponent(teamId)}&ready=true`)
+      const r = await apiFetch(`/api/board?teamId=${encodeURIComponent(teamId)}&ready=true`)
       if (!r.ok) return []
       const body = (await r.json()) as { tasks?: BoardTask[] }
       return body.tasks ?? []
@@ -138,7 +139,7 @@ export const boardClient: BoardClient = {
 
   async listExecutions(taskId) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/executions`)
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/executions`)
       // `null`, not `[]` — an unreachable server means the ledger is UNKNOWN, and
       // an empty ledger is what tells the fire policy a task may auto-fire. See
       // the note on BoardClient.listExecutions.
@@ -158,7 +159,7 @@ export const boardClient: BoardClient = {
 
   async listTasks(teamId) {
     try {
-      const r = await fetch(`/api/board?teamId=${encodeURIComponent(teamId)}`)
+      const r = await apiFetch(`/api/board?teamId=${encodeURIComponent(teamId)}`)
       if (!r.ok) return []
       const body = (await r.json()) as { tasks?: BoardTask[] }
       return body.tasks ?? []
@@ -169,7 +170,7 @@ export const boardClient: BoardClient = {
 
   async cancelDependents(taskId) {
     try {
-      const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/cancel-dependents`, {
+      const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/cancel-dependents`, {
         method: 'POST',
         headers: JSON_HEADERS,
       })
@@ -196,7 +197,7 @@ export interface BoardFetchResult {
 export async function fetchBoardResult(teamId?: string): Promise<BoardFetchResult> {
   try {
     const url = teamId ? `/api/board?teamId=${encodeURIComponent(teamId)}` : '/api/board'
-    const r = await fetch(url)
+    const r = await apiFetch(url)
     if (!r.ok) return { tasks: [], ok: false }
     const body = (await r.json()) as { tasks?: BoardTask[] }
     return { tasks: body.tasks ?? [], ok: true }
@@ -237,7 +238,7 @@ export async function updateStatusResult(
   opts: { humanOverride?: boolean } = {},
 ): Promise<StatusChangeResult> {
   try {
-    const r = await fetch(`/api/board/${encodeURIComponent(taskId)}`, {
+    const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}`, {
       method: 'PATCH',
       headers: JSON_HEADERS,
       body: JSON.stringify({ status, ...(opts.humanOverride ? { humanOverride: true } : {}) }),
@@ -266,7 +267,7 @@ export interface BoardExecution {
 
 export async function getTaskExecutions(taskId: string): Promise<BoardExecution[]> {
   try {
-    const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/executions`)
+    const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/executions`)
     if (!r.ok) return []
     const body = (await r.json()) as { executions?: BoardExecution[] }
     return body.executions ?? []
@@ -297,7 +298,7 @@ export interface WorkspaceDetail {
 
 export async function getWorkspaceDetail(taskId: string): Promise<WorkspaceDetail | null> {
   try {
-    const r = await fetch(`/api/board/${encodeURIComponent(taskId)}/workspace/detail`)
+    const r = await apiFetch(`/api/board/${encodeURIComponent(taskId)}/workspace/detail`)
     if (!r.ok) return null
     return (await r.json()) as WorkspaceDetail
   } catch {

--- a/apps/web/src/lib/capabilitiesClient.ts
+++ b/apps/web/src/lib/capabilitiesClient.ts
@@ -5,6 +5,7 @@
 // memoryClient. CapabilityRecord types come straight from the browser-safe
 // @clawboo/capability-registry package.
 
+import { apiFetch } from '@clawboo/control-client'
 import type {
   CapabilityInstallSpec,
   CapabilityRecord,
@@ -37,7 +38,7 @@ export async function fetchCapabilities(filter: CapabilityFilter = {}): Promise<
   if (filter.agentId) qs.set('agentId', filter.agentId)
   const url = qs.toString() ? `/api/capabilities?${qs}` : '/api/capabilities'
   try {
-    const res = await fetch(url)
+    const res = await apiFetch(url)
     if (!res.ok) return { records: [], sources: [], ok: false }
     const body = (await res.json()) as Partial<CapabilitiesView>
     return { records: body.records ?? [], sources: body.sources ?? [], ok: true }
@@ -55,7 +56,7 @@ export interface CapabilityActionResult {
 
 async function postAction(action: string, body: unknown): Promise<CapabilityActionResult> {
   try {
-    const res = await fetch(`/api/capabilities/${action}`, {
+    const res = await apiFetch(`/api/capabilities/${action}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),

--- a/apps/web/src/lib/evalsClient.ts
+++ b/apps/web/src/lib/evalsClient.ts
@@ -5,6 +5,8 @@
 // here (they match `@clawboo/evals` `SuiteReport` / `TaskReport` and the
 // `AblationScorecard` shape the scorecard renders).
 
+import { apiFetch } from '@clawboo/control-client'
+
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const
 
 export type EvalSuite = 'capability' | 'regression'
@@ -47,7 +49,7 @@ export interface AblationScorecard {
 /** POST /api/eval/smoke — run the deterministic smoke suite, return a SuiteReport. */
 export async function runSmokeEvals(opts: { trials?: number } = {}): Promise<SuiteReport | null> {
   try {
-    const r = await fetch('/api/eval/smoke', {
+    const r = await apiFetch('/api/eval/smoke', {
       method: 'POST',
       headers: JSON_HEADERS,
       body: JSON.stringify(opts.trials ? { trials: opts.trials } : {}),

--- a/apps/web/src/lib/execConfigMap.ts
+++ b/apps/web/src/lib/execConfigMap.ts
@@ -1,3 +1,5 @@
+import { apiFetch } from '@clawboo/control-client'
+
 /**
  * Fetches the per-agent exec config map from SQLite via the API.
  * Returns a Map of agentId → { execAsk }. Returns empty map on failure.
@@ -5,7 +7,7 @@
 export async function fetchExecConfigMap(): Promise<Map<string, { execAsk: string }>> {
   const map = new Map<string, { execAsk: string }>()
   try {
-    const res = await fetch('/api/exec-settings/all')
+    const res = await apiFetch('/api/exec-settings/all')
     const data = (await res.json()) as {
       configs?: Record<string, { execAsk: string }>
     }

--- a/apps/web/src/lib/fleetClient.ts
+++ b/apps/web/src/lib/fleetClient.ts
@@ -3,7 +3,7 @@
 // task/verification pass-rate · spend · budgets). Never throws; an unreachable
 // server resolves to null and the view shows an empty state.
 
-import type { RuntimeClass } from '@clawboo/control-client'
+import { apiFetch, type RuntimeClass } from '@clawboo/control-client'
 
 export interface FleetRuntimeTile {
   runtime: string
@@ -40,7 +40,7 @@ export interface FleetSummary {
 
 export async function fetchFleetSummary(): Promise<FleetSummary | null> {
   try {
-    const res = await fetch('/api/fleet/summary')
+    const res = await apiFetch('/api/fleet/summary')
     if (!res.ok) return null
     return (await res.json()) as FleetSummary
   } catch {
@@ -58,7 +58,7 @@ export interface FleetIssue {
 /** Recent issues = the last N error events from the obs taxonomy (GET /api/obs/errors). */
 export async function fetchRecentIssues(limit = 6): Promise<FleetIssue[]> {
   try {
-    const res = await fetch('/api/obs/errors')
+    const res = await apiFetch('/api/obs/errors')
     if (!res.ok) return []
     const body = (await res.json()) as { errors?: FleetIssue[] }
     return (body.errors ?? []).slice(0, limit)

--- a/apps/web/src/lib/gatewayConnect.ts
+++ b/apps/web/src/lib/gatewayConnect.ts
@@ -22,13 +22,14 @@
  * propagates so callers can branch on it). Callers `catch` and fall back.
  */
 
+import { apiFetch } from '@clawboo/control-client'
 import { GatewayClient, resolveProxyGatewayUrl } from '@clawboo/gateway-client'
 
 export async function connectGatewayFromSettings(): Promise<{
   client: GatewayClient
   gatewayUrl: string
 }> {
-  const resp = await fetch('/api/settings')
+  const resp = await apiFetch('/api/settings')
   if (!resp.ok) {
     throw new Error('Could not read saved Gateway settings')
   }

--- a/apps/web/src/lib/governanceClient.ts
+++ b/apps/web/src/lib/governanceClient.ts
@@ -3,6 +3,8 @@
 // safe value on failure, never throwing. The SPA never imports server packages,
 // so the row shapes are mirrored locally here.
 
+import { apiFetch } from '@clawboo/control-client'
+
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const
 
 export type BudgetScope = 'agent' | 'mission' | 'team' | 'tenant'
@@ -47,7 +49,7 @@ export interface BudgetsResult {
 /** GET /api/governance/budgets */
 export async function listBudgets(): Promise<BudgetsResult> {
   try {
-    const r = await fetch('/api/governance/budgets')
+    const r = await apiFetch('/api/governance/budgets')
     if (!r.ok) return { budgets: [], ok: false }
     const body = (await r.json()) as { budgets?: Budget[] }
     return { budgets: body.budgets ?? [], ok: true }
@@ -68,7 +70,7 @@ export interface SetBudgetInput {
 /** POST /api/governance/budgets — set/raise a cap (raising above spend un-pauses). */
 export async function setBudget(input: SetBudgetInput): Promise<Budget | null> {
   try {
-    const r = await fetch('/api/governance/budgets', {
+    const r = await apiFetch('/api/governance/budgets', {
       method: 'POST',
       headers: JSON_HEADERS,
       body: JSON.stringify(input),
@@ -96,7 +98,7 @@ export async function resumeBudget(
   graceUsdCents?: number,
 ): Promise<ResumeBudgetResult> {
   try {
-    const r = await fetch(
+    const r = await apiFetch(
       `/api/governance/budgets/${encodeURIComponent(scope)}/${encodeURIComponent(scopeId)}/resume`,
       {
         method: 'POST',
@@ -128,7 +130,7 @@ export async function listAudit(filter: AuditFilter = {}): Promise<AuditRow[]> {
     if (filter.since) p.set('since', String(filter.since))
     if (filter.limit) p.set('limit', String(filter.limit))
     const qs = p.toString()
-    const r = await fetch(`/api/governance/audit${qs ? `?${qs}` : ''}`)
+    const r = await apiFetch(`/api/governance/audit${qs ? `?${qs}` : ''}`)
     if (!r.ok) return []
     const body = (await r.json()) as { audit?: AuditRow[] }
     return body.audit ?? []

--- a/apps/web/src/lib/hydrateTeams.ts
+++ b/apps/web/src/lib/hydrateTeams.ts
@@ -1,3 +1,4 @@
+import { apiFetch } from '@clawboo/control-client'
 import { useTeamStore } from '@/stores/team'
 import { useFleetStore } from '@/stores/fleet'
 import type { CollectionId } from '@/lib/teamPalettes'
@@ -9,7 +10,7 @@ import { normalizeTeamColor } from '@/lib/normalizeTeamColor'
  */
 export async function hydrateTeams(): Promise<void> {
   try {
-    const r = await fetch('/api/teams?includeArchived=true')
+    const r = await apiFetch('/api/teams?includeArchived=true')
     const data = (await r.json()) as {
       teams?: {
         id: string
@@ -50,7 +51,7 @@ export async function hydrateTeams(): Promise<void> {
       for (const t of data.teams) {
         const normalized = normalizeTeamColor(t.color)
         if (normalized !== t.color) {
-          void fetch(`/api/teams/${t.id}`, {
+          void apiFetch(`/api/teams/${t.id}`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ color: normalized }),

--- a/apps/web/src/lib/memoryClient.ts
+++ b/apps/web/src/lib/memoryClient.ts
@@ -4,6 +4,8 @@
 // never throwing to the caller. The SPA never imports server packages, so the
 // shapes are mirrored locally here.
 
+import { apiFetch } from '@clawboo/control-client'
+
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const
 
 export type SearchMode = 'fts' | 'vector' | 'hybrid'
@@ -58,7 +60,7 @@ export async function searchMemory(
     if (opts.limit) p.set('limit', String(opts.limit))
     if (opts.teamId) p.set('teamId', opts.teamId)
     if (opts.agentId) p.set('agentId', opts.agentId)
-    const r = await fetch(`/api/memory?${p.toString()}`)
+    const r = await apiFetch(`/api/memory?${p.toString()}`)
     if (!r.ok) return []
     const body = (await r.json()) as { results?: MemorySearchResult[] }
     return body.results ?? []
@@ -76,7 +78,7 @@ export interface SaveFactInput {
 /** POST /api/memory — save a declarative fact. Returns the saved fact or null. */
 export async function saveFact(input: SaveFactInput): Promise<MemoryFact | null> {
   try {
-    const r = await fetch('/api/memory', {
+    const r = await apiFetch('/api/memory', {
       method: 'POST',
       headers: JSON_HEADERS,
       body: JSON.stringify({ kind: 'fact', ...input }),
@@ -105,7 +107,7 @@ export async function browseMemory(opts: SearchOpts = {}): Promise<BrowseResult>
     if (opts.teamId) p.set('teamId', opts.teamId)
     if (opts.agentId) p.set('agentId', opts.agentId)
     const qs = p.toString()
-    const r = await fetch(`/api/memory/browse${qs ? `?${qs}` : ''}`)
+    const r = await apiFetch(`/api/memory/browse${qs ? `?${qs}` : ''}`)
     if (!r.ok) return { facts: [], procedures: [], ok: false }
     const body = (await r.json()) as { facts?: MemoryFact[]; procedures?: MemoryProcedure[] }
     return { facts: body.facts ?? [], procedures: body.procedures ?? [], ok: true }
@@ -117,7 +119,7 @@ export async function browseMemory(opts: SearchOpts = {}): Promise<BrowseResult>
 /** GET /api/memory/provider — the active embedding provider (null = FTS-only). */
 export async function getProvider(): Promise<EmbeddingProviderInfo | null> {
   try {
-    const r = await fetch('/api/memory/provider')
+    const r = await apiFetch('/api/memory/provider')
     if (!r.ok) return null
     const body = (await r.json()) as { provider?: EmbeddingProviderInfo | null }
     return body.provider ?? null

--- a/apps/web/src/lib/openclawDefaultModel.ts
+++ b/apps/web/src/lib/openclawDefaultModel.ts
@@ -12,6 +12,7 @@
 // Sharing one fetch keeps them consistent (they must agree for the same agent).
 
 import { useEffect, useState } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 
 /**
  * Reads the OpenClaw default model from `/api/system/openclaw-config`.
@@ -20,7 +21,7 @@ import { useEffect, useState } from 'react'
  */
 export async function fetchOpenclawDefaultModel(): Promise<string | null> {
   try {
-    const res = await fetch('/api/system/openclaw-config')
+    const res = await apiFetch('/api/system/openclaw-config')
     const data = (await res.json()) as {
       config?: { agents?: { defaults?: { model?: { primary?: string } } } }
     }

--- a/apps/web/src/lib/schedulesClient.ts
+++ b/apps/web/src/lib/schedulesClient.ts
@@ -10,6 +10,7 @@ import type {
   ScheduleSourceReadStatus,
   ScheduleUpdatePatch,
 } from '@clawboo/scheduler'
+import { apiFetch } from '@clawboo/control-client'
 
 export type { ScheduleRecord, ScheduleSourceReadStatus } from '@clawboo/scheduler'
 
@@ -20,7 +21,7 @@ export interface SchedulesView {
 
 export async function fetchSchedules(): Promise<SchedulesView> {
   try {
-    const res = await fetch('/api/schedules')
+    const res = await apiFetch('/api/schedules')
     if (!res.ok) return { schedules: [], sources: [] }
     const body = (await res.json()) as Partial<SchedulesView>
     return { schedules: body.schedules ?? [], sources: body.sources ?? [] }
@@ -53,7 +54,7 @@ function fail(err: unknown): ScheduleActionResult {
 
 async function send(url: string, method: string, body?: object): Promise<ScheduleActionResult> {
   try {
-    const res = await fetch(url, {
+    const res = await apiFetch(url, {
       method,
       ...(body
         ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }

--- a/apps/web/src/lib/teamChatClient.ts
+++ b/apps/web/src/lib/teamChatClient.ts
@@ -7,6 +7,8 @@
 // NOTE: the polished room panel (interleaving these named-peer rows into the team
 // view) is a future UX coherence lap; this is the data layer it builds on.
 
+import { apiFetch } from '@clawboo/control-client'
+
 export interface TeamChatPost {
   id: string
   roomId: string
@@ -29,7 +31,7 @@ export interface TeamChatRoom {
 export async function fetchTeamChat(teamId: string, sinceSeq = 0): Promise<TeamChatRoom> {
   const empty: TeamChatRoom = { roomId: `team:${teamId}`, posts: [], nextSeq: sinceSeq }
   try {
-    const res = await fetch(
+    const res = await apiFetch(
       `/api/team-chat?teamId=${encodeURIComponent(teamId)}&sinceSeq=${sinceSeq}`,
     )
     if (!res.ok) return empty

--- a/apps/web/src/lib/teamRules.ts
+++ b/apps/web/src/lib/teamRules.ts
@@ -15,6 +15,8 @@
 //   2. The team chat composer slash command `/rule <text>` — appends a
 //      line to the team's rules in one click.
 
+import { apiFetch } from '@clawboo/control-client'
+
 const CACHE_TTL_MS = 5_000
 
 interface CacheEntry {
@@ -67,7 +69,7 @@ export async function fetchTeamRules(teamId: string): Promise<string> {
     return cached.content
   }
   try {
-    const res = await fetch(`/api/team-rules/${encodeURIComponent(teamId)}`)
+    const res = await apiFetch(`/api/team-rules/${encodeURIComponent(teamId)}`)
     if (!res.ok) return ''
     const body = (await res.json()) as { content?: string | null }
     const content = typeof body.content === 'string' ? body.content : ''
@@ -81,7 +83,7 @@ export async function fetchTeamRules(teamId: string): Promise<string> {
 /** PUT new rules content for a team. Invalidates the local cache. */
 export async function saveTeamRules(teamId: string, content: string): Promise<boolean> {
   try {
-    const res = await fetch(`/api/team-rules/${encodeURIComponent(teamId)}`, {
+    const res = await apiFetch(`/api/team-rules/${encodeURIComponent(teamId)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ content }),

--- a/apps/web/src/lib/useModelCatalog.ts
+++ b/apps/web/src/lib/useModelCatalog.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { apiFetch } from '@clawboo/control-client'
 import { MODEL_GROUPS, type ModelGroup } from './modelCatalog'
 import { useOpenClawModelGroups } from './useOpenRouterModels'
 
@@ -13,7 +14,7 @@ let fetchPromise: Promise<void> | null = null
 
 async function fetchDynamic(): Promise<void> {
   try {
-    const res = await fetch('/api/system/models')
+    const res = await apiFetch('/api/system/models')
     const data = (await res.json()) as {
       groups: ModelGroup[] | null
       configuredProviders?: string[]

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,9 @@
+// FIRST import, deliberately: it reads the URL prefix the server templated into
+// the shell and points the control client at it. Module evaluation is depth-first
+// in import order, so this runs before App's graph and no request is ever built
+// against the wrong base. See `app/bootstrapBase.ts`.
+import './app/bootstrapBase'
+
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App'

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -43,6 +43,13 @@ function resolveApiPort(): number {
 const apiPort = resolveApiPort()
 
 export default defineConfig({
+  // RELATIVE, so one prebuilt bundle serves from any mount point. clawboo ships
+  // `dist/ui` through npm, so a build-time absolute base would force users to
+  // rebuild just to serve under a path prefix. With './' every asset URL the
+  // bundle emits resolves at RUNTIME: JS-hosted ones against the importing
+  // chunk's own URL, CSS ones against the stylesheet, and index.html's own refs
+  // against the `<base href>` the server injects (see `server/lib/serveSpa.ts`).
+  base: './',
   plugins: [react(), tsconfigPaths({ ignoreConfigErrors: true })],
   build: {
     outDir: 'dist/ui',

--- a/docs/guides/self-host-securely.md
+++ b/docs/guides/self-host-securely.md
@@ -82,6 +82,8 @@ Skip those two variables and the proxy recipe fails in a way that looks like it 
 
 With either option, Clawboo never accepts a connection off-host directly; your tunnel or proxy is the only network-facing surface, and it brings its own authentication and TLS. You can still add an access token on top, but you do not have to widen the bind to get there.
 
+**Sharing a hostname with other apps.** The recipe above gives Clawboo the whole origin. To put it under a path instead, set `CLAWBOO_BASE_PATH=/clawboo` and forward `location /clawboo/` with a `proxy_pass` that carries no URI part, so the prefix reaches Clawboo intact ([Serving under a path prefix](/operating/deployment#serving-under-a-path-prefix)). Requests are stripped of the prefix before any security check runs, so the same-origin guard and the access gate enforce exactly what they do at the root, and the access cookie is scoped to `Path=/clawboo` so the sibling apps on that origin never receive it.
+
 ## Step 3: Or widen the bind, and set an access token
 
 If you do bind a non-loopback interface, you take on the access gate yourself. Set `HOST` **and** `STUDIO_ACCESS_TOKEN` together (a token-less wide bind refuses to start):
@@ -108,7 +110,7 @@ The token must come from the safe charset `[A-Za-z0-9._~-]` (which `openssl rand
 
 When `STUDIO_ACCESS_TOKEN` is set, the access gate is the only authentication on the dashboard. Four behaviors matter for a self-host setup; the [security page](/operating/security#the-access-gate-opt-in) has the full treatment.
 
-**Presenting the token, and the cookie.** Open `/?access_token=<token>` once. The gate validates it, sets an `HttpOnly`, `SameSite=Lax`, `Path=/` cookie named `clawboo_access`, and 302-redirects to strip the token from the URL. After that the cookie is the steady-state credential, validated on every `/api/*` request and on the `/api/gateway/ws` WebSocket upgrade. A request without a valid cookie gets `401` with a JSON `{ error }` body whose message tells you to open `/?access_token=<token>` once.
+**Presenting the token, and the cookie.** Open `/?access_token=<token>` once. The gate validates it, sets an `HttpOnly`, `SameSite=Lax` cookie named `clawboo_access` scoped to the path the app is served under (`Path=/` by default, or the `CLAWBOO_BASE_PATH` prefix when one is set), and 302-redirects to strip the token from the URL. After that the cookie is the steady-state credential, validated on every `/api/*` request and on the `/api/gateway/ws` WebSocket upgrade. A request without a valid cookie gets `401` with a JSON `{ error }` body whose message tells you to open `/?access_token=<token>` once.
 
 **Constant-time, length-hiding compare.** The token is never compared byte-by-byte. Both the cookie value and the configured token are SHA-256-hashed to a fixed 32-byte digest first, then compared in constant time; so the check neither short-circuits on the first differing byte (a timing oracle) nor leaks the token's length.
 

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -188,6 +188,39 @@ location / {
 
 Bind Clawboo to loopback and let the proxy be the only network-facing surface, **or** bind it wide and protect it with `STUDIO_ACCESS_TOKEN`, full details in [Security](/operating/security).
 
+### Serving under a path prefix
+
+When Clawboo shares a hostname with other apps, mount it under a prefix with `CLAWBOO_BASE_PATH` instead of giving it the whole origin:
+
+```bash
+CLAWBOO_BASE_PATH=/clawboo \
+CLAWBOO_ALLOWED_ORIGINS=https://apps.example.com \
+CLAWBOO_ALLOWED_HOSTS=apps.example.com \
+  npx clawboo
+```
+
+```nginx
+# The prefix is passed THROUGH to Clawboo, so proxy_pass carries no URI part
+# (no trailing slash after the port). With a trailing slash nginx strips the
+# location prefix before forwarding, and Clawboo, seeing requests arrive at the
+# root, redirects them back to the prefix: the browser then loops between the
+# two until it gives up.
+location /clawboo/ {
+    proxy_pass http://127.0.0.1:18790;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+}
+```
+
+The SPA, every `/api` route, the SSE streams, and the Gateway WebSocket all live under the prefix, and the prebuilt bundle needs no rebuild: the server templates the mount point into the shell it serves. The access cookie is scoped to the prefix (`Path=/clawboo`), so a sibling app on the same origin never receives it, which also means a browser hitting the unprefixed `/api` on a token-gated install gets a 401. That root `/api` surface stays served for the loopback control plane (the CLI probe, the MCP callback URLs, the self-update check) and stays exactly as gated as before.
+
+<Note>
+An invalid `CLAWBOO_BASE_PATH` makes the server refuse to start rather than silently serving at the root, so a typo surfaces at boot instead of looking like a broken proxy. In `pnpm dev` the Vite dev server still serves the SPA at the root and proxies `/api` to the API server, so the prefix shapes only what that API server accepts; develop at the root and set the prefix on the built server.
+</Note>
+
 ## Verify it worked
 
 - Hit `GET /api/settings`; a 200 with `{ gatewayUrl, hasToken }` confirms the server is up and Clawboo-shaped.

--- a/docs/operating/deployment.md
+++ b/docs/operating/deployment.md
@@ -213,6 +213,12 @@ location /clawboo/ {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
 }
+
+# `location /clawboo/` matches only the trailing-slash form, so without this the
+# bare `/clawboo` never reaches Clawboo and cannot be redirected by it.
+location = /clawboo {
+    return 308 /clawboo/;
+}
 ```
 
 The SPA, every `/api` route, the SSE streams, and the Gateway WebSocket all live under the prefix, and the prebuilt bundle needs no rebuild: the server templates the mount point into the shell it serves. The access cookie is scoped to the prefix (`Path=/clawboo`), so a sibling app on the same origin never receives it, which also means a browser hitting the unprefixed `/api` on a token-gated install gets a 401. That root `/api` surface stays served for the loopback control plane (the CLI probe, the MCP callback URLs, the self-update check) and stays exactly as gated as before.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -34,6 +34,7 @@ Provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, 
 | `HOSTNAME`                             | Ports & binding    | (ignored)                        | ignored (no longer a bind signal)       |
 | `CLAWBOO_ALLOWED_ORIGINS`              | Ports & binding    | (loopback only)                  | same-origin guard (widen)               |
 | `CLAWBOO_ALLOWED_HOSTS`                | Ports & binding    | (loopback only)                  | same-origin guard (widen)               |
+| `CLAWBOO_BASE_PATH`                    | Ports & binding    | (none, served at `/`)            | server boot + CLI printed URLs          |
 | `STUDIO_ACCESS_TOKEN`                  | Secrets & auth     | (none)                           | access gate                             |
 | `CLAWBOO_ALLOW_INSECURE`               | Secrets & auth     | (unset)                          | boot guard (wide-bind opt-out)          |
 | `CLAWBOO_SECRETS_MASTER_KEY`           | Secrets & auth     | auto-generated key file          | secrets vault                           |
@@ -179,6 +180,12 @@ A non-loopback bind (`HOST=0.0.0.0`, a LAN IP, or a hostname) WITHOUT `STUDIO_AC
 - **Read by**: the always-on same-origin guard (`createOriginGuard`), constructed at server boot in `apps/web/server/index.ts`.
 - **Purpose**: a comma-separated list of extra hostnames to accept in the HTTP `Host` header (the guard's DNS-rebinding defense). Like `CLAWBOO_ALLOWED_ORIGINS`, it only widens the always-enforced loopback allowlist. Set it when a reverse proxy forwards a public hostname to the dashboard.
 - **Default**: none (only loopback hostnames plus the actual bind host are accepted).
+
+### `CLAWBOO_BASE_PATH`
+
+- **Read by**: server boot in `apps/web/server/index.ts` (via `resolveBasePath()` in `@clawboo/config`), the SPA shell the server templates (`mountSpa`), and the URLs the CLI prints.
+- **Purpose**: serve the whole dashboard under a URL path prefix instead of the origin root, for example `/clawboo` when clawboo shares a hostname with other apps behind a reverse proxy. The SPA, every `/api` route, the SSE streams, and the Gateway WebSocket proxy all move under the prefix together. The prebuilt bundle needs no rebuild: the server templates the mount point into the shell it serves, and the app reads it at runtime. Requests are stripped of the prefix before any routing or security check runs, so the same-origin guard and the access gate enforce exactly what they do at the root. The access cookie is scoped to the prefix, so a sibling app on the same origin never receives it. The unprefixed `/api` surface stays served for the loopback control plane (the CLI discovery probe, the MCP callback URLs handed to spawned runtimes, the self-update check) and stays exactly as gated as before. Accepts a value with or without a leading or trailing slash. A malformed value (an empty or dot segment, whitespace, a percent sign, or a first segment of `api`, which would collide with the API routes) makes the server **refuse to start** with the reason, rather than quietly falling back to the root and looking like a broken deployment. In `pnpm dev` the Vite dev server serves the SPA at the root and proxies `/api`, so the prefix shapes only what the API server accepts; the dashboard itself is developed at the root.
+- **Default**: none (served at `/`, behaving as every release before this existed; the served shell gains a `<base href="/">` naming its mount, which at the root resolves exactly as the absolute paths it replaces).
 
 ### `CLAWBOO_AWAIT_PORT`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,34 @@ const CAPTURE_KEY_LISTENER_OBJ =
 const CAPTURE_KEY_LISTENER_MESSAGE =
   'No capture-phase key listeners in the SPA. Capture runs before both the dismissable-layer stack and every React onKeyDown, so two overlays act on one Escape (issue #95). Register the overlay with useDismissableLayer() instead; if you truly need a raw listener, use the bubble phase.'
 
+// Root-absolute API URLs in the SPA. clawboo can be mounted under a URL path
+// prefix (CLAWBOO_BASE_PATH), so a hardcoded `/api/...` request bypasses the
+// prefix and 404s at the origin root. The failure is invisible on a default
+// install, where the prefix is empty and the two spellings coincide, which is
+// exactly why it needs a lint rule rather than review attention.
+//
+// Both the string and template-literal forms, for `fetch` and `EventSource`.
+const ROOT_ABSOLUTE_API_FETCH =
+  "CallExpression[callee.name='fetch'] > Literal.arguments:first-child[value=/^\\/api\\//]"
+const ROOT_ABSOLUTE_API_FETCH_TEMPLATE =
+  "CallExpression[callee.name='fetch'] > TemplateLiteral.arguments:first-child > TemplateElement:first-child[value.raw=/^\\/api\\//]"
+const ROOT_ABSOLUTE_API_EVENTSOURCE =
+  "NewExpression[callee.name='EventSource'] > Literal.arguments:first-child[value=/^\\/api\\//]"
+const ROOT_ABSOLUTE_API_EVENTSOURCE_TEMPLATE =
+  "NewExpression[callee.name='EventSource'] > TemplateLiteral.arguments:first-child > TemplateElement:first-child[value.raw=/^\\/api\\//]"
+// Root-absolute STATIC asset refs in JSX (`src="/logo.svg"`). Vite rewrites the
+// ones in index.html and in CSS, but a string literal in a component is emitted
+// verbatim, so it escapes the mount and 404s at the origin root. A relative ref
+// resolves against the `<base href>` the server injects, which is correct at the
+// root and under a prefix.
+const ROOT_ABSOLUTE_ASSET_JSX =
+  'JSXAttribute[name.name=/^(src|href|poster)$/] > Literal[value=/^\\/[^/].*\\.(svg|png|jpe?g|gif|webp|avif|ico|woff2?|mp4|webm)$/]'
+const ROOT_ABSOLUTE_ASSET_MESSAGE =
+  'Use a RELATIVE asset path (e.g. "logo.svg", not "/logo.svg"). clawboo can be served under a path prefix (CLAWBOO_BASE_PATH); a root-absolute reference escapes the mount and 404s. Relative paths resolve against the <base href> the server injects, which is correct at the root too.'
+
+const ROOT_ABSOLUTE_API_MESSAGE =
+  "Use apiFetch()/apiUrl() from '@clawboo/control-client' instead of a root-absolute '/api/...' URL. clawboo can be served under a path prefix (CLAWBOO_BASE_PATH), and a hardcoded root path skips it and 404s. Both helpers are identity at the root, so the default install is unchanged."
+
 const SERVER_TO_SPA_MESSAGE =
   'apps/web/server must not import from apps/web/src. The server and the browser SPA are separate build targets — move anything they share into a @clawboo/* package (see packages/model-catalog).'
 const SPA_TO_SERVER_MESSAGE =
@@ -154,6 +182,11 @@ export default tseslint.config(
         { selector: DYNAMIC_IMPORT_INTO_SERVER, message: SPA_TO_SERVER_MESSAGE },
         { selector: CAPTURE_KEY_LISTENER, message: CAPTURE_KEY_LISTENER_MESSAGE },
         { selector: CAPTURE_KEY_LISTENER_OBJ, message: CAPTURE_KEY_LISTENER_MESSAGE },
+        { selector: ROOT_ABSOLUTE_API_FETCH, message: ROOT_ABSOLUTE_API_MESSAGE },
+        { selector: ROOT_ABSOLUTE_API_FETCH_TEMPLATE, message: ROOT_ABSOLUTE_API_MESSAGE },
+        { selector: ROOT_ABSOLUTE_API_EVENTSOURCE, message: ROOT_ABSOLUTE_API_MESSAGE },
+        { selector: ROOT_ABSOLUTE_API_EVENTSOURCE_TEMPLATE, message: ROOT_ABSOLUTE_API_MESSAGE },
+        { selector: ROOT_ABSOLUTE_ASSET_JSX, message: ROOT_ABSOLUTE_ASSET_MESSAGE },
       ],
     },
   },

--- a/packages/config/src/__tests__/basePath.test.ts
+++ b/packages/config/src/__tests__/basePath.test.ts
@@ -1,0 +1,91 @@
+// The CLAWBOO_BASE_PATH contract. Everything that has to agree on the prefix
+// (the Express mount, the templated SPA shell, the WS upgrade route, the access
+// cookie scope, the CLI's printed URLs) normalizes through here, so the accepted
+// and rejected shapes are pinned in one place.
+
+import { describe, expect, it } from 'vitest'
+
+import { normalizeBasePath, resolveBasePath, resolveBasePathOrRoot } from '../basePath'
+
+describe('normalizeBasePath', () => {
+  it('treats unset, empty, and "/" as the root', () => {
+    for (const raw of [undefined, null, '', '   ', '/']) {
+      expect(normalizeBasePath(raw)).toEqual({ ok: true, basePath: '' })
+    }
+  })
+
+  it('normalizes the shapes an operator actually types', () => {
+    // A proxy location block gets copied in with or without either slash.
+    for (const raw of ['/clawboo', 'clawboo', '/clawboo/', 'clawboo/', '  /clawboo/  ']) {
+      expect(normalizeBasePath(raw)).toEqual({ ok: true, basePath: '/clawboo' })
+    }
+  })
+
+  it('keeps a multi-segment prefix', () => {
+    expect(normalizeBasePath('/tools/clawboo')).toEqual({ ok: true, basePath: '/tools/clawboo' })
+    expect(normalizeBasePath('tools/clawboo/')).toEqual({ ok: true, basePath: '/tools/clawboo' })
+  })
+
+  it('accepts the unreserved characters and rejects everything else', () => {
+    expect(normalizeBasePath('/claw-boo_v2.1~x')).toEqual({
+      ok: true,
+      basePath: '/claw-boo_v2.1~x',
+    })
+    for (const raw of [
+      '/claw boo',
+      '/claw\tboo',
+      '/claw\\boo',
+      '/claw?boo',
+      '/claw#boo',
+      '/cl%61w',
+    ]) {
+      expect(normalizeBasePath(raw).ok).toBe(false)
+    }
+  })
+
+  it('rejects empty and dot segments rather than silently repairing them', () => {
+    // Repairing these would change what the prefix MATCHES, which is a silently
+    // broken mount instead of a loud startup failure.
+    for (const raw of ['//clawboo', '/clawboo//x', '/./clawboo', '/../clawboo', '/clawboo/..']) {
+      expect(normalizeBasePath(raw).ok).toBe(false)
+    }
+    expect(normalizeBasePath('//')).toEqual({ ok: false, reason: 'contains only slashes' })
+  })
+
+  it("rejects a first segment of 'api', which would collide with the API routes", () => {
+    for (const raw of ['/api', 'api', '/API', '/Api/x']) {
+      const out = normalizeBasePath(raw)
+      expect(out.ok).toBe(false)
+      if (!out.ok) expect(out.reason).toMatch(/api/i)
+    }
+    // Only the FIRST segment collides; 'api' deeper in the prefix is fine.
+    expect(normalizeBasePath('/tools/api')).toEqual({ ok: true, basePath: '/tools/api' })
+  })
+
+  it('gives a reason for every rejection', () => {
+    for (const raw of ['/claw boo', '//clawboo', '/api', '/cl%61w', '/claw\\boo']) {
+      const out = normalizeBasePath(raw)
+      expect(out.ok).toBe(false)
+      if (!out.ok) expect(out.reason.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('resolveBasePath', () => {
+  it('reads CLAWBOO_BASE_PATH from the supplied env bag', () => {
+    expect(resolveBasePath({ CLAWBOO_BASE_PATH: '/clawboo/' })).toEqual({
+      ok: true,
+      basePath: '/clawboo',
+    })
+    expect(resolveBasePath({})).toEqual({ ok: true, basePath: '' })
+    expect(resolveBasePath({ CLAWBOO_BASE_PATH: '/api' }).ok).toBe(false)
+  })
+
+  it('resolveBasePathOrRoot falls back to the root for a display-only caller', () => {
+    // The CLI only prints URLs, so it must not die on a value the server will
+    // reject on its own with a precise message.
+    expect(resolveBasePathOrRoot({ CLAWBOO_BASE_PATH: '/clawboo' })).toBe('/clawboo')
+    expect(resolveBasePathOrRoot({ CLAWBOO_BASE_PATH: '/api' })).toBe('')
+    expect(resolveBasePathOrRoot({})).toBe('')
+  })
+})

--- a/packages/config/src/basePath.ts
+++ b/packages/config/src/basePath.ts
@@ -1,0 +1,98 @@
+// The URL path prefix clawboo is served under (CLAWBOO_BASE_PATH), normalized once
+// and shared by everything that has to agree on it: the Express mount, the SPA
+// shell the server templates, the WebSocket upgrade route, the access cookie's
+// scope, and the URLs the CLI prints.
+//
+// Lives here rather than in the server because the CLI needs the same answer
+// without importing the server, and @clawboo/config is the package both already
+// depend on. It is pure string work: no filesystem, no env beyond the one read.
+//
+// The stored form is either '' (serve at the origin root, the default and the
+// behavior of every install that never sets the variable) or '/segment' with no
+// trailing slash, so callers can always write `${basePath}/api/...` and get a
+// single leading slash.
+
+/** A rejected value, with the reason to show the operator before exiting. */
+export interface BasePathError {
+  ok: false
+  reason: string
+}
+
+export interface BasePathOk {
+  ok: true
+  /** '' for the root, else a leading-slash, no-trailing-slash prefix. */
+  basePath: string
+}
+
+export type BasePathResult = BasePathOk | BasePathError
+
+// Per segment: unreserved URL characters only. Anything needing percent-encoding
+// would have to be encoded identically by the server, the SPA, and the proxy, and
+// a mismatch there is a silently broken mount rather than a loud error.
+const SEGMENT_RE = /^[A-Za-z0-9._~-]+$/
+
+/**
+ * Normalize a raw CLAWBOO_BASE_PATH value.
+ *
+ * Accepts a missing leading slash and a trailing slash (`clawboo`, `/clawboo/`
+ * and `/clawboo` all normalize to `/clawboo`), since an operator copying a proxy
+ * location block will write it either way. Empty and `/` mean the root.
+ *
+ * Rejects rather than silently repairing anything that would change what the
+ * prefix MATCHES: empty segments, dot segments, percent signs, whitespace,
+ * backslashes, query or fragment characters. Also rejects a first segment of
+ * `api`, which would collide with the API surface the mount serves underneath.
+ */
+export function normalizeBasePath(raw: string | undefined | null): BasePathResult {
+  const trimmed = (raw ?? '').trim()
+  if (!trimmed || trimmed === '/') return { ok: true, basePath: '' }
+
+  if (/\s/.test(trimmed)) return { ok: false, reason: 'contains whitespace' }
+  if (trimmed.includes('\\')) return { ok: false, reason: 'contains a backslash' }
+  if (trimmed.includes('?') || trimmed.includes('#')) {
+    return { ok: false, reason: 'contains a query or fragment character' }
+  }
+  if (trimmed.includes('%')) {
+    return { ok: false, reason: 'contains a percent sign (use unencoded characters)' }
+  }
+
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  const withoutTrailing = withLeading.replace(/\/+$/, '')
+  // A value that was only slashes ('//' or '///') collapses to empty here, which
+  // is an empty segment rather than the root.
+  if (!withoutTrailing) return { ok: false, reason: 'contains only slashes' }
+
+  const segments = withoutTrailing.slice(1).split('/')
+  for (const segment of segments) {
+    if (!segment) return { ok: false, reason: 'contains an empty segment (a doubled slash)' }
+    if (segment === '.' || segment === '..') {
+      return { ok: false, reason: `contains a '${segment}' segment` }
+    }
+    if (!SEGMENT_RE.test(segment)) {
+      return {
+        ok: false,
+        reason: `segment '${segment}' has characters outside A-Z a-z 0-9 . _ ~ -`,
+      }
+    }
+  }
+  if (segments[0]?.toLowerCase() === 'api') {
+    return { ok: false, reason: "must not start with 'api' (it would collide with the API routes)" }
+  }
+
+  return { ok: true, basePath: withoutTrailing }
+}
+
+/** Read + normalize CLAWBOO_BASE_PATH from an env bag. */
+export function resolveBasePath(env: NodeJS.ProcessEnv = process.env): BasePathResult {
+  return normalizeBasePath(env['CLAWBOO_BASE_PATH'])
+}
+
+/**
+ * The base path, or '' when unset or invalid. For callers that only DISPLAY a URL
+ * (the CLI's printed links) and must not fail on a value the server will reject
+ * on its own with a precise message.
+ */
+export function resolveBasePathOrRoot(env: NodeJS.ProcessEnv = process.env): string {
+  const result = resolveBasePath(env)
+  return result.ok ? result.basePath : ''
+}

--- a/packages/config/src/basePath.ts
+++ b/packages/config/src/basePath.ts
@@ -57,7 +57,12 @@ export function normalizeBasePath(raw: string | undefined | null): BasePathResul
   }
 
   const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
-  const withoutTrailing = withLeading.replace(/\/+$/, '')
+  // Trailing slashes are trimmed by scanning, not by `/\/+$/`: that pattern
+  // backtracks polynomially on a long run of slashes, and this helper is exported,
+  // so it should not depend on its input staying operator-controlled.
+  let end = withLeading.length
+  while (end > 0 && withLeading[end - 1] === '/') end -= 1
+  const withoutTrailing = withLeading.slice(0, end)
   // A value that was only slashes ('//' or '///') collapses to empty here, which
   // is an empty segment rather than the root.
   if (!withoutTrailing) return { ok: false, reason: 'contains only slashes' }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,6 +2,17 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
+// The URL path prefix the whole app is served under. Re-exported by name (a
+// `export *` of a workspace dep breaks downstream bundling in this repo).
+export {
+  normalizeBasePath,
+  resolveBasePath,
+  resolveBasePathOrRoot,
+  type BasePathError,
+  type BasePathOk,
+  type BasePathResult,
+} from './basePath'
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const NEW_STATE_DIRNAME = '.openclaw'

--- a/packages/gateway-client/src/__tests__/resolveProxyGatewayUrl.test.ts
+++ b/packages/gateway-client/src/__tests__/resolveProxyGatewayUrl.test.ts
@@ -1,0 +1,50 @@
+// The Gateway proxy URL under a path prefix.
+//
+// The prefix reaches this helper two ways: the global the server templates into
+// the SPA shell, and an explicit argument. Both are normalized, because a caller
+// (or an operator's env value) may spell the prefix with a trailing slash, and
+// `/clawboo/` + `/api/gateway/ws` would otherwise produce a doubled slash. `/`
+// is worse than cosmetic: `//api/gateway/ws` is protocol-relative.
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { resolveProxyGatewayUrl } from '../helpers'
+
+const g = globalThis as { __CLAWBOO_BASE__?: unknown }
+afterEach(() => {
+  delete g.__CLAWBOO_BASE__
+})
+
+// `window` is undefined here, so the helper takes its SSR branch and returns the
+// loopback form. The base handling is identical on both branches.
+describe('resolveProxyGatewayUrl', () => {
+  it('serves the root when no prefix is set', () => {
+    expect(resolveProxyGatewayUrl()).toBe('ws://localhost:18790/api/gateway/ws')
+  })
+
+  it('reads the prefix the server templated into the shell', () => {
+    g.__CLAWBOO_BASE__ = '/clawboo'
+    expect(resolveProxyGatewayUrl()).toBe('ws://localhost:18790/clawboo/api/gateway/ws')
+  })
+
+  it('normalizes whatever shape the prefix arrives in', () => {
+    for (const raw of ['/clawboo', 'clawboo', '/clawboo/', 'clawboo//', '  /clawboo/  ']) {
+      expect(resolveProxyGatewayUrl(raw), raw).toBe('ws://localhost:18790/clawboo/api/gateway/ws')
+    }
+  })
+
+  it('treats an empty or root-only prefix as the root, never a doubled slash', () => {
+    // `//api/gateway/ws` would be read as protocol-relative, pointing the socket
+    // at a host named "api".
+    for (const raw of ['', '/', '   ', '//']) {
+      expect(resolveProxyGatewayUrl(raw), JSON.stringify(raw)).toBe(
+        'ws://localhost:18790/api/gateway/ws',
+      )
+    }
+  })
+
+  it('ignores a non-string global rather than interpolating it', () => {
+    g.__CLAWBOO_BASE__ = 42
+    expect(resolveProxyGatewayUrl()).toBe('ws://localhost:18790/api/gateway/ws')
+  })
+})

--- a/packages/gateway-client/src/helpers.ts
+++ b/packages/gateway-client/src/helpers.ts
@@ -116,22 +116,30 @@ export const authRetryAfterMs = (err: unknown): number | null => {
 
 // ─── URL helpers ──────────────────────────────────────────────────────────────
 
-/** The URL prefix the app is served under, templated into the shell by the server.
- *  Read defensively so this helper stays usable outside the SPA bundle. */
-const injectedBasePath = (): string => {
-  const raw = (globalThis as { __CLAWBOO_BASE__?: unknown }).__CLAWBOO_BASE__
+/** Normalize a URL prefix to '' or '/segment', whatever shape it arrives in.
+ *  Applied to the EXPLICIT argument as well as the injected global: a caller
+ *  passing '/clawboo/' or '/' would otherwise build '/clawboo//api/gateway/ws'
+ *  or '//api/gateway/ws', and the second is protocol-relative once it lands in a
+ *  URL. Trailing slashes are trimmed by scanning rather than with `/\/+$/`,
+ *  which backtracks polynomially on a long run of slashes. */
+const normalizeBase = (raw: unknown): string => {
   if (typeof raw !== 'string') return ''
   const trimmed = raw.trim()
   if (!trimmed || trimmed === '/') return ''
   const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
-  return withLeading.replace(/\/+$/, '')
+  let end = withLeading.length
+  while (end > 0 && withLeading[end - 1] === '/') end -= 1
+  return withLeading.slice(0, end)
 }
 
 export const resolveProxyGatewayUrl = (basePath?: string): string => {
   // The proxy route lives UNDER the app's path prefix, so a subpath mount has to
   // carry it here too. `window.location.pathname` is not a substitute: it is the
-  // current route, not the mount point.
-  const base = basePath ?? injectedBasePath()
+  // current route, not the mount point. Read defensively so this helper stays
+  // usable outside the SPA bundle.
+  const base = normalizeBase(
+    basePath ?? (globalThis as { __CLAWBOO_BASE__?: unknown }).__CLAWBOO_BASE__,
+  )
   // Browser path: same-origin, so we never hardcode a port. The string below
   // is only used in SSR / Node test contexts where `window` is undefined —
   // 18790 mirrors the default in `apps/web/server/lib/portUtils.ts`.

--- a/packages/gateway-client/src/helpers.ts
+++ b/packages/gateway-client/src/helpers.ts
@@ -116,14 +116,29 @@ export const authRetryAfterMs = (err: unknown): number | null => {
 
 // ─── URL helpers ──────────────────────────────────────────────────────────────
 
-export const resolveProxyGatewayUrl = (): string => {
+/** The URL prefix the app is served under, templated into the shell by the server.
+ *  Read defensively so this helper stays usable outside the SPA bundle. */
+const injectedBasePath = (): string => {
+  const raw = (globalThis as { __CLAWBOO_BASE__?: unknown }).__CLAWBOO_BASE__
+  if (typeof raw !== 'string') return ''
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed === '/') return ''
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeading.replace(/\/+$/, '')
+}
+
+export const resolveProxyGatewayUrl = (basePath?: string): string => {
+  // The proxy route lives UNDER the app's path prefix, so a subpath mount has to
+  // carry it here too. `window.location.pathname` is not a substitute: it is the
+  // current route, not the mount point.
+  const base = basePath ?? injectedBasePath()
   // Browser path: same-origin, so we never hardcode a port. The string below
   // is only used in SSR / Node test contexts where `window` is undefined —
   // 18790 mirrors the default in `apps/web/server/lib/portUtils.ts`.
-  if (typeof window === 'undefined') return 'ws://localhost:18790/api/gateway/ws'
+  if (typeof window === 'undefined') return `ws://localhost:18790${base}/api/gateway/ws`
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
   const host = window.location.host
-  return `${protocol}://${host}/api/gateway/ws`
+  return `${protocol}://${host}${base}/api/gateway/ws`
 }
 
 export const isLocalGatewayUrl = (url: string): boolean => {

--- a/packages/gateway-proxy/src/access-gate.ts
+++ b/packages/gateway-proxy/src/access-gate.ts
@@ -11,6 +11,16 @@ export interface AccessGateOptions {
   cookieName?: string
   /** URL query param that carries the one-time token. Defaults to 'access_token'. */
   queryParam?: string
+  /**
+   * The URL prefix the app is mounted under ('' = origin root), already normalized.
+   *
+   * The gate runs BEHIND the base-path strip, so the pathnames it tests are always
+   * root-form and its `/api/` checks need no change. This is used only where a
+   * path leaves the gate: the cookie's `Path` (so a mount does not hand its
+   * operator cookie to a sibling app on the same origin) and the post-exchange
+   * redirect (which must land back under the mount, not at the origin root).
+   */
+  basePath?: string
 }
 
 export interface AccessGate {
@@ -91,6 +101,9 @@ export function createAccessGate(options: AccessGateOptions = {}): AccessGate {
   let token = String(options.token ?? '').trim()
   const cookieName = String(options.cookieName ?? 'clawboo_access').trim() || 'clawboo_access'
   const queryParam = String(options.queryParam ?? 'access_token').trim() || 'access_token'
+  // '' at the origin root, else '/mount'. The cookie needs a non-empty Path.
+  const basePath = String(options.basePath ?? '').trim()
+  const cookiePath = basePath || '/'
   // The gate is the ONLY auth for a non-loopback bind, and the token is written raw
   // into the Set-Cookie value + compared raw against the cookie but percent-decoded in
   // the query path. A token with a cookie-delimiter / non-token char would corrupt the
@@ -135,8 +148,13 @@ export function createAccessGate(options: AccessGateOptions = {}): AccessGate {
       url.searchParams.delete(queryParam)
       const secure = requestIsHttps(req) ? '; Secure' : ''
       res.statusCode = 302
-      res.setHeader('Set-Cookie', `${cookieName}=${token}; HttpOnly; Path=/; SameSite=Lax${secure}`)
-      res.setHeader('Location', buildRedirectUrl(req, url.pathname + url.search))
+      res.setHeader(
+        'Set-Cookie',
+        `${cookieName}=${token}; HttpOnly; Path=${cookiePath}; SameSite=Lax${secure}`,
+      )
+      // The pathname here is post-strip, so re-attach the mount prefix or the
+      // operator is redirected to the origin root and out of the app.
+      res.setHeader('Location', buildRedirectUrl(req, basePath + url.pathname + url.search))
       res.end()
       return true
     }

--- a/scripts/check-entry-chunk.mjs
+++ b/scripts/check-entry-chunk.mjs
@@ -84,8 +84,10 @@ if (preloadTags.length === 0) {
   )
 }
 
+// The build uses a RELATIVE base (`./assets/…`) so one bundle serves from any
+// mount point; accept the absolute spelling too in case that changes back.
 const preloadedAll = preloadTags
-  .map((tag) => /href="\/assets\/([^"]+)"/.exec(tag)?.[1] ?? tag)
+  .map((tag) => /href="(?:\.\/|\/)assets\/([^"]+)"/.exec(tag)?.[1] ?? tag)
   .map((href) => href.replace(/-[\w-]{8}\.js$/, '.js'))
 const preloaded = preloadTags.filter((tag) => tag.includes(CHUNK))
 if (preloaded.length > 0) {
@@ -103,7 +105,7 @@ const kb = (f) => Math.round(statSync(path.join(ASSETS_DIR, f)).size / 1024)
 
 // Read the entry from the script tag rather than matching `index-*.js`: several app
 // modules are named index.ts and emit chunks matching that pattern too.
-const entry = /<script[^>]+type="module"[^>]*\ssrc="\/assets\/([^"]+)"/.exec(html)?.[1]
+const entry = /<script[^>]+type="module"[^>]*\ssrc="(?:\.\/|\/)assets\/([^"]+)"/.exec(html)?.[1]
 
 console.log('\n✅ Marketplace catalog is a deferred chunk, not preloaded by the entry.')
 for (const f of chunks) console.log(`   ${f} — ${kb(f)} KB (fetched on demand)`)

--- a/tests/e2e/04-teams.spec.ts
+++ b/tests/e2e/04-teams.spec.ts
@@ -13,7 +13,7 @@ test.describe('Teams', () => {
     await expect(teamSidebar).toBeVisible({ timeout: 5_000 })
 
     // Mascot logo should be in the team sidebar
-    const mascot = teamSidebar.locator('img[src="/logo.svg"]')
+    const mascot = teamSidebar.locator('img[src$="logo.svg"]')
     await expect(mascot).toBeVisible({ timeout: 5_000 })
 
     // Agents should appear in the agent list column (Col 2).

--- a/tests/e2e/05-group-chat.spec.ts
+++ b/tests/e2e/05-group-chat.spec.ts
@@ -145,7 +145,7 @@ test.describe('Group Chat', () => {
 
     // Click mascot icon to deselect team (enters Boo Zero view — hides AgentListColumn)
     const teamSidebar = page.locator('[data-testid="team-sidebar"]')
-    await teamSidebar.locator('img[src="/logo.svg"]').click()
+    await teamSidebar.locator('img[src$="logo.svg"]').click()
 
     // Group chat row should not be visible (AgentListColumn hidden in Boo Zero view)
     await expect(agentList.locator('[data-testid="group-chat-row"]')).not.toBeVisible({

--- a/tests/e2e/17-base-path.spec.ts
+++ b/tests/e2e/17-base-path.spec.ts
@@ -1,0 +1,287 @@
+// Serving the whole app under a URL path prefix (CLAWBOO_BASE_PATH).
+//
+// Two servers, because the interesting half is the token-gated one: the same
+// -origin guard and the access gate decide what to protect by matching the API
+// path and FAIL OPEN on anything else, so "the API is still guarded once it moves
+// under a prefix" is the property worth proving end to end rather than in a unit.
+//
+// These spawn their own servers rather than using the shared one from
+// playwright.config.ts, since the prefix is a boot-time setting. They reuse the
+// `dist/ui` that config already built, so nothing here rebuilds.
+
+import { spawn, type ChildProcess } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from '@playwright/test'
+
+// Specs load as CommonJS here, so no `import.meta`. Playwright resolves its
+// config from the repo root and runs from there.
+const WEB_DIR = path.join(process.cwd(), 'apps/web')
+const BASE_PATH = '/clawboo'
+
+// HOME is sandboxed per server below, and corepack keys its cache off HOME, so
+// without an explicit COREPACK_HOME the pnpm shim re-downloads itself from the
+// registry and this otherwise network-free suite quietly needs the network.
+// playwright.config.ts computes the same fallback for its own webServer; it is
+// recomputed here because that value lives in the config's module scope and is
+// never exported into the runner's environment.
+const COREPACK_HOME =
+  process.env['COREPACK_HOME'] ??
+  path.join(
+    process.env['XDG_CACHE_HOME'] ??
+      process.env['LOCALAPPDATA'] ??
+      path.join(os.homedir(), process.platform === 'win32' ? 'AppData/Local' : '.cache'),
+    'node/corepack',
+  )
+
+interface Started {
+  origin: string
+  stop: () => void
+}
+
+// Every server spawned by this file, registered the moment it exists. A hook
+// that times out or throws never returns its handle, so a per-describe
+// `afterAll(() => server?.stop())` cannot clean up what it was never given, and
+// a detached server would keep the port for the next run. The sweep below always
+// runs and always sees them.
+const spawned: Started[] = []
+test.afterAll(() => {
+  for (const s of spawned.splice(0)) s.stop()
+})
+
+/**
+ * Fail if anything already holds the port.
+ *
+ * The port is pinned, so a collision makes OUR server die on EADDRINUSE while
+ * the squatter keeps answering. Checking after the fact cannot work: the
+ * squatter replies to the first probe about a second before the child's exit is
+ * observed, so the readiness loop adopts it and the whole spec silently tests
+ * someone else's server. The only reliable moment is before the spawn.
+ */
+async function assertPortFree(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const probe = net
+      .createServer()
+      .once('error', (err: NodeJS.ErrnoException) =>
+        reject(
+          new Error(
+            `port ${port} is already in use (${err.code}), so this spec cannot tell its own server from the squatter`,
+          ),
+        ),
+      )
+      .once('listening', () => probe.close(() => resolve()))
+      .listen(port, '127.0.0.1')
+  })
+}
+
+/** Boot a sandboxed server under the prefix and wait for it to answer. */
+async function startServer(port: number, extraEnv: Record<string, string> = {}): Promise<Started> {
+  await assertPortFree(port)
+  const home = mkdtempSync(path.join(os.tmpdir(), 'clawboo-e2e-base-'))
+  // `detached` puts the server in its own process GROUP. `pnpm exec` is a wrapper
+  // that forks the real node process, so signalling the child alone leaves the
+  // server orphaned and still holding the port: the next run's readiness probe
+  // then answers from that stale process, whose sandbox this run already deleted,
+  // and the app serves its shell but never initializes.
+  const child: ChildProcess = spawn('pnpm', ['exec', 'tsx', 'server/index.ts'], {
+    cwd: WEB_DIR,
+    stdio: 'ignore',
+    detached: true,
+    env: {
+      ...process.env,
+      HOME: home,
+      CLAWBOO_HOME: path.join(home, '.clawboo'),
+      OPENCLAW_STATE_DIR: path.join(home, '.openclaw'),
+      CLAWBOO_API_PORT: String(port),
+      CLAWBOO_BASE_PATH: BASE_PATH,
+      CLAWBOO_UI_DIR: path.join(WEB_DIR, 'dist/ui'),
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: '0',
+      COREPACK_HOME,
+      ...extraEnv,
+    },
+  })
+
+  /** Kill the whole process group, so no orphan keeps holding the port. */
+  const stop = (): void => {
+    try {
+      if (child.pid) process.kill(-child.pid, 'SIGKILL')
+    } catch {
+      // Already gone.
+    }
+    rmSync(home, { recursive: true, force: true })
+  }
+
+  const started: Started = { origin: `http://127.0.0.1:${port}`, stop }
+  // Registered BEFORE the wait, so a hook timeout mid-boot still gets cleaned up.
+  spawned.push(started)
+
+  let exited = false
+  child.once('exit', () => {
+    exited = true
+  })
+
+  const origin = started.origin
+  const deadline = Date.now() + 90_000
+  for (;;) {
+    // Belt to assertPortFree's braces: catches a child that dies for any other
+    // reason (a crash on boot) instead of waiting out the full deadline.
+    if (exited) {
+      stop()
+      throw new Error(`server for ${port} exited during startup (is the port taken?)`)
+    }
+    if (Date.now() > deadline) {
+      stop()
+      throw new Error(`server on ${port} did not become ready`)
+    }
+    try {
+      // Any answer (200 or a 401 from the gate) means it is listening.
+      await fetch(`${origin}${BASE_PATH}/api/settings`)
+      break
+    } catch {
+      await new Promise((r) => setTimeout(r, 500))
+    }
+  }
+
+  return started
+}
+
+/** Boot inside a hook, widening the hook's own timeout to cover a cold start. */
+async function startInHook(port: number, extraEnv?: Record<string, string>): Promise<Started> {
+  // A beforeAll hook inherits the project timeout (30s by default), which is less
+  // than a cold server boot, so without this the hook is killed before the
+  // readiness loop's own deadline can report anything useful.
+  test.setTimeout(150_000)
+  return startServer(port, extraEnv)
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test.describe('served under a path prefix', () => {
+  let server: Started
+
+  test.beforeAll(async () => {
+    server = await startInHook(19971)
+  })
+  test.afterAll(() => server?.stop())
+
+  test('the dashboard loads at the mount and its assets resolve', async ({ page }) => {
+    // Same-origin only: the shell loads Google Fonts, and an egress-restricted
+    // runner failing that request says nothing about the base path.
+    const sameOrigin = (url: string): boolean => url.startsWith(server.origin)
+    const failed: string[] = []
+    page.on('requestfailed', (r) => {
+      if (sameOrigin(r.url())) failed.push(r.url())
+    })
+    page.on('response', (r) => {
+      if (sameOrigin(r.url()) && r.status() >= 400) failed.push(`${r.status()} ${r.url()}`)
+    })
+    // Anything the app addresses at the ORIGIN ROOT escaped the mount. The server
+    // still serves the unprefixed /api for its loopback control plane, so such a
+    // request answers 200 and would never show up as a failure: this is the only
+    // check that sees it.
+    const escaped: string[] = []
+    const apiRequests: string[] = []
+    page.on('request', (r) => {
+      if (!sameOrigin(r.url())) return
+      const p = new URL(r.url()).pathname
+      if (p.startsWith(`${BASE_PATH}/api/`)) apiRequests.push(r.url())
+      else if (p.startsWith('/api/')) escaped.push(r.url())
+    })
+
+    await page.goto(`${server.origin}${BASE_PATH}/`)
+    // The shell advertises its own mount point, which is what lets the prebuilt
+    // bundle resolve assets and build API URLs without a rebuild.
+    await expect(page.locator('base')).toHaveAttribute('href', `${BASE_PATH}/`)
+    expect(await page.evaluate(() => window.__CLAWBOO_BASE__)).toBe(BASE_PATH)
+    // Assets first: a 404 here is the root cause of an empty #root, so asserting
+    // it before the render check makes the failure name itself.
+    expect(failed, `no request under the mount should fail:\n${failed.join('\n')}`).toEqual([])
+    // The app actually mounted (React rendered into #root).
+    await expect(page.locator('#root')).not.toBeEmpty({ timeout: 30_000 })
+
+    // The SPA issues almost all of its API traffic AFTER first paint, so let the
+    // network settle before judging where those requests went. Asserting at first
+    // paint would have seen a single request and passed regardless.
+    await page.waitForLoadState('networkidle').catch(() => undefined)
+    expect(apiRequests.length, 'the app should have called its API by now').toBeGreaterThan(1)
+    expect(
+      escaped,
+      `these addressed the origin root instead of the mount:\n${escaped.join('\n')}`,
+    ).toEqual([])
+  })
+
+  test('a deep route serves the shell and the API answers under the prefix', async () => {
+    const deep = await fetch(`${server.origin}${BASE_PATH}/board`)
+    expect(deep.status).toBe(200)
+    expect(await deep.text()).toContain('__CLAWBOO_BASE__')
+
+    const api = await fetch(`${server.origin}${BASE_PATH}/api/settings`)
+    expect(api.status).toBe(200)
+    expect(await api.json()).toHaveProperty('gatewayUrl')
+  })
+
+  test('the bare prefix and the root redirect to the mount, preserving the query', async () => {
+    const bare = await fetch(`${server.origin}${BASE_PATH}`, { redirect: 'manual' })
+    expect(bare.status).toBe(302)
+    expect(bare.headers.get('location')).toBe(`${BASE_PATH}/`)
+
+    // The CLI prints `/?access_token=...`; dropping the query would break it.
+    const root = await fetch(`${server.origin}/?access_token=abc`, { redirect: 'manual' })
+    expect(root.status).toBe(302)
+    expect(root.headers.get('location')).toBe(`${BASE_PATH}/?access_token=abc`)
+  })
+
+  test('paths outside the mount 404', async () => {
+    for (const p of ['/clawboonot/x', '/elsewhere']) {
+      expect((await fetch(`${server.origin}${p}`)).status).toBe(404)
+    }
+  })
+})
+
+test.describe('the guards still enforce under the prefix', () => {
+  let server: Started
+  const TOKEN = 'e2ebasepathtoken'
+
+  test.beforeAll(async () => {
+    server = await startInHook(19972, { STUDIO_ACCESS_TOKEN: TOKEN })
+  })
+  test.afterAll(() => server?.stop())
+
+  test('the access gate blocks the prefixed API without a cookie', async () => {
+    const res = await fetch(`${server.origin}${BASE_PATH}/api/settings`)
+    expect(res.status).toBe(401)
+  })
+
+  test('the same-origin guard blocks a foreign Origin under the prefix', async () => {
+    // The fail-open case: a guard still matching only the unprefixed path would
+    // wave this through as if it were a static asset.
+    const res = await fetch(`${server.origin}${BASE_PATH}/api/settings`, {
+      headers: { Origin: 'https://evil.example' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  test('the token exchange scopes its cookie to the mount and returns to it', async () => {
+    const res = await fetch(`${server.origin}${BASE_PATH}/?access_token=${TOKEN}`, {
+      redirect: 'manual',
+    })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('set-cookie')).toContain(`Path=${BASE_PATH}`)
+    expect(res.headers.get('location')).toContain(`${BASE_PATH}/`)
+
+    const authed = await fetch(`${server.origin}${BASE_PATH}/api/settings`, {
+      headers: { Cookie: `clawboo_access=${TOKEN}` },
+    })
+    expect(authed.status).toBe(200)
+  })
+
+  test('the unprefixed API is still gated, not opened up', async () => {
+    // It stays served for the loopback control plane, but the prefix must not
+    // have turned it into an unauthenticated bypass.
+    const res = await fetch(`${server.origin}/api/settings`)
+    expect(res.status).toBe(401)
+  })
+})


### PR DESCRIPTION
## Summary

* Adds support for serving the Clawboo dashboard beneath a configurable URL path prefix instead of requiring deployment at `/`.
* Propagates the configured base path through server routing, SPA asset/navigation behavior, and CLI-generated dashboard URLs.
* Documents `CLAWBOO_BASE_PATH` and preserves existing behavior by defaulting to root-path serving when no prefix is configured.

## Type

* [x] Feature (`feat:`)
* [ ] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [x] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clawboo can now be served under a configurable URL path prefix.
  * Dashboard pages, assets, APIs, SSE streams, WebSocket connections, redirects, cookies, and CLI links support the configured prefix.
  * Unprefixed control-plane API access remains available where supported.
  * Invalid path-prefix settings are rejected at startup.

* **Bug Fixes**
  * Improved path handling and security for prefixed routes, including deep links and equivalent path spellings.
  * Improved asset and API URL resolution when hosted below the site root.

* **Documentation**
  * Added deployment and environment-variable guidance for path-prefix hosting.

* **Tests**
  * Added coverage for prefixed serving, authentication, routing, assets, and WebSockets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->