### PR TITLE
fix(test): skip machine-generated lockfiles in the repo-hygiene guard

### DIFF
--- a/apps/web/server/lib/__tests__/repoHygieneTracked.test.ts
+++ b/apps/web/server/lib/__tests__/repoHygieneTracked.test.ts
@@ -74,6 +74,14 @@ const EXCLUDES = [
   ':!apps/web/src/features/marketplace/agents/agency/specialized.ts',
   ':!apps/web/server/lib/__tests__/repoHygiene.test.ts',
   ':!apps/web/server/lib/__tests__/repoHygieneTracked.test.ts',
+  // The two pnpm lockfiles are machine-generated from the registry, so they can
+  // carry no internal shorthand to leak, and their base64 integrity hashes will
+  // randomly satisfy the S-code shape: `/` and `+` are non-word characters, so a
+  // hash containing `/S45+` reads as a word-bounded `S45`. That is a coin flip on
+  // every regeneration (typescript-eslint@8.68.0 lost it), which would fail this
+  // guard on an unrelated dependency bump and teach the next reader to ignore it.
+  ':!pnpm-lock.yaml',
+  ':!website/pnpm-lock.yaml',
 ]
 
 describe('repo hygiene (tracked surface): a git grep over committed files leaks nothing', () => {


### PR DESCRIPTION
## What

Excludes `pnpm-lock.yaml` and `website/pnpm-lock.yaml` from the tracked-surface repo-hygiene grep.

## Why

The guard greps for internal build-session shorthand with a word-bounded S-code shape (`\b[sS][0-9]{2}\b`). A pnpm lockfile's base64 integrity hashes satisfy that shape at random, because `/` and `+` are non-word characters: a hash carrying `/S45+` reads as a word-bounded `S45`.

`typescript-eslint@8.68.0` drew exactly such a hash:

```
sha512-MHy0Y0ynqeEbx/S45+i/bBssdy3X6KNBfmJAP35GrgtNxu2TQ5K5xsFDhAnmsq1jvpdoZOPG1LGtJo0HWqYCrQ==
```

That failed `Test` and `Test (cross-platform) (windows-latest)` on #180, a dependency bump with nothing wrong in it. `main` is clean today only by luck, so this recurs on roughly any lockfile regeneration.

A lockfile is generated from the registry, so it cannot carry the internal shorthand this guard exists to catch. Scanning it produces only false positives, and a gate that goes red for unrelated reasons teaches the next reader to wave it through.

## Verification

Reproduced CI's exact `expected [ Array(1) ] to deeply equal []` against #180's head, then confirmed the exclusion yields zero offenders. Both hygiene guards pass locally, and the file is Prettier-clean.

Note: on macOS `git grep -E` does not honour `\b`, so this only reproduces with `-P` locally. CI's Linux git matches it natively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repository hygiene checks from reporting false failures caused by generated pnpm lockfile integrity hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->