### PR TITLE
chore(deps-dev): upgrade TypeScript to 6.0.3

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -58,6 +58,6 @@
     "@types/better-sqlite3": "^7.6.0",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -98,7 +98,7 @@
     "tailwindcss": "^4.3.3",
     "tsup": "^8.4.0",
     "tsx": "^4.23.13",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vite": "^8.2.2",
     "vite-tsconfig-paths": "^5.1.0"
   }

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+// Vite's ambient client types. These declare the side-effect asset imports
+// (`*.css` and friends) plus `import.meta.env`. TypeScript 6 errors on a
+// side-effect import with no declaration (TS2882), so this is required, not
+// merely conventional.
+/// <reference types="vite/client" />

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "tsup": "^8.4.0",
     "tsx": "^4.23.13",
     "turbo": "^2.10.12",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.68.0",
     "vitest": "^3.2.7",
     "ws": "^8.21.3"

--- a/packages/adapters/claude-code/package.json
+++ b/packages/adapters/claude-code/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/adapters/codex/package.json
+++ b/packages/adapters/codex/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/adapters/hermes/package.json
+++ b/packages/adapters/hermes/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/adapters/mock/package.json
+++ b/packages/adapters/mock/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/adapters/native/package.json
+++ b/packages/adapters/native/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/adapters/openclaw/package.json
+++ b/packages/adapters/openclaw/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/agent-registry/package.json
+++ b/packages/agent-registry/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/board-core/package.json
+++ b/packages/board-core/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/boo-avatar/package.json
+++ b/packages/boo-avatar/package.json
@@ -40,6 +40,6 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/capability-registry/package.json
+++ b/packages/capability-registry/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/compaction/package.json
+++ b/packages/compaction/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,6 +40,6 @@
     "@clawboo/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/connector-catalog/package.json
+++ b/packages/connector-catalog/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7",
     "zod": "^3.25.0"
   }

--- a/packages/control-client/package.json
+++ b/packages/control-client/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -54,6 +54,6 @@
     "@types/node": "^22.0.0",
     "drizzle-kit": "^0.31.10",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -45,7 +45,7 @@
     "@clawboo/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -44,6 +44,6 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -47,6 +47,6 @@
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/gateway-proxy/package.json
+++ b/packages/gateway-proxy/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/governance/package.json
+++ b/packages/governance/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -44,6 +44,6 @@
     "@clawboo/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -53,7 +53,7 @@
     "@clawboo/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/model-catalog/package.json
+++ b/packages/model-catalog/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/obs/package.json
+++ b/packages/obs/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/process-lookup/package.json
+++ b/packages/process-lookup/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -39,6 +39,6 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/team-orchestration/package.json
+++ b/packages/team-orchestration/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@clawboo/tsconfig": "workspace:*",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/packages/team-orchestration/src/nudgeQueue.ts
+++ b/packages/team-orchestration/src/nudgeQueue.ts
@@ -76,8 +76,12 @@ export function createNudgeQueue(opts?: {
       void Promise.resolve(opts?.onWedge?.(sessionKey)).catch(() => undefined)
       markIdle(sessionKey)
     }, wedgeMs)
-    if (typeof (t as { unref?: () => void }).unref === 'function')
-      (t as { unref: () => void }).unref()
+    // `setTimeout` is typed as the DOM's (returning `number`) because this
+    // package is browser-safe, but under Node the handle is a Timeout carrying
+    // `unref`. TS 6 rejects the direct assertion as non-overlapping, so widen
+    // through `unknown`; the runtime probe below is what actually guards it.
+    const handle = t as unknown as { unref?: () => void }
+    if (typeof handle.unref === 'function') handle.unref()
     wedgeTimers.set(sessionKey, t)
   }
 

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,6 +53,6 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/worktrees/package.json
+++ b/packages/worktrees/package.json
@@ -44,7 +44,7 @@
     "@clawboo/tsconfig": "workspace:*",
     "@types/node": "^22.0.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "typescript": "^6.0.3",
     "vitest": "^3.2.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-v8':
         specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0))
+        version: 3.2.4(vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0))
       eslint:
         specifier: ^9.0.0
         version: 9.39.2(jiti@2.7.0)
@@ -58,7 +58,7 @@ importers:
         version: 15.5.2
       msw:
         specifier: ^2.15.0
-        version: 2.15.0(@types/node@22.19.11)(typescript@5.9.3)
+        version: 2.15.0(@types/node@22.19.11)(typescript@6.0.3)
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -67,7 +67,7 @@ importers:
         version: 16.29.0
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.23.13
         version: 4.23.13
@@ -75,14 +75,14 @@ importers:
         specifier: ^2.10.12
         version: 2.10.12
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.68.0
-        version: 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+        version: 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
       ws:
         specifier: ^8.21.3
         version: 8.21.3
@@ -134,10 +134,10 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   apps/web:
     dependencies:
@@ -378,19 +378,19 @@ importers:
         version: 4.3.3
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       tsx:
         specifier: ^4.23.13
         version: 4.23.13
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
       vite-tsconfig-paths:
         specifier: ^5.1.0
-        version: 5.1.4(typescript@5.9.3)(vite@8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
+        version: 5.1.4(typescript@6.0.3)(vite@8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
 
   docs:
     devDependencies:
@@ -409,13 +409,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/adapters/codex:
     dependencies:
@@ -428,13 +428,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/adapters/hermes:
     dependencies:
@@ -447,13 +447,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/adapters/mock:
     dependencies:
@@ -466,13 +466,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/adapters/native:
     dependencies:
@@ -488,13 +488,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/adapters/openclaw:
     dependencies:
@@ -519,13 +519,13 @@ importers:
         version: link:../../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/agent-registry:
     devDependencies:
@@ -534,13 +534,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/board-core:
     devDependencies:
@@ -549,13 +549,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/boo-avatar:
     devDependencies:
@@ -564,10 +564,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/capability-registry:
     devDependencies:
@@ -576,13 +576,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/compaction:
     devDependencies:
@@ -591,13 +591,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/config:
     devDependencies:
@@ -609,10 +609,10 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/connector-catalog:
     devDependencies:
@@ -621,13 +621,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -643,13 +643,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/db:
     dependencies:
@@ -692,10 +692,10 @@ importers:
         version: 0.31.10
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/evals:
     dependencies:
@@ -723,13 +723,13 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/events:
     dependencies:
@@ -748,10 +748,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/executor:
     devDependencies:
@@ -760,13 +760,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/gateway-client:
     dependencies:
@@ -791,10 +791,10 @@ importers:
         version: 8.18.1
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/gateway-proxy:
     dependencies:
@@ -819,13 +819,13 @@ importers:
         version: 8.18.1
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/governance:
     dependencies:
@@ -838,13 +838,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/logger:
     dependencies:
@@ -863,10 +863,10 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/mcp:
     dependencies:
@@ -888,13 +888,13 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/model-catalog:
     devDependencies:
@@ -903,13 +903,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/obs:
     dependencies:
@@ -922,13 +922,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/process-lookup:
     devDependencies:
@@ -937,13 +937,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/protocol:
     devDependencies:
@@ -952,10 +952,10 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/scheduler:
     dependencies:
@@ -971,13 +971,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/team-orchestration:
     dependencies:
@@ -996,13 +996,13 @@ importers:
         version: link:../tsconfig
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
   packages/tsconfig: {}
 
@@ -1038,10 +1038,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/worktrees:
     dependencies:
@@ -1057,13 +1057,13 @@ importers:
         version: 22.19.11
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
 
 packages:
 
@@ -6028,8 +6028,8 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8230,40 +8230,40 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
-      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.68.0
       eslint: 9.39.2(jiti@2.7.0)
       ignore: 7.0.8
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.68.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.68.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.68.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.68.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8272,47 +8272,47 @@ snapshots:
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/visitor-keys': 8.68.0
 
-  '@typescript-eslint/tsconfig-utils@8.68.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.68.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.68.0': {}
 
-  '@typescript-eslint/typescript-estree@8.68.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.68.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.68.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/visitor-keys': 8.68.0
       debug: 4.4.3
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.2(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8328,7 +8328,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8343,7 +8343,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0)
+      vitest: 3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8355,13 +8355,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.13)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.7(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.15.0(@types/node@22.19.11)(typescript@5.9.3)
+      msw: 2.15.0(@types/node@22.19.11)(typescript@6.0.3)
       vite: 7.3.6(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.13)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.7':
@@ -10338,7 +10338,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3):
+  msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@22.19.11)
       '@mswjs/interceptors': 0.41.9
@@ -10359,7 +10359,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -11296,19 +11296,19 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
+  tsconfck@3.1.6(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(typescript@6.0.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -11329,7 +11329,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.26
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -11369,18 +11369,18 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3):
+  typescript-eslint@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.68.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 
@@ -11487,11 +11487,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
+  vite-tsconfig-paths@5.1.4(typescript@6.0.3)(vite@8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
+      tsconfck: 3.1.6(typescript@6.0.3)
     optionalDependencies:
       vite: 8.2.2(@types/node@22.19.11)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -11529,11 +11529,11 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.9.0
 
-  vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.23.13)(yaml@2.9.0):
+  vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.19.11)(jiti@2.7.0)(jsdom@30.0.1)(lightningcss@1.33.0)(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(msw@2.15.0(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.13)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(msw@2.15.0(@types/node@22.19.11)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.13)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7


### PR DESCRIPTION
Supersedes #165. Dependabot's version bump alone could not pass CI, because TypeScript 6 needs three small compatibility changes alongside it. Every job on #165 failed, all on the same root cause.

## The three changes

**1. `ignoreDeprecations: "6.0"` in `packages/tsconfig/base.json`**

TS 6 deprecates `baseUrl` (TS5101). We do not set it anywhere, but tsup's DTS plugin injects it, so every package's `DTS Build` failed:

```
DTS Build start
error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

The shared base config is the one place every package extends, so it silences this once. This is a stopgap tied to tsup rather than to our source, and it will need revisiting for TS 7.

**2. `nudgeQueue.ts` widens a timer assertion through `unknown`**

The package is browser-safe, so `setTimeout` is typed as the DOM's and returns `number`, while under Node the handle carries `unref`. TS 6 rejects asserting between them as non-overlapping. The runtime `typeof` probe is unchanged and is still what actually guards the call, so behaviour is identical.

**3. `apps/web/src/vite-env.d.ts` added**

TS 6 errors on side-effect imports that have no declarations (TS2882), which hit the three CSS imports in `apps/web`. This is the ambient Vite client types file Vite normally scaffolds and the app was missing.

## Verification

Run locally on this branch, against current `main`:

| Gate | Result |
|---|---|
| `pnpm build` | 34/34 tasks |
| `pnpm typecheck` | 65/65 tasks |
| `pnpm lint` | 65/65 tasks |
| `pnpm format:check` | clean |
| `pnpm test` | 64/64 tasks, 0 failures (apps/web 2965 passed) |