### PR TITLE
ci: gate the website build and stabilise the Windows leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,14 @@ jobs:
       # install). The Linux `test` job gets this for free from `turbo test`, which
       # builds a package's dependencies first; here we invoke Vitest directly to
       # scope to the platform-sensitive suites, so the dependency build is explicit.
+      #
+      # Windows fails process CREATION under load: turbo forking a build for all 34
+      # packages at once has produced STATUS_DLL_INIT_FAILED (exit 0xC0000142) here,
+      # which reads as a build error but is the OS refusing to start another process.
+      # Bound the fan-out on that leg only; macOS builds at turbo's default width.
       - run: pnpm build
+        env:
+          TURBO_CONCURRENCY: ${{ matrix.os == 'windows-latest' && '4' || '10' }}
 
       # packages/worktrees: the real-git, per-task worktree lifecycle that underpins
       # every file-mutating task. Drives a real `git` binary via its gitHarness.
@@ -164,6 +171,38 @@ jobs:
       # The dedicated platform.test.ts step this replaces is redundant now, since that
       # file runs as part of the full suite here.
       - run: pnpm --filter @clawboo/web --fail-if-no-match exec vitest run server/
+
+  # website/ declares its own pnpm root so Cloudflare Pages can build the
+  # subdirectory alone, which also means the root workspace's Lint/Typecheck/Test/
+  # Build jobs never touch it. Without this job a website change ships to
+  # www.claw.boo on a green tick that only ever described the monorepo: the
+  # astro 5 -> 6 major landed exactly that way. These steps mirror the Pages build
+  # (same command, same Node), so green here means the deploy compiles.
+  #
+  # Deliberately NOT behind a paths filter. It is a required check, and a
+  # path-filtered required check never reports on unrelated PRs, which blocks them
+  # forever. Running it always costs ~1 minute and keeps the gate honest.
+  website:
+    name: Website
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
 
   build:
     name: Build

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,6 +4,17 @@ import { defineConfig } from 'vitest/config'
 
 const alias = { '@': path.resolve(__dirname, 'src') }
 
+// The node project's server suites drive a real `git` binary, real SQLite, and real
+// child processes, so their wall-clock is dominated by the host's I/O and process
+// spawn cost rather than by our code. GitHub's windows-latest runners are about
+// twice as slow as macOS for this same suite (measured 6m57s against 3m45s on a
+// green run), and some of that work shells out to PowerShell, where a single
+// Get-CimInstance probe can cost seconds. A 30s budget tuned on Linux therefore
+// reads as a timeout on Windows for tests that are merely slow, not broken. Widen
+// the tolerance on that platform only. This is a tolerance, not a fix: a test that
+// fails here for a genuine race should be fixed rather than given more seconds.
+const SERVER_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 30_000
+
 // Two projects (vitest 3.x): the existing node-env suites (the React/SPA logic in
 // src/ + the Express-server tests in server/, all `.test.ts`) and a jsdom project
 // for React component tests (`.test.tsx`). Splitting by project keeps component
@@ -41,8 +52,8 @@ export default defineConfig({
           // component transforms run concurrently in the same `vitest run`, those
           // tests can be starved past the 5 s default — give them headroom (they
           // pass on their own merits; this only widens the tolerance, not results).
-          testTimeout: 30_000,
-          hookTimeout: 30_000,
+          testTimeout: SERVER_TIMEOUT_MS,
+          hookTimeout: SERVER_TIMEOUT_MS,
         },
       },
       {


### PR DESCRIPTION
Follow-up to the dependency sweep, which surfaced both of these.

## 1. The website had no CI at all

`website/` declares its own pnpm root so Cloudflare Pages can build the subdirectory alone. The consequence is that no root-workspace job touches it: `Lint`, `Typecheck`, `Test`, `Build` and `E2E` all pass without ever compiling the site. So a website change ships to www.claw.boo on a green tick that only ever described the monorepo.

That is how **astro 5.18.2 to 6.4.8 (#161) landed with zero automated verification**. I built it by hand before merging; the next one would not get that.

The new `Website` job mirrors the Pages build exactly, same command and same Node, so green here means the deploy compiles.

It deliberately has **no `paths` filter**. It is intended to be a required check, and a path-filtered required check never reports on unrelated PRs, which leaves them blocked forever. Running it always costs about a minute.

`astro check` is not included: it currently prompts to install `@astrojs/check` and `typescript`, which are not dependencies. `astro build` is what Cloudflare runs and is the honest gate.

## 2. The Windows leg is unstable in two distinct ways

During the sweep, Windows failed **four times in four separate runs**, each on a different test, all passing on re-run. Two different causes:

**Process creation under load.** `@clawboo/config#build` exited `-1073741502` (`0xC0000142`, `STATUS_DLL_INIT_FAILED`). That is not a compile error, it is the OS refusing to start another process while turbo forks builds for all 34 packages at once. Now bounded via `TURBO_CONCURRENCY` on the Windows leg only; macOS keeps turbo's default width.

**Timeouts on a slower platform.** `pidFile` and `executorRunner` both hit the 30s per-test cap. Measured on a green run, Windows takes **6m57s** for the suite macOS does in **3m45s**, and some of that work shells out to PowerShell, where a single `Get-CimInstance` probe (`pidFile.ts:109`) costs seconds. The 30s budget was tuned on Linux. Now 60s on `win32` only.

To be explicit about what this second change is: **a tolerance, not a fix.** It buys time for tests that are genuinely just slow. A test failing here for a real race still needs fixing rather than more seconds, which is why I did not reach for a blanket `retry`. A retry would have silently swallowed the real hygiene-guard failure on #180.

Still outstanding and deliberately not addressed here: `codexLeaderCascade` failed on an assertion rather than a timeout (`expected length 2 but got 1`), which looks like a genuine race between its fake timers and real fs I/O. That wants a real fix, not a wider budget.

## Verification

- `ci.yml` parses; all 10 jobs resolve, `website` has the right working directory, and the cross-platform build step carries the conditional `TURBO_CONCURRENCY`.
- `TURBO_CONCURRENCY` confirmed to reach turbo through `pnpm build` (a bogus value errors on the `--concurrency` flag; a valid one builds).
- `pidFile.test.ts` and `executorRunner.test.ts` pass under the new config (38 tests).
- Website build verified locally against current `main`, including the astro 6 upgrade.
- Both files Prettier-clean.

## After merge

`Website` needs adding to the ruleset's required status checks. That has to happen after this merges, because a required check that has never reported blocks every open PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability on Windows by limiting concurrent build tasks.
  * Increased test and setup timeouts on Windows to reduce platform-specific test failures.

* **Chores**
  * Added automated website installation and build checks to continuous integration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->