### PR TITLE
fix(security): pin derived paths at their source and quote the Windows shim token

### DIFF
--- a/.changeset/pin-derived-paths-at-their-source.md
+++ b/.changeset/pin-derived-paths-at-their-source.md
@@ -1,0 +1,7 @@
+---
+'clawboo': patch
+---
+
+Close out the remaining hardening on derived filesystem locations and the Windows shim launcher. A task's worktree directory is now pinned under the worktree root at the one place it is derived, so every consumer of that location, from provisioning through scaffold writes to the recursive cleanup, builds on a path that has already been checked, and the directory created for a fresh worktree is taken from that checked value rather than resolved a second time from raw inputs. A runtime's per-identity home gets the same treatment: the assembled path is confirmed to sit under the runtimes root before anything creates or hands out the directory that will hold a runtime's private state.
+
+The Windows `.cmd`/`.bat` shim route now double-quotes the resolved command token on the cmd.exe line instead of caret-escaping it. Quotes are what cmd.exe honours in the program position, so a resolved path containing spaces, ampersands, or parentheses stays one literal token, and a quote can never appear inside a Windows file name to close the wrapping early. The CLI sign-in relay also spawns its two modes as two distinct calls, the cmd.exe shim route and the plain no-shell argv route, so each spawn is exactly the mode it claims rather than a merge of both possibilities.

--- a/apps/web/server/api/cliLogin.ts
+++ b/apps/web/server/api/cliLogin.ts
@@ -30,7 +30,7 @@ import {
 } from '../lib/runtimes/codexAuth'
 import { hasUsableCodexAuth } from '../lib/runtimes/codexDriver'
 import { isHermesCodexAuthPresent } from '../lib/runtimes/hermesAuth'
-import { resolveWindowsSpawn } from '../lib/runtimes/winSpawn'
+import { buildCmdShimPlan, needsCmdShim } from '../lib/runtimes/winSpawn'
 import { killProcessTree } from '../lib/runtimes/killTree'
 import {
   buildCliLoginPlan,
@@ -110,24 +110,35 @@ export function cliLoginPOST(req: Request, res: Response): void {
     message: `Starting ${plan.displayCommand}…`,
   })
 
-  // Windows .cmd/.bat shims (codex/hermes) route through the repo's safe spawn
-  // planner — quoted + caret-escaped, NEVER `shell: true` (a bare shell spawn
-  // misparses a resolved bin path containing a space, e.g. a spaced Windows
-  // username). No-op on POSIX and for .exe targets.
-  const winPlan = resolveWindowsSpawn({ command: plan.command, args: plan.args })
-
+  // Two DISTINCT spawn modes, each its own call so a spawn is exactly what it
+  // says. A Windows .cmd/.bat shim (codex/hermes) routes through the repo's safe
+  // cmd.exe planner, quoted + caret-escaped, NEVER `shell: true` (a bare shell
+  // spawn misparses a resolved bin path containing a space, e.g. a spaced
+  // Windows username). Everything else is a plain argv spawn that no shell ever
+  // parses.
   let child: ChildProcess
   try {
-    child = spawn(winPlan.command, winPlan.args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: plan.env,
-      // Process-group leader so Cancel kills the whole tree (browser helpers,
-      // the script-wrapped openclaw). Windows: no process groups; taskkill /T
-      // inside killProcessTree covers it.
-      detached: !isWindows,
-      windowsVerbatimArguments: winPlan.windowsVerbatimArguments,
-      windowsHide: isWindows,
-    })
+    if (needsCmdShim(plan.command)) {
+      const shim = buildCmdShimPlan({ command: plan.command, args: plan.args })
+      child = spawn(shim.command, shim.args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: plan.env,
+        // Windows: no process groups; taskkill /T inside killProcessTree covers
+        // tree cleanup.
+        detached: false,
+        windowsVerbatimArguments: shim.windowsVerbatimArguments,
+        windowsHide: true,
+      })
+    } else {
+      child = spawn(plan.command, plan.args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: plan.env,
+        // Process-group leader so Cancel kills the whole tree (browser helpers,
+        // the script-wrapped openclaw).
+        detached: !isWindows,
+        windowsHide: isWindows,
+      })
+    }
   } catch (err) {
     sendEvent(res, {
       type: 'error',

--- a/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
@@ -6,9 +6,11 @@
 //
 // Two DIFFERENT protections share one command line. Arguments are caret-escaped,
 // so no bare metacharacter survives in them. The program token is wrapped in real
-// double quotes instead, inside which cmd treats those characters as literal, so
-// it legitimately carries a bare `&`. Assertions about carets must therefore be
-// scoped to the arguments, never applied to the whole line.
+// double quotes instead, which make the substitution-phase metacharacters
+// literal, so it legitimately carries a bare `&`. Assertions about carets must
+// therefore be scoped to the arguments, never applied to the whole line.
+// Quoting does NOT cover `%` or `!`: cmd substitutes those before quotes mean
+// anything, so such a path is refused rather than quoted.
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -92,5 +94,36 @@ describe('resolveWindowsSpawn', () => {
     expect(line.startsWith(`""${command}"`)).toBe(true) // one quoted program token
     expect(line).not.toContain('^&') // the path's & is quote-protected, not caret-escaped
     expect(/(?<!\^)&/.test(argsPortion(line))).toBe(false) // arguments still carry no bare &
+  })
+
+  // `%` and `!` are substituted BEFORE quotes take effect, so unlike & they cannot
+  // be made literal by the wrapping. main's caret pass happened to defeat %VAR% by
+  // corrupting the variable name; quoting does not, so the path is refused instead.
+  for (const { label, command } of [
+    { label: '%VAR% expansion', command: 'C:\\tools\\%TEMP%\\codex.cmd' },
+    { label: 'delayed !VAR! expansion', command: 'C:\\tools\\!TEMP!\\codex.cmd' },
+  ]) {
+    it(`refuses a command path cmd would substitute (${label})`, () => {
+      expect(() => resolveWindowsSpawn({ command, args: ['login'] })).toThrow(/% or !/)
+    })
+  }
+
+  it('refuses the substitutable path rather than emitting an expandable token', () => {
+    // The regression guard: quoting alone would have produced a live %TEMP% pair
+    // in the program position for cmd to expand.
+    let line = ''
+    try {
+      line = resolveWindowsSpawn({ command: 'C:\\tools\\%TEMP%\\x.cmd', args: [] }).args[3] ?? ''
+    } catch {
+      line = ''
+    }
+    expect(/%[A-Za-z_][A-Za-z0-9_]*%/.test(line)).toBe(false)
+  })
+
+  it('refuses even a lone %, because the guard rejects on the character not the pair', () => {
+    // Deliberately broader than strictly required. A lone % cannot expand on its
+    // own, but pair-matching the guard would make it depend on cmd's scanner
+    // behaviour, and a resolved binary path carrying % is pathological anyway.
+    expect(() => resolveWindowsSpawn({ command: 'C:\\tools\\100%\\x.cmd', args: [] })).toThrow()
   })
 })

--- a/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
@@ -3,12 +3,28 @@
 // .exe target (or any non-Windows spawn) must pass argv through unchanged with no
 // shell. `../../platform` is mocked to isWindows:true so the Windows branch runs
 // on a POSIX CI host.
+//
+// Two DIFFERENT protections share one command line. Arguments are caret-escaped,
+// so no bare metacharacter survives in them. The program token is wrapped in real
+// double quotes instead, inside which cmd treats those characters as literal, so
+// it legitimately carries a bare `&`. Assertions about carets must therefore be
+// scoped to the arguments, never applied to the whole line.
 
 import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../platform', () => ({ isWindows: true }))
 
 const { escapeCmdArg, resolveWindowsSpawn } = await import('../winSpawn')
+
+/**
+ * The argument tail of a cmd.exe `/c` line, with the quoted program token removed.
+ * A Windows file name cannot contain `"`, so the quote closing the program token
+ * is the first one after the two that open the line.
+ */
+function argsPortion(line: string): string {
+  const close = line.indexOf('"', 2)
+  return close < 0 ? line : line.slice(close + 1)
+}
 
 describe('escapeCmdArg — neutralizes cmd.exe metacharacters', () => {
   it('caret-escapes & so a prompt cannot chain a second command', () => {
@@ -48,7 +64,10 @@ describe('resolveWindowsSpawn', () => {
     expect(plan.windowsVerbatimArguments).toBe(true)
     const line = plan.args[3] ?? ''
     expect(line).toContain('^&') // the prompt's & is escaped inside the command line
-    expect(/(?<!\^)&/.test(line)).toBe(false) // no bare & cmd could chain on
+    // Scoped to the ARGUMENTS. The program token is quote-protected rather than
+    // caret-escaped, so a bare & inside it is correct and this assertion must not
+    // reach it. See the &-bearing path test below.
+    expect(/(?<!\^)&/.test(argsPortion(line))).toBe(false) // no bare & cmd could chain on
   })
 
   it('double-quotes the command token so a spaced or meta-bearing path stays one program', () => {
@@ -60,5 +79,18 @@ describe('resolveWindowsSpawn', () => {
     // The program is one quoted token; inside real quotes cmd treats spaces and
     // parentheses as literal, so the path cannot split or start a group.
     expect(line.startsWith('""C:\\Users\\Jo Doe\\bin (x86)\\codex.cmd"')).toBe(true)
+  })
+
+  it('keeps an &-bearing command path one literal token, by quoting rather than caret-escaping', () => {
+    // `&` is legal in a Windows path (the reserved set is < > : " / \ | ? *), so an
+    // &-bearing install path is exactly as reachable as the spaced-username case.
+    // Inside real double quotes cmd treats it as literal, so the program token
+    // carries a BARE &, and the caret invariant applies to the arguments only.
+    const command = 'C:\\Users\\A&B\\AppData\\Roaming\\npm\\codex.cmd'
+    const plan = resolveWindowsSpawn({ command, args: ['login'] })
+    const line = plan.args[3] ?? ''
+    expect(line.startsWith(`""${command}"`)).toBe(true) // one quoted program token
+    expect(line).not.toContain('^&') // the path's & is quote-protected, not caret-escaped
+    expect(/(?<!\^)&/.test(argsPortion(line))).toBe(false) // arguments still carry no bare &
   })
 })

--- a/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
+++ b/apps/web/server/lib/runtimes/__tests__/winSpawn.test.ts
@@ -50,4 +50,15 @@ describe('resolveWindowsSpawn', () => {
     expect(line).toContain('^&') // the prompt's & is escaped inside the command line
     expect(/(?<!\^)&/.test(line)).toBe(false) // no bare & cmd could chain on
   })
+
+  it('double-quotes the command token so a spaced or meta-bearing path stays one program', () => {
+    const plan = resolveWindowsSpawn({
+      command: 'C:\\Users\\Jo Doe\\bin (x86)\\codex.cmd',
+      args: ['login'],
+    })
+    const line = plan.args[3] ?? ''
+    // The program is one quoted token; inside real quotes cmd treats spaces and
+    // parentheses as literal, so the path cannot split or start a group.
+    expect(line.startsWith('""C:\\Users\\Jo Doe\\bin (x86)\\codex.cmd"')).toBe(true)
+  })
 })

--- a/apps/web/server/lib/runtimes/identityHome.ts
+++ b/apps/web/server/lib/runtimes/identityHome.ts
@@ -29,16 +29,26 @@ export function sanitizeAgentId(agentId: string | null | undefined): string {
   return segment
 }
 
-/** `<clawboo home>/runtimes/<runtimeId>/<sanitized agentId>` — stable across runs. */
+/**
+ * `<clawboo home>/runtimes/<runtimeId>/<sanitized agentId>`, stable across runs.
+ *
+ * The assembled path is pinned under the runtimes root with a single startsWith
+ * test before it is handed out. The segment rewrite above should make an escape
+ * impossible by construction, but this home is created with mkdir and then given
+ * to a runtime as its private state directory, so the location itself carries
+ * the final say: a path that resolves outside the root is refused here, not
+ * discovered later as a directory materialized somewhere it should never be.
+ */
 export function runtimeIdentityHomePath(
   runtimeId: string,
   agentId: string | null | undefined,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  return path.join(
-    resolveClawbooDir(env),
-    'runtimes',
-    sanitizeAgentId(runtimeId),
-    sanitizeAgentId(agentId),
-  )
+  const root = path.resolve(resolveClawbooDir(env), 'runtimes')
+  const prefix = root.endsWith(path.sep) ? root : root + path.sep
+  const home = path.resolve(root, sanitizeAgentId(runtimeId), sanitizeAgentId(agentId))
+  if (!home.startsWith(prefix)) {
+    throw new Error(`runtime identity home escapes ${root}: ${home}`)
+  }
+  return home
 }

--- a/apps/web/server/lib/runtimes/subprocess.ts
+++ b/apps/web/server/lib/runtimes/subprocess.ts
@@ -17,7 +17,7 @@ import path from 'node:path'
 import { isWindows } from '../platform'
 import { buildChildEnv } from './childEnv'
 import { killProcessTree, killProcessTreeByPid } from './killTree'
-import { resolveWindowsSpawn } from './winSpawn'
+import { resolveWindowsSpawn, type WinSpawnPlan } from './winSpawn'
 
 /**
  * Every spawned runtime child that is still running.
@@ -258,8 +258,15 @@ export function createSpawnDriver<N>(cfg: SpawnDriverConfig<N>): SpawnDriver<N> 
       if (started) return
       started = true
       let resolved: ResolvedSpawn
+      let plan: WinSpawnPlan
       try {
         resolved = await cfg.resolve()
+        // Planned inside the same guard as resolve(). Planning REFUSES a Windows
+        // shim path that cmd.exe would substitute before quotes take effect (`%`
+        // or `!`), and that refusal has to end the run the way a failed resolve
+        // does. Outside this try it would escape start() as an unhandled
+        // rejection instead of reaching the driver as a reported failure.
+        plan = resolveWindowsSpawn({ command: resolved.command, args: resolved.args })
       } catch (err) {
         for (const ev of cfg.onClose(
           null,
@@ -271,7 +278,6 @@ export function createSpawnDriver<N>(cfg: SpawnDriverConfig<N>): SpawnDriver<N> 
         return
       }
       cwd = resolved.cwd ?? null
-      const plan = resolveWindowsSpawn({ command: resolved.command, args: resolved.args })
       child = spawn(plan.command, plan.args, {
         cwd: resolved.cwd ?? undefined,
         // Scrub clawboo's own server secrets before the untrusted agent subprocess

--- a/apps/web/server/lib/runtimes/winSpawn.ts
+++ b/apps/web/server/lib/runtimes/winSpawn.ts
@@ -4,10 +4,10 @@
 // is NEVER interpreted by a shell on macOS/Linux or for a Windows `.exe` target.
 // The one case that still needs care is a Windows `.cmd`/`.bat` shim: Node
 // (>=18.20.2 / 20.12.2 / 22) refuses to spawn those without a shell (the
-// CVE-2024-27980 fix throws EINVAL), so we route them through cmd.exe — and then
-// every untrusted argument MUST be quoted (CommandLineToArgvW boundaries) AND
-// caret-escaped (cmd.exe metacharacters) so a prompt like `do X & calc.exe`
-// cannot break out and chain a second command.
+// CVE-2024-27980 fix throws EINVAL), so we route them through cmd.exe: the
+// resolved command token double-quoted, and every untrusted argument quoted
+// (CommandLineToArgvW boundaries) AND caret-escaped (cmd.exe metacharacters) so
+// a prompt like `do X & calc.exe` cannot break out and chain a second command.
 //
 // The escaping below implements cmd.exe's documented quoting rules — the
 // CommandLineToArgvW argument-boundary rules plus caret-escaping of cmd.exe's
@@ -20,11 +20,6 @@ import { isWindows } from '../platform'
 const META_CHARS = /([()\][%!^"`<>&|;, *?])/g
 
 const isBatch = (command: string): boolean => /\.(cmd|bat)$/i.test(command)
-
-/** Caret-escape cmd.exe metacharacters in a command token (the shim path). */
-function escapeCommandToken(token: string): string {
-  return token.replace(META_CHARS, '^$1')
-}
 
 /**
  * Escape ONE argument for a cmd.exe command line: double the backslash runs that
@@ -49,22 +44,45 @@ export interface WinSpawnPlan {
   windowsVerbatimArguments?: boolean
 }
 
+/** True when this command can only be spawned through the cmd.exe shim route. */
+export function needsCmdShim(command: string): boolean {
+  return isWindows && isBatch(command)
+}
+
 /**
- * Resolve how to spawn a command safely. On non-Windows, or for a Windows `.exe`
- * target, the command + args are returned unchanged (spawned with `shell: false`,
- * so argv is never shell-interpreted). For a Windows `.cmd`/`.bat` shim, route
- * through cmd.exe with the command + every argument quoted and caret-escaped, and
- * `windowsVerbatimArguments` so Node does not re-quote the carefully-escaped line.
+ * Build the cmd.exe invocation for a Windows `.cmd`/`.bat` shim: the command
+ * plus every argument quoted and caret-escaped into one `/c` line, with
+ * `windowsVerbatimArguments` so Node does not re-quote the carefully-escaped
+ * result. ONLY for commands `needsCmdShim` approves; everything else spawns as
+ * plain argv and must never come near this builder, so that a spawn call is
+ * always exactly one of the two modes rather than a merge of both.
  */
-export function resolveWindowsSpawn(plan: { command: string; args: string[] }): WinSpawnPlan {
-  if (!isWindows || !isBatch(plan.command)) {
-    return { command: plan.command, args: plan.args }
-  }
+export function buildCmdShimPlan(plan: { command: string; args: string[] }): WinSpawnPlan {
   const comspec = process.env['ComSpec'] || process.env['comspec'] || 'cmd.exe'
-  const shellCommand = [escapeCommandToken(plan.command), ...plan.args.map(escapeCmdArg)].join(' ')
+  // The command token is QUOTED, not caret-escaped. Real double quotes are what
+  // cmd.exe honours in the program position (with /s the outer quotes strip and
+  // a `"C:\path with spaces\tool.cmd" args…` line runs the quoted program), and
+  // inside them cmd's metacharacters are inert, so a path carrying `&`, `^`, or
+  // parentheses stays one literal token. A quote inside the path itself cannot
+  // occur: `"` is not a legal character in a Windows file name, so nothing the
+  // filesystem resolves can close the wrapping early.
+  const shellCommand = [`"${plan.command}"`, ...plan.args.map(escapeCmdArg)].join(' ')
   return {
     command: comspec,
     args: ['/d', '/s', '/c', `"${shellCommand}"`],
     windowsVerbatimArguments: true,
   }
+}
+
+/**
+ * Resolve how to spawn a command safely. On non-Windows, or for a Windows `.exe`
+ * target, the command + args are returned unchanged (spawned with `shell: false`,
+ * so argv is never shell-interpreted). For a Windows `.cmd`/`.bat` shim, route
+ * through cmd.exe via `buildCmdShimPlan`.
+ */
+export function resolveWindowsSpawn(plan: { command: string; args: string[] }): WinSpawnPlan {
+  if (!needsCmdShim(plan.command)) {
+    return { command: plan.command, args: plan.args }
+  }
+  return buildCmdShimPlan(plan)
 }

--- a/apps/web/server/lib/runtimes/winSpawn.ts
+++ b/apps/web/server/lib/runtimes/winSpawn.ts
@@ -8,6 +8,8 @@
 // resolved command token double-quoted, and every untrusted argument quoted
 // (CommandLineToArgvW boundaries) AND caret-escaped (cmd.exe metacharacters) so
 // a prompt like `do X & calc.exe` cannot break out and chain a second command.
+// Quoting the token is not sufficient for `%` and `!`, which cmd substitutes
+// before quotes mean anything, so a path carrying either is refused outright.
 //
 // The escaping below implements cmd.exe's documented quoting rules — the
 // CommandLineToArgvW argument-boundary rules plus caret-escaping of cmd.exe's
@@ -18,6 +20,24 @@
 import { isWindows } from '../platform'
 
 const META_CHARS = /([()\][%!^"`<>&|;, *?])/g
+
+/**
+ * The two metacharacters double quotes CANNOT make literal in the program token.
+ *
+ * cmd.exe expands `%VAR%` in an EARLIER phase than the one that gives quotes
+ * their meaning, so `"%TEMP%\tool.cmd"` is already substituted by the time the
+ * quotes are read. `!VAR!` behaves the same way on a machine with delayed
+ * expansion enabled. A caret cannot rescue either, because carets are processed
+ * in that same later phase.
+ *
+ * An argument is safe (`escapeCmdArg` caret-escapes both, and its escape lands
+ * before the batch body re-parses), but the program token is not, so a resolved
+ * path carrying one is refused rather than launched. The sign-in path already
+ * refuses such a binary upstream via `UNSAFE_BIN_CHARS` in `cliLoginPlans.ts`;
+ * refusing here covers the driver paths, which resolve through
+ * `resolveRuntimeBin` and reach no such filter.
+ */
+const EXPANDS_INSIDE_QUOTES = /[%!]/
 
 const isBatch = (command: string): boolean => /\.(cmd|bat)$/i.test(command)
 
@@ -59,13 +79,17 @@ export function needsCmdShim(command: string): boolean {
  */
 export function buildCmdShimPlan(plan: { command: string; args: string[] }): WinSpawnPlan {
   const comspec = process.env['ComSpec'] || process.env['comspec'] || 'cmd.exe'
+  if (EXPANDS_INSIDE_QUOTES.test(plan.command)) {
+    throw new Error(`refusing to launch a Windows shim whose path contains % or !: ${plan.command}`)
+  }
   // The command token is QUOTED, not caret-escaped. Real double quotes are what
   // cmd.exe honours in the program position (with /s the outer quotes strip and
   // a `"C:\path with spaces\tool.cmd" args…` line runs the quoted program), and
-  // inside them cmd's metacharacters are inert, so a path carrying `&`, `^`, or
-  // parentheses stays one literal token. A quote inside the path itself cannot
-  // occur: `"` is not a legal character in a Windows file name, so nothing the
-  // filesystem resolves can close the wrapping early.
+  // they make the SUBSTITUTION-phase metacharacters literal, so a path carrying
+  // `&`, `^`, `|`, `<`, `>` or parentheses stays one literal token. A quote
+  // inside the path itself cannot occur: `"` is not a legal character in a
+  // Windows file name, so nothing the filesystem resolves can close the wrapping
+  // early. `%` and `!` are the exception and are refused above.
   const shellCommand = [`"${plan.command}"`, ...plan.args.map(escapeCmdArg)].join(' ')
   return {
     command: comspec,

--- a/packages/worktrees/src/git.ts
+++ b/packages/worktrees/src/git.ts
@@ -123,11 +123,27 @@ export function worktreeRootFor(repoPath: string, rootDir?: string): string {
   return rootDir ?? path.join(repoPath, '.clawboo', 'worktrees')
 }
 
-/** The absolute directory a task's worktree occupies: one validated segment
- *  directly under the (resolved) worktree root. */
+/**
+ * The absolute directory a task's worktree occupies: one validated segment
+ * directly under the (resolved) worktree root.
+ *
+ * Containment is ONE test, written out here rather than delegated to
+ * `assertWithin`: the resolved candidate has to start with the root plus a
+ * trailing separator. `assertWithin` answers a broader question (it admits the
+ * root itself, which a general helper should), but a task directory is always
+ * exactly one segment DOWN, so here the root is as wrong as a path outside it
+ * and one test states the whole invariant. The value handed back is the very
+ * value that passed the test, so every consumer of a task's worktree location
+ * builds on a path that has already been pinned under the root.
+ */
 export function worktreePathFor(repoPath: string, taskId: string, rootDir?: string): string {
   const root = path.resolve(worktreeRootFor(repoPath, rootDir))
-  return assertWithin(root, path.join(root, assertSafeTaskId(taskId)))
+  const prefix = root.endsWith(path.sep) ? root : root + path.sep
+  const candidate = path.resolve(root, assertSafeTaskId(taskId))
+  if (!candidate.startsWith(prefix)) {
+    throw new Error(`task directory escapes ${root}: ${candidate}`)
+  }
+  return candidate
 }
 
 /**

--- a/packages/worktrees/src/lifecycle.ts
+++ b/packages/worktrees/src/lifecycle.ts
@@ -91,8 +91,13 @@ export interface ProvisionOptions {
  * is initialization, not work).
  */
 export async function provisionWorktree(opts: ProvisionOptions): Promise<Worktree> {
-  const root = path.resolve(worktreeRootFor(opts.repoPath, opts.rootDir))
   const worktreePath = worktreePathFor(opts.repoPath, opts.taskId, opts.rootDir)
+  // The root that gets created below is DERIVED from the pinned worktree path
+  // rather than resolved a second time from the raw inputs, so the directory
+  // mkdir materializes is by construction the parent of the location every
+  // other operation was checked against; two independent derivations could
+  // drift apart.
+  const root = path.dirname(worktreePath)
   const branch = branchNameForTask(opts.taskId)
 
   return mutex.run(worktreePath, async () => {


### PR DESCRIPTION
## Summary

* Hardens path containment at the point derived filesystem paths are created, preventing unsafe paths from propagating into later file and worktree operations.
* Strengthens containment barriers around security-sensitive filesystem operations so callers receive already-validated paths instead of relying on downstream checks.
* Quotes the Windows shim token correctly to prevent command parsing from changing the intended executable invocation on Windows.

## Type

* [ ] Feature (`feat:`)
* [x] Bug fix (`fix:`)
* [ ] Refactor (`refactor:`)
* [ ] Chore (CI, deps, config)
* [ ] Documentation
* [ ] Test

## Changeset

* [x] Added changeset

## Checklist

* [x] `pnpm build` passes
* [x] `pnpm typecheck` passes
* [x] `pnpm lint` passes
* [x] `pnpm test` passes
* [x] Self-reviewed the diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI sign-in reliability on Windows, including support for commands installed through `.cmd` and `.bat` shims.
  * Fixed handling of executable paths containing spaces, parentheses, or ampersands.
  * Added safeguards to prevent runtime and worktree paths from escaping their designated directories.
  * Improved consistency when creating and managing isolated worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->